### PR TITLE
Cif2 conversion: various small corrections

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10793,11 +10793,12 @@ save__space_group.IT_number
 _definition.id                          '_space_group.IT_number'
 loop_
   _alias.definition_id
-         '_space_group.IT_number'      
+         '_space_group.IT_number'
          '_space_group_IT_number'
          '_symmetry.Int_Tables_number'
+         '_symmetry_Int_Tables_number'
 _definition.update                      2016-05-09
-_description.text                       
+_description.text
 ;
      The number as assigned in International Tables for Crystallography
      Vol A, specifying the proper affine class (i.e. the orientation
@@ -11277,19 +11278,19 @@ save__space_group_symop.id
 _definition.id                          '_space_group_symop.id'
 loop_
   _alias.definition_id
-         '_space_group_symop.id'       
-         '_space_group_symop_id'       
+         '_space_group_symop.id'
+         '_space_group_symop_id'
          '_symmetry_equiv.pos_site_id'
+         '_symmetry_equiv_pos_site_id'
 _definition.update                      2016-05-13
-_description.text     
-                  
-; 
+_description.text 
+;
      Index identifying each entry in the _space_group_symop.operation_xyz
      list. It is normally the sequence number of the entry in that
      list, and should be identified with the code 'n' in the geometry
      symmetry codes of the form 'n_klm'. The identity operation
      (i.e. _space_group_symop.operation_xyz set to 'x,y,z') should be
-     set to 1.  
+     set to 1.
 ;
 
 _name.category_id                       space_group_symop
@@ -11302,10 +11303,10 @@ _enumeration.range                      1:
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      _space_group_symop.id = Current_Row(space_group_symop) + 1
-; 
+;
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1124,7 +1124,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -1265,7 +1265,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -2054,7 +2054,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -2650,7 +2650,7 @@ _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -2681,7 +2681,7 @@ _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -3308,7 +3308,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -3885,7 +3885,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -4474,7 +4474,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Table
 _type.contents                          Real
-_type.dimension []
+_type.dimension                         '[]'
 _units.code                             none
 loop_
   _method.purpose
@@ -4531,7 +4531,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -5323,7 +5323,7 @@ _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 _units.code                             none
 loop_
   _method.purpose
@@ -5356,7 +5356,7 @@ _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
 _units.code                             none
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -6017,7 +6017,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [2]
+_type.dimension                         '[2]'
 _units.code                             angstroms
 loop_
   _method.purpose
@@ -6697,7 +6697,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -6732,7 +6732,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -7295,7 +7295,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -7401,7 +7401,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -7438,7 +7438,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -7471,7 +7471,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -7505,7 +7505,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -7883,7 +7883,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -7911,7 +7911,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -7939,7 +7939,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -7966,7 +7966,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -7992,7 +7992,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -8021,7 +8021,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -9681,7 +9681,7 @@ _type.purpose                           Composite
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Code
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _description_example.case
          '[transluscent, pale, green]' 
@@ -10479,7 +10479,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -11422,7 +11422,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -11457,7 +11457,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -11489,7 +11489,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [4  4]
+_type.dimension                         '[4  4]'
 loop_
   _method.purpose
   _method.expression
@@ -11515,7 +11515,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -11748,7 +11748,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         List
 _type.contents                          'Matrix(Real,Real,Real)'
-_type.dimension [2]
+_type.dimension                         '[2]'
 loop_
   _method.purpose
   _method.expression
@@ -11785,7 +11785,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [4  4]
+_type.dimension                         '[4  4]'
 loop_
   _method.purpose
   _method.expression
@@ -11851,7 +11851,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -11922,7 +11922,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -12280,7 +12280,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [2]
+_type.dimension                         '[2]'
 _units.code                             angstroms
 
 save_
@@ -13543,7 +13543,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 _units.code                             angstroms
 
 save_
@@ -13745,7 +13745,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         List
 _type.contents                          'List(Real,Real,Real,Real)'
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -13778,7 +13778,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -13811,7 +13811,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -13868,7 +13868,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -16440,7 +16440,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Integer
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -19192,7 +19192,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -19461,7 +19461,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -19976,7 +19976,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -20455,7 +20455,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -20488,7 +20488,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -21236,7 +21236,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -21317,7 +21317,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -21540,7 +21540,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3  3]
+_type.dimension                         '[3  3]'
 loop_
   _method.purpose
   _method.expression
@@ -21621,7 +21621,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension [3]
+_type.dimension                         '[3]'
 loop_
   _method.purpose
   _method.expression
@@ -22212,7 +22212,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [9]
+_type.dimension                         '[9]'
 _units.code                             none
 loop_
   _method.purpose
@@ -22547,7 +22547,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [4]
+_type.dimension                         '[4]'
 _units.code                             none
 loop_
   _method.purpose
@@ -22659,7 +22659,7 @@ _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         List
 _type.contents                          'List(Real,Real)'
-_type.dimension []
+_type.dimension                         '[]'
 _units.code                             none
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11648,6 +11648,7 @@ save_space_group_Wyckoff.site_symmetry
 
 save__symmetry.cell_setting
     _definition.id               '_symmetry.cell_setting'
+    loop_
     _alias.definition_id         '_symmetry_cell_setting'
     _definition.update           2017-06-10
     _definition.replaced_by      '_space_group.crystal_system'

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -658,7 +658,7 @@ save__atom_site_displace_special_func.sawtooth
     _type.source                 Derived
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     _enumeration.default         [0.0  0.0  0.0]
     loop_
     _method.purpose
@@ -2394,7 +2394,7 @@ save__atom_sites_modulation.global_phase_list
     _type.source                 Derived
     _type.container              List
     _type.contents               Real
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -2880,7 +2880,7 @@ save__cell_subsystem.matrix_W
     _type.source                 Derived
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [11  11]
+    _type.dimension              '[11  11]'
     loop_
     _method.purpose
     _method.expression
@@ -4112,7 +4112,7 @@ save__cell_wave_vector.x
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     _enumeration.default         0.0
 
 save_
@@ -4152,7 +4152,7 @@ save__cell_wave_vector.xyz
     _type.source                 Derived
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     loop_
     _method.purpose
     _method.expression
@@ -4184,7 +4184,7 @@ save__cell_wave_vector.y
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     _enumeration.default         0.0
 
 save_
@@ -4207,7 +4207,7 @@ save__cell_wave_vector.z
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     _enumeration.default         0.0
 save_
 
@@ -5182,7 +5182,7 @@ save__diffrn_refln.index_m_list
     _type.source                 Recorded
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -5300,7 +5300,7 @@ save__diffrn_reflns.limit_index_m_max_list
     _type.source                 Derived
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -5420,7 +5420,7 @@ save__diffrn_reflns.limit_index_m_min_list
     _type.source                 Derived
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -5572,7 +5572,7 @@ save__diffrn_standard_refln.index_m_list
     _type.source                 Recorded
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -5716,7 +5716,7 @@ save__exptl_crystal_face.index_m_list
     _type.source                 Recorded
     _type.container              Single
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -5862,7 +5862,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension [2]
+_type.dimension                         '[2]'
 _units.code                             angstroms
 
 save_
@@ -6521,7 +6521,7 @@ save__refln.index_m_list
     _type.source                 Recorded
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -6583,7 +6583,7 @@ save__reflns.limit_index_m_max_list
     _type.source                 Derived
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression
@@ -6625,7 +6625,7 @@ save__reflns.limit_index_m_min_list
     _type.source                 Derived
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
     _method.purpose
     _method.expression

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -570,6 +570,7 @@ save_ATOM_SITE_DISPLACE_SPECIAL_FUNC
 ;
     _name.category_id            MS_GROUP
     _name.object_id              ATOM_SITE_DISPLACE_SPECIAL_FUNC
+    loop_
     _category_key.name           '_atom_site_displace_special_func.id'
 
 save_
@@ -4064,6 +4065,7 @@ save_CELL_WAVE_VECTOR
 ;
     _name.category_id            MS_GROUP
     _name.object_id              CELL_WAVE_VECTOR
+	loop_
     _category_key.name           '_cell_wave_vector.seq_id'
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -192,6 +192,7 @@ save_PD_BLOCK_DIFFRACTOGRAM
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_BLOCK_DIFFRACTOGRAM
+    loop_
     _category_key.name           '_pd_block_diffractogram.id'
     
 save_
@@ -288,6 +289,7 @@ save_PD_CALC
 ;
     _name.category_id            PD_DATA
     _name.object_id              PD_CALC
+    loop_
     _category_key.name           '_pd_calc.point_id'
 
 save_
@@ -412,6 +414,7 @@ save_PD_CALIB
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_CALIB
+    loop_
     _category_key.name           '_pd_calib.detector_id'
 
 save_
@@ -1071,6 +1074,7 @@ save_PD_DATA
 
     _name.category_id            PD_GROUP
     _name.object_id              PD_DATA
+    loop_
     _category_key.name           '_pd_data.point_id'
 
 save_
@@ -2170,6 +2174,7 @@ save_PD_INSTR_DETECTOR
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_INSTR_DETECTOR
+    loop_
     _category_key.name           '_pd_instr_detector.id'
 
 save_
@@ -3320,6 +3325,7 @@ save_PD_MEAS
 ;
     _name.category_id            PD_DATA
     _name.object_id              PD_MEAS
+    loop_
     _category_key.name           '_pd_meas.point_id'
 
 save_
@@ -3818,6 +3824,7 @@ save_PD_MEAS_INFO_AUTHOR
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_MEAS_INFO_AUTHOR
+    loop_
     _category_key.name           '_pd_meas_info_author.name'
 
 save_
@@ -4009,6 +4016,7 @@ save_PD_PEAK
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_PEAK
+    loop_
     _category_key.name           '_pd_peak.id'
 
 save_
@@ -4652,6 +4660,7 @@ save_PD_PROC
 ;
     _name.category_id            PD_DATA
     _name.object_id              PD_PROC
+    loop_
     _category_key.name          '_pd_proc.point_id'
 
 save_
@@ -5061,6 +5070,7 @@ save_PD_PROC_INFO_AUTHOR
 ;
     _name.category_id            PD_GROUP
     _name.object_id              PD_PROC_INFO_AUTHOR
+    loop_
     _category_key.name           '_pd_proc_info_author.name'
 
 save_
@@ -5804,6 +5814,7 @@ save_PD_PHASE
 ;
     _name.category_id            PD_EXT_GROUP
     _name.object_id              PD_PHASE
+    loop_
     _category_key.name           '_pd_phase.id'
 
 save_

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -1623,7 +1623,8 @@ save__pd_instr.monochr_pre_spec
     _definition.update           2014-06-20
     loop_
       _alias.definition_id
-          '_pd_instr_monochr_pre/spec' 
+          '_pd_instr_monochr_pre/spec'
+          '_pd_instr_monochr_pre_spec'
     _description.text                   
 ;
 
@@ -2495,7 +2496,8 @@ save__pd_instr.monochr_post_spec
     _definition.update           2014-10-20
     loop_
       _alias.definition_id
-          '_pd_instr_monochr_post/spec' 
+          '_pd_instr_monochr_post/spec'
+          '_pd_instr_monochr_post_spec'
     _description.text                   
 ;
 

--- a/cif_pow_multiphase.dic
+++ b/cif_pow_multiphase.dic
@@ -68,6 +68,7 @@ save_PD_PHASE
 ;
     _name.category_id            PD_EXT_GROUP
     _name.object_id              PD_PHASE
+	loop_
     _category_key.name           '_pd_phase.id'
 
 save_

--- a/cif_twin.dic
+++ b/cif_twin.dic
@@ -787,7 +787,7 @@ save_twin_refln.index_hkl
     _type.source                 Derived
     _type.container              Matrix
     _type.contents               Integer
-    _type.dimension              [3]
+    _type.dimension              '[3]'
     loop_
     _method.purpose
     _method.expression

--- a/ddl.dic
+++ b/ddl.dic
@@ -371,7 +371,7 @@ save_DESCRIPTION
     _definition.update           2011-06-20
     _description.text                   
 ;
-     The attributes of descriptive (non-machine parseable) parts of
+     The attributes of descriptive (non-machine parsable) parts of
      definitions.
 ;
     _name.category_id            ATTRIBUTES
@@ -449,7 +449,7 @@ save_DESCRIPTION_EXAMPLE
     _definition.update           2013-09-08
     _description.text                   
 ;
-     The attributes of descriptive (non-machine parseable) examples of
+     The attributes of descriptive (non-machine parsable) examples of
      values of the defined items.
 ;
     _name.category_id            DESCRIPTION
@@ -1816,7 +1816,7 @@ save_type.contents
               Code          'case-insens contig. string of STAR characters'    
               Name          'case-insens contig. string of alpha-num chars or underscore'         
               Tag           'case-insens contig. STAR string with leading underscore'   
-              Filename      'case-sens string indentifying an external file'   
+              Filename      'case-sens string identifying an external file'
               Uri           'case-sens string as universal resource indicator of a file'          
               Date          'ISO standard date format <yyyy>-<mm>-<dd>'        
               Version       'version digit string of the form <major>.<version>.<update>'         
@@ -2004,7 +2004,7 @@ save_type.purpose
 ;        
               Encode        
 ;                  Used to type items with values that are text or codes 
-                   that are formatted to be machine parsible.
+                   that are formatted to be machine parsable.
 ;        
               State         
 ;                  Used to type items with values that are restricted to 
@@ -2425,7 +2425,7 @@ save_
 ;        
          3.8.02    2011-06-21           
 ;
-Reconfigure _dictionary_valid attribures into lists, and reset the
+Reconfigure _dictionary_valid attributes into lists, and reset the
 attribute application criteria at the rear of the DDL dictionary.
 ;        
          3.8.03    2011-06-22           

--- a/ddl.dic
+++ b/ddl.dic
@@ -675,7 +675,7 @@ save_dictionary.uri
     _definition.update           2006-11-16
     _description.text
 ;
-     The universal resource indicator of this dictionary.
+     The uniform resource identifier of this dictionary.
 ;
     _name.category_id            dictionary
     _name.object_id              uri
@@ -1822,7 +1822,7 @@ save_type.contents
               Name          'case-insens contig. string of alpha-num chars or underscore'
               Tag           'case-insens contig. STAR string with leading underscore'
               Filename      'case-sens string identifying an external file'
-              Uri           'case-sens string as universal resource indicator of a file'
+              Uri           'case-sens string as uniform resource identifier of a file'
               Date          'ISO standard date format <yyyy>-<mm>-<dd>'
               Version       'version digit string of the form <major>.<version>.<update>'
               Dimension     'integer limits of an Array/Matrix/List in square brackets'
@@ -1921,7 +1921,7 @@ save_type.indices
      Filename     'name of an external file'
      Code         'code used for indexing data or referencing data resources'
      Date         'ISO date format yyyy-mm-dd'
-     Uri          'an universal resource identifier string, per RFC 3986'
+     Uri          'an uniform resource identifier string, per RFC 3986'
      Version      'version digit string of the form <major>.<version>.<update>'
      ByReference
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -13,10 +13,10 @@ data_DDL_DIC
     _dictionary.uri              www.iucr.org/cif/dic/ddl.dic
     _dictionary.ddl_conformance  3.11.10
     _dictionary.namespace        DdlDic
-    _description.text                   
+    _description.text
 ;
      This dictionary contains the definitions of attributes that
-     make up the DDLm dictionary definition language.  It provides 
+     make up the DDLm dictionary definition language. It provides
      the meta meta data for all CIF dictionaries.
 ;
 
@@ -26,7 +26,7 @@ save_ATTRIBUTES
     _definition.scope            Category
     _definition.class            Head
     _definition.update           2011-07-27
-    _description.text                   
+    _description.text
 ;
      This category is parent of all other categories in the DDLm
      dictionary.
@@ -43,7 +43,7 @@ save_ALIAS
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      The attributes used to specify the aliased names of definitions.
 ;
@@ -52,7 +52,7 @@ save_ALIAS
     _category.key_id             '_alias.definition_id'
     loop_
     _category_key.name
-                                 '_alias.definition_id' 
+                                 '_alias.definition_id'
 
 save_
 
@@ -62,7 +62,7 @@ save_alias.definition_id
     _definition.id               '_alias.definition_id'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      Identifier tag of an aliased definition.
 ;
@@ -81,7 +81,7 @@ save_alias.deprecation_date
     _definition.id               '_alias.deprecation_date'
     _definition.class            Attribute
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Date that the aliased tag was deprecated as a definition tag.
 ;
@@ -100,7 +100,7 @@ save_alias.dictionary_uri
     _definition.id               '_alias.dictionary_uri'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      Dictionary URI in which the aliased definition belongs.
 ;
@@ -121,7 +121,7 @@ save_CATEGORY
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      The attributes used to specify the properties of a
      "category" of data items.
@@ -137,12 +137,12 @@ save_category.key_id
     _definition.id               '_category.key_id'
     _definition.class            Attribute
     _definition.update           2011-07-27
-    _description.text                   
+    _description.text
 ;
      Tag of a single data item in a Loop category which is the generic key
      to access other items in the category. The value of this
      item must be unique in order to provide unambiguous access to
-     a packet (row) in the table of values.  This may be assumed to be a function
+     a packet (row) in the table of values. This may be assumed to be a function
      of the datanames listed in category_key.name.
 ;
     _name.category_id            category
@@ -162,9 +162,9 @@ save_CATEGORY_KEY
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2014-09-18
-    _description.text                   
+    _description.text
 ;
-     The attributes used to specify (possibly multiple) 
+     The attributes used to specify (possibly multiple)
      keys for a given category.
 ;
     _name.category_id            CATEGORY
@@ -180,12 +180,12 @@ save_category_key.name
     _definition.id               '_category_key.name'
     _definition.class            Attribute
     _definition.update           2014-09-18
-    _description.text                   
+    _description.text
 ;
      A minimal list of tag(s) that together constitute a compound key
      to access other items in a Loop category. In other words, the combined values of the
-     datanames listed in this loop must be unique, so that unambiguous access 
-     to a packet (row) in the table of values is possible.  The dataname associated with
+     datanames listed in this loop must be unique, so that unambiguous access
+     to a packet (row) in the table of values is possible. The dataname associated with
      category.key_id is only included in this loop if no other set of datanames can form
      a compound key.
 ;
@@ -206,7 +206,7 @@ save_DEFINITION
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      The attributes for classifying dictionary definitions.
 ;
@@ -221,7 +221,7 @@ save_definition.class
     _definition.id               '_definition.class'
     _definition.class            Attribute
     _definition.update           2013-03-08
-    _description.text                   
+    _description.text
 ;
      The nature and the function of a definition or definitions.
 ;
@@ -234,44 +234,44 @@ save_definition.class
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Attribute     
+              Attribute
 ;                 Item used as an attribute in the definition
-                  of other data items in DDLm dictionaries. 
+                  of other data items in DDLm dictionaries.
                   These items never appear in data instance files.
-;        
-              Functions     
+;
+              Functions
 ;                 Category of items that are transient function
                   definitions used only in dREL methods scripts.
                   These items never appear in data instance files.
-;        
-              Datum         
-;                 Item defined in a domain-specific dictionary.  
+;
+              Datum
+;                 Item defined in a domain-specific dictionary.
                   These items appear only in data instance files.
-;        
-              Head          
+;
+              Head
 ;                 Category of items that is the parent of
                   all other categories in the dictionary.
-;        
-              Loop          
+;
+              Loop
 ;                 Category of items that in a data file must
                   reside in a loop-list with a key item defined.
-;        
-              Set           
+;
+              Set
 ;                 Category of items that form a set (but not a
-                  loopable list). These items may be referenced 
+                  loopable list). These items may be referenced
                   as a class of items in a dREL methods expression.
-;        
-              Ref-loop      
-;                 A category containing one item that identifies the     
+;
+              Ref-loop
+;                 A category containing one item that identifies the
                   a category of items that is repeated in a sequence
                   of save frames. The item, which is specifies as a
-                  as a Ref-table value (see type.container), is looped. 
-                  This construction is for loop categories that contain 
+                  as a Ref-table value (see type.container), is looped.
+                  This construction is for loop categories that contain
                   child categories.
                   If in the instance file, the child items have only
                   one set of values, the Ref-loop item need not be used
                   and child items need not be placed in a save frame.
-; 
+;
     _enumeration.default         Datum
 
 save_
@@ -282,9 +282,9 @@ save_definition.id
     _definition.id               '_definition.id'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
-     Identifier name of the Item or Category definition contained 
+     Identifier name of the Item or Category definition contained
      within a save frame.
 ;
     _name.category_id            definition
@@ -302,7 +302,7 @@ save_definition.scope
     _definition.id               '_definition.scope'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The extent to which a definition affects other definitions.
 ;
@@ -315,9 +315,9 @@ save_definition.scope
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Dictionary    'applies to all defined items in the dictionary'   
-              Category      'applies to all defined items in the category'     
-              Item          'applies to a single item definition' 
+              Dictionary    'applies to all defined items in the dictionary'
+              Category      'applies to all defined items in the category'
+              Item          'applies to a single item definition'
     _enumeration.default         Item
 
 save_
@@ -328,7 +328,7 @@ save_definition.update
     _definition.id               '_definition.update'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The date that a definition was last changed.
 ;
@@ -347,7 +347,7 @@ save_definition.xref_code
     _definition.id               '_definition.xref_code'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      Code identifying the equivalent definition in the dictionary
      referenced by the DICTIONARY_XREF attributes.
@@ -369,7 +369,7 @@ save_DESCRIPTION
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      The attributes of descriptive (non-machine parsable) parts of
      definitions.
@@ -385,7 +385,7 @@ save_description.common
     _definition.id               '_description.common'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      Commonly-used identifying name for the item.
 ;
@@ -405,7 +405,7 @@ save_description.key_words
     _definition.id               '_description.key_words'
     _definition.class            Attribute
     _definition.update           2013-03-06
-    _description.text                   
+    _description.text
 ;
      List of key-words categorising the item.
 ;
@@ -425,7 +425,7 @@ save_description.text
     _definition.id               '_description.text'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The text description of the defined item.
 ;
@@ -447,7 +447,7 @@ save_DESCRIPTION_EXAMPLE
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      The attributes of descriptive (non-machine parsable) examples of
      values of the defined items.
@@ -457,7 +457,7 @@ save_DESCRIPTION_EXAMPLE
     _category.key_id             '_description_example.case'
     loop_
     _category_key.name
-                                 '_description_example.case' 
+                                 '_description_example.case'
 
 save_
 
@@ -467,7 +467,7 @@ save_description_example.case
     _definition.id               '_description_example.case'
     _definition.class            Attribute
     _definition.update           2013-03-08
-    _description.text                   
+    _description.text
 ;
      An example case of the defined item.
 ;
@@ -486,7 +486,7 @@ save_description_example.detail
     _definition.id               '_description_example.detail'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      A description of an example case for the defined item.
 ;
@@ -507,7 +507,7 @@ save_DICTIONARY
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      Attributes for identifying and registering the dictionary. The items
      in this category are NOT used as attributes of INDIVIDUAL data items.
@@ -523,7 +523,7 @@ save_dictionary.class
     _definition.id               '_dictionary.class'
     _definition.class            Attribute
     _definition.update           2012-05-07
-    _description.text                   
+    _description.text
 ;
      The nature, or field of interest, of data items defined in the dictionary.
 ;
@@ -536,10 +536,10 @@ save_dictionary.class
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Reference     'DDLm reference attribute definitions'   
-              Instance      'domain-specific data instance definitions'        
-              Template      'domain-specific attribute/enumeration templates'  
-              Function      'domain-specific method function scripts' 
+              Reference     'DDLm reference attribute definitions'
+              Instance      'domain-specific data instance definitions'
+              Template      'domain-specific attribute/enumeration templates'
+              Function      'domain-specific method function scripts'
     _enumeration.default         Instance
 
 save_
@@ -550,7 +550,7 @@ save_dictionary.date
     _definition.id               '_dictionary.date'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The date that the last dictionary revision took place.
 ;
@@ -569,7 +569,7 @@ save_dictionary.ddl_conformance
     _definition.id               '_dictionary.ddl_conformance'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The version number of the DDL dictionary that this dictionary
      conforms to.
@@ -588,7 +588,7 @@ save_dictionary.formalism
     _definition.id               '_dictionary.formalism'
     _definition.class            Attribute
     _definition.update           2017-01-25
-    _description.text                   
+    _description.text
 ;
 
      The definitions contained in this dictionary are associated
@@ -612,10 +612,10 @@ save_dictionary.namespace
     _definition.id               '_dictionary.namespace'
     _definition.class            Attribute
     _definition.update           2006-12-05
-    _description.text                   
+    _description.text
 ;
      The namespace code that may be prefixed (with a trailing colon
-     ":") to an item tag defined in the defining dictionary when used 
+     ":") to an item tag defined in the defining dictionary when used
      in particular applications. Because tags must be unique, namespace
      codes are unlikely to be used in data files.
 ;
@@ -634,7 +634,7 @@ save_dictionary.title
     _definition.id               '_dictionary.title'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The common title of the dictionary. Will usually match the name
      attached to the data_ statement of the dictionary file.
@@ -654,7 +654,7 @@ save_dictionary.uri
     _definition.id               '_dictionary.uri'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The universal resource indicator of this dictionary.
 ;
@@ -673,7 +673,7 @@ save_dictionary.version
     _definition.id               '_dictionary.version'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      A unique version identifier for the dictionary.
 ;
@@ -694,7 +694,7 @@ save_DICTIONARY_AUDIT
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Attributes for identifying and registering the dictionary. The items
      in this category are NOT used as attributes of individual data items.
@@ -704,7 +704,7 @@ save_DICTIONARY_AUDIT
     _category.key_id             '_dictionary_audit.version'
     loop_
     _category_key.name
-                                 '_dictionary_audit.version' 
+                                 '_dictionary_audit.version'
 
 save_
 
@@ -714,7 +714,7 @@ save_dictionary_audit.date
     _definition.id               '_dictionary_audit.date'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      The date of each dictionary revision.
 ;
@@ -733,7 +733,7 @@ save_dictionary_audit.revision
     _definition.id               '_dictionary_audit.revision'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      A description of the revision applied for the _dictionary_audit.version.
 ;
@@ -752,7 +752,7 @@ save_dictionary_audit.version
     _definition.id               '_dictionary_audit.version'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      A unique version identifier for each revision of the dictionary.
 ;
@@ -773,10 +773,10 @@ save_DICTIONARY_VALID
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Data items which are used to specify the contents of definitions in
-     the dictionary in terms of the _definition.scope     and the required
+     the dictionary in terms of the _definition.scope and the required
      and prohibited attributes.
 ;
     _name.category_id            DICTIONARY
@@ -784,7 +784,7 @@ save_DICTIONARY_VALID
     _category.key_id             '_dictionary_valid.application'
     loop_
     _category_key.name
-                                 '_dictionary_valid.application' 
+                                 '_dictionary_valid.application'
 
 save_
 
@@ -794,11 +794,11 @@ save_dictionary_valid.application
     _definition.id               '_dictionary_valid.application'
     _definition.class            Attribute
     _definition.update           2013-02-12
-    _description.text                   
+    _description.text
 ;
      Provides the information identifying the definition scope (
-     from the _definition.scope enumeration list) and the validity 
-     options (from the _dictionary_valid.option enumeration list), 
+     from the _definition.scope enumeration list) and the validity
+     options (from the _dictionary_valid.option enumeration list),
      as a two element list. This list signals the validity of applying
      the attributes given in _dictionary_valid.attributes.
 ;
@@ -812,11 +812,11 @@ save_dictionary_valid.application
     loop_
     _method.purpose
     _method.expression
-     Definition    
+     Definition
 ;
-     _dictionary_valid.application 
+     _dictionary_valid.application
                       = [_dictionary_valid.scope,_dictionary_valid.option]
-; 
+;
 
 save_
 
@@ -826,7 +826,7 @@ save_dictionary_valid.attributes
     _definition.id               '_dictionary_valid.attributes'
     _definition.class            Attribute
     _definition.update           2013-03-06
-    _description.text                   
+    _description.text
 ;
      A list of the attribute names and categories that are assessed
      for application in the item, category and dictionary definitions.
@@ -846,10 +846,10 @@ save_dictionary_valid.scope
     _definition.id               '_dictionary_valid.scope'
     _definition.class            Attribute
     _definition.update           2015-01-28
-    _description.text                   
+    _description.text
 ;
      The scope to which the specified restriction on usable
-     attributes applies.  
+     attributes applies.
 ;
     _name.category_id            dictionary_valid
     _name.object_id              scope
@@ -860,9 +860,9 @@ save_dictionary_valid.scope
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Dictionary    'restriction applies to dictionary definition data frame'   
-              Category      'restriction applies to a category definition save frame'     
-              Item          'restriction applies to an item definition save frame' 
+              Dictionary    'restriction applies to dictionary definition data frame'
+              Category      'restriction applies to a category definition save frame'
+              Item          'restriction applies to an item definition save frame'
 
 save_
 
@@ -871,7 +871,7 @@ save_dictionary_valid.option
     _definition.id               '_dictionary_valid.option'
     _definition.class            Attribute
     _definition.update           2013-03-06
-    _description.text                   
+    _description.text
 ;
      Option codes for applicability of attributes in definitions.
 ;
@@ -884,9 +884,9 @@ save_dictionary_valid.option
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Mandatory     'attribute must be present in definition frame'    
-              Recommended   'attribute is usually in definition frame'         
-              Prohibited    'attribute must not be used in definition frame' 
+              Mandatory     'attribute must be present in definition frame'
+              Recommended   'attribute is usually in definition frame'
+              Prohibited    'attribute must not be used in definition frame'
     _enumeration.default         Recommended
 
 save_
@@ -899,18 +899,18 @@ save_DICTIONARY_XREF
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Data items which are used to cross reference other dictionaries that
-     have defined the same data items. Data items in this category are NOT 
-    o used as attributes of individual data items.
+     have defined the same data items. Data items in this category are NOT
+     used as attributes of individual data items.
 ;
     _name.category_id            DICTIONARY
     _name.object_id              DICTIONARY_XREF
     _category.key_id             '_dictionary_xref.code'
     loop_
     _category_key.name
-                                 '_dictionary_xref.code' 
+                                 '_dictionary_xref.code'
 
 save_
 
@@ -920,7 +920,7 @@ save_dictionary_xref.code
     _definition.id               '_dictionary_xref.code'
     _definition.class            Attribute
     _definition.update           2006-11-27
-    _description.text                   
+    _description.text
 ;
      A code identifying the cross-referenced dictionary.
 ;
@@ -939,7 +939,7 @@ save_dictionary_xref.date
     _definition.id               '_dictionary_xref.date'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      Date of the cross-referenced dictionary.
 ;
@@ -958,7 +958,7 @@ save_dictionary_xref.format
     _definition.id               '_dictionary_xref.format'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      Format of the cross referenced dictionary.
 ;
@@ -977,7 +977,7 @@ save_dictionary_xref.name
     _definition.id               '_dictionary_xref.name'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      The name and description of the cross-referenced dictionary.
 ;
@@ -996,7 +996,7 @@ save_dictionary_xref.uri
     _definition.id               '_dictionary_xref.uri'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      The source URI of the cross referenced dictionary data.
 ;
@@ -1017,7 +1017,7 @@ save_ENUMERATION
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      The attributes for restricting the values of defined data items.
 ;
@@ -1032,12 +1032,12 @@ save_enumeration.def_index_id
     _definition.id               '_enumeration.def_index_id'
     _definition.class            Attribute
     _definition.update           2012-05-07
-    _description.text                   
+    _description.text
 ;
-     Specifies the data name with a value used as an index to the 
+     Specifies the data name with a value used as an index to the
      DEFAULT enumeration list (in category enumeration_default)
-     in order to select the default enumeration value for the 
-     defined item. The value of the identified data item must match 
+     in order to select the default enumeration value for the
+     defined item. The value of the identified data item must match
      one of the _enumeration_default.index values.
 ;
     _name.category_id            enumeration
@@ -1055,7 +1055,7 @@ save_enumeration.default
     _definition.id               '_enumeration.default'
     _definition.class            Attribute
     _definition.update           2013-03-08
-    _description.text                   
+    _description.text
 ;
      The default value for the defined item if it is not specified explicitly.
 ;
@@ -1074,8 +1074,8 @@ save_enumeration.mandatory
     _definition.id               '_enumeration.mandatory'
     _definition.class            Attribute
     _definition.update           2012-05-07
-    _description.text                   
-;   
+    _description.text
+;
      Yes or No flag on whether the enumerate states specified for an
      item in the current definition (in which item appears) MUST be
      used on instantiation.
@@ -1089,8 +1089,8 @@ save_enumeration.mandatory
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Yes           'Use of state is mandatory'    
-              No            'Use of state is unnecessary' 
+              Yes           'Use of state is mandatory'
+              No            'Use of state is unnecessary'
     _enumeration.default         Yes
 
 save_
@@ -1101,7 +1101,7 @@ save_enumeration.range
     _definition.id               '_enumeration.range'
     _definition.class            Attribute
     _definition.update           2013-04-17
-    _description.text                   
+    _description.text
 ;
      The inclusive range of values "from:to" allowed for the defined item.
 ;
@@ -1122,9 +1122,9 @@ save_ENUMERATION_DEFAULT
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
-     Loop of pre-determined default enumeration values indexed to a 
+     Loop of pre-determined default enumeration values indexed to a
      data item by the item _enumeration.def_index_id.
 ;
     _name.category_id            ENUMERATION
@@ -1132,7 +1132,7 @@ save_ENUMERATION_DEFAULT
     _category.key_id             '_enumeration_default.index'
     loop_
     _category_key.name
-                                 '_enumeration_default.index' 
+                                 '_enumeration_default.index'
 
 save_
 
@@ -1142,7 +1142,7 @@ save_enumeration_default.index
     _definition.id               '_enumeration_default.index'
     _definition.class            Attribute
     _definition.update           2013-04-17
-    _description.text                   
+    _description.text
 ;
      Index key in the list default values referenced to by the value
      of _enumeration.def_index_id .
@@ -1162,7 +1162,7 @@ save_enumeration_default.value
     _definition.id               '_enumeration_default.value'
     _definition.class            Attribute
     _definition.update           2013-04-17
-    _description.text                   
+    _description.text
 ;
      Default enumeration value in the list referenced by the value of
      _enumeration.def_index_id. The reference index key is given by
@@ -1185,7 +1185,7 @@ save_ENUMERATION_SET
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Attributes of data items which are used to define a
      set of unique pre-determined values.
@@ -1195,7 +1195,7 @@ save_ENUMERATION_SET
     _category.key_id             '_enumeration_set.state'
     loop_
     _category_key.name
-                                 '_enumeration_set.state' 
+                                 '_enumeration_set.state'
 
 save_
 
@@ -1205,7 +1205,7 @@ save_enumeration_set.detail
     _definition.id               '_enumeration_set.detail'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      The meaning of the code (identified by _enumeration_set.state)
      in terms of the value of the quantity it describes.
@@ -1225,7 +1225,7 @@ save_enumeration_set.state
     _definition.id               '_enumeration_set.state'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      Permitted value state for the defined item.
 ;
@@ -1244,7 +1244,7 @@ save_enumeration_set.xref_code
     _definition.id               '_enumeration_set.xref_code'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
      Identity of the equivalent item in the dictionary
      referenced by the DICTIONARY_XREF attributes.
@@ -1264,9 +1264,9 @@ save_enumeration_set.xref_dictionary
     _definition.id               '_enumeration_set.xref_dictionary'
     _definition.class            Attribute
     _definition.update           2011-06-27
-    _description.text                   
+    _description.text
 ;
-     Code identifying the dictionary in the DICTIONARY_XREF 
+     Code identifying the dictionary in the DICTIONARY_XREF
      list.
 ;
     _name.category_id            enumeration_set
@@ -1286,9 +1286,9 @@ save_IMPORT
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-27
-    _description.text                   
-;   
-     Used to import the values of specific attributes from other dictionary 
+    _description.text
+;
+     Used to import the values of specific attributes from other dictionary
      definitions within and without the current dictionary.
 ;
     _name.category_id            ATTRIBUTES
@@ -1301,10 +1301,10 @@ save_import.get
     _definition.id               '_import.get'
     _definition.class            Attribute
     _definition.update           2015-01-06
-    _description.text                   
+    _description.text
 ;
-     A list of tables of attributes defined individually in the category IMPORT_DETAILS,  
-     used to import definitions from other dictionaries. 
+     A list of tables of attributes defined individually in the category IMPORT_DETAILS,
+     used to import definitions from other dictionaries.
 ;
     _name.category_id            import
     _name.object_id              get
@@ -1316,19 +1316,19 @@ save_import.get
     loop_
     _method.purpose
     _method.expression
-     Evaluation    
+     Evaluation
 ;
      imp_order_list = []
      loop id as import_details {
          imp_order_list ++= id.order
-     } 
+     }
      sort(imp_order_list)
      final_val = []
      for ord in imp_order_list {
          final_val ++= import_details[ord].single
      }
     _import.get = final_val
-; 
+;
 
 save_
 
@@ -1338,7 +1338,7 @@ save_IMPORT_DETAILS
     _name.category_id           IMPORT
     _name.object_id             IMPORT_DETAILS
     _definition.class           Loop
-    _category.key_id		  '_import_details.order'
+    _category.key_id            '_import_details.order'
     loop_
         _category_key.name     '_import_details.order'
     _description.text
@@ -1353,7 +1353,7 @@ save_import_details.file_id
     _definition.id               '_import_details.file_id'
     _definition.class            Attribute
     _definition.update           2015-05-06
-    _description.text                   
+    _description.text
 ;
      The file name/URI of the source dictionary
 ;
@@ -1371,7 +1371,7 @@ save_import_details.frame_id
     _definition.id               '_import_details.frame_id'
     _definition.class            Attribute
     _definition.update           2015-05-06
-    _description.text                   
+    _description.text
 ;
      The framecode of the definition frame to be imported.
 ;
@@ -1386,21 +1386,21 @@ save_
 
 
 save_import_details.order
-	_definition.id			'_import_details.order'
-	_definition.class		Attribute
-        _definition.update              2015-05-07
-	_description.text			
+    _definition.id               '_import_details.order'
+    _definition.class            Attribute
+    _definition.update           2015-05-07
+    _description.text
 ;
-     	The order in which the import described by the referenced row should be      	
-        executed.
+     The order in which the import described by the referenced row should be
+     executed.
 ;
-	_name.category_id	        'import_details'
-	_name.object_id		        'order'
-	_type.container	                Single
-        _type.contents	 		Integer
-        _type.source                    Assigned
-        _type.purpose                   Key
-        
+    _name.category_id           'import_details'
+    _name.object_id             'order'
+    _type.container             Single
+    _type.contents              Integer
+    _type.source                Assigned
+    _type.purpose               Key
+
 save_
 
 save_import_details.if_dupl
@@ -1408,9 +1408,9 @@ save_import_details.if_dupl
     _definition.id               '_import_details.if_dupl'
     _definition.class            Attribute
     _definition.update           2015-05-06
-    _description.text                   
+    _description.text
 ;
-     Code identifying the action taken if the requested definition block 
+     Code identifying the action taken if the requested definition block
      already exists within the importing dictionary.
 ;
     _name.category_id            import_details
@@ -1422,9 +1422,9 @@ save_import_details.if_dupl
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Ignore        'ignore imported definitions if id conflict'       
-              Replace       'replace existing with imported definitions'       
-              Exit          'issue error exception and exit' 
+              Ignore        'ignore imported definitions if id conflict'
+              Replace       'replace existing with imported definitions'
+              Exit          'issue error exception and exit'
     _enumeration.default         Exit
 
 save_
@@ -1435,9 +1435,9 @@ save_import_details.if_miss
     _definition.id               '_import_details.if_miss'
     _definition.class            Attribute
     _definition.update           2015-05-06
-    _description.text                   
+    _description.text
 ;
-     Code identifying the action taken if the requested definition block 
+     Code identifying the action taken if the requested definition block
      is missing from the source dictionary.
 ;
     _name.category_id            import_details
@@ -1449,8 +1449,8 @@ save_import_details.if_miss
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Ignore        'ignore import'      
-              Exit          'issue error exception and exit' 
+              Ignore        'ignore import'
+              Exit          'issue error exception and exit'
     _enumeration.default         Exit
 
 save_
@@ -1461,11 +1461,10 @@ save_import_details.mode
     _definition.id               '_import_details.mode'
     _definition.class            Attribute
     _definition.update           2015-05-06
-    _description.text                   
+    _description.text
 ;
-
      Code identifying how the definition referenced
-     by _import_details.frame_id is to be imported.  "Full" imports the
+     by _import_details.frame_id is to be imported. "Full" imports the
      entire definition together with any child definitions (in the case
      of categories) found in the target dictionary. The importing
      definition becomes the parent of the imported definition. As a
@@ -1474,7 +1473,6 @@ save_import_details.mode
      category as children of the importing 'Head' category.
      "Contents" imports only the attributes found in the imported
      definition.
-     
 ;
     _name.category_id            import_details
     _name.object_id              mode
@@ -1485,21 +1483,21 @@ save_import_details.mode
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Full          'import requested definition together with any child definitions'           
-              Contents      'import contents of requested definition' 
+              Full          'import requested definition together with any child definitions'
+              Contents      'import contents of requested definition'
     _enumeration.default         Contents
 
 save_
 
 save_import_details.single
-    _definition.id             '_import_details.single' 
-    _definition.update           2015-04-24 
-    _definition.class            Attribute 
-    _description.text 
-; 
+    _definition.id             '_import_details.single'
+    _definition.update           2015-04-24
+    _definition.class            Attribute
+    _description.text
+;
      A Table mapping attributes defined individually in category IMPORT to
-     their values; used to import definitions from other dictionaries.  
-; 
+     their values; used to import definitions from other dictionaries.
+;
     _name.category_id            import_details
     _name.object_id              single
     _type.purpose                Internal
@@ -1508,27 +1506,27 @@ save_import_details.single
     _type.indices                 ByReference
     _type.indices_referenced_id    '_import_details.single_index'
     loop_
-	_method.purpose
-	_method.expression
-	Evaluation
+    _method.purpose
+    _method.expression
+    Evaluation
 ;
-	with id as import_details
-	_import_details.single = {"file":id.file_id, 
- 					"save":id.frame_id,
-					"mode":id.mode,
-					"dupl":id.if_dupl, 
-					"miss":id.if_miss}
+    with id as import_details
+    _import_details.single = {"file":id.file_id,
+                              "save":id.frame_id,
+                              "mode":id.mode,
+                              "dupl":id.if_dupl,
+                              "miss":id.if_miss}
 ;
      save_
 
 save_import_details.single_index
-    _definition.id             '_import_details.single_index' 
-    _definition.update           2015-04-24 
-    _definition.class            Attribute 
-    _description.text 
-; 
+    _definition.id             '_import_details.single_index'
+    _definition.update           2015-04-24
+    _definition.class            Attribute
+    _description.text
+;
      One of the indices permitted in the entries of values of attribute _import_details.single.
-; 
+;
     _name.category_id            import_details
     _name.object_id              single_index
     _type.purpose                Internal
@@ -1552,7 +1550,7 @@ save_LOOP
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      Attributes for looped lists.
 ;
@@ -1567,7 +1565,7 @@ save_loop.level
     _definition.id               '_loop.level'
     _definition.class            Attribute
     _definition.update           2012-05-07
-    _description.text                   
+    _description.text
 ;
      Specifies the level of the loop structure in which a defined
      item must reside if it used in a looped list.
@@ -1591,7 +1589,7 @@ save_METHOD
     _definition.scope            Category
     _definition.class            Loop
     _definition.update           2013-09-08
-    _description.text                   
+    _description.text
 ;
      Methods used for evaluating, validating and defining items.
 ;
@@ -1600,7 +1598,7 @@ save_METHOD
     _category.key_id             '_method.purpose'
     loop_
     _category_key.name
-                                 '_method.purpose' 
+                                 '_method.purpose'
 
 save_
 
@@ -1610,7 +1608,7 @@ save_method.expression
     _definition.id               '_method.expression'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The method expression for the defined item.
 ;
@@ -1629,7 +1627,7 @@ save_method.purpose
     _definition.id               '_method.purpose'
     _definition.class            Attribute
     _definition.update           2006-11-16
-    _description.text                   
+    _description.text
 ;
      The purpose and scope of the method expression.
 ;
@@ -1642,8 +1640,8 @@ save_method.purpose
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Evaluation    'method evaluates an item from related item values'         
-              Definition    'method generates attribute value(s) in the definition'     
+              Evaluation    'method evaluates an item from related item values'
+              Definition    'method generates attribute value(s) in the definition'
               Validation    'method compares an evaluation with existing item value'
     _enumeration.default         Evaluation
 
@@ -1657,7 +1655,7 @@ save_NAME
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-20
-    _description.text                   
+    _description.text
 ;
      Attributes for identifying items and item categories.
 ;
@@ -1672,7 +1670,7 @@ save_name.category_id
     _definition.id               '_name.category_id'
     _definition.class            Attribute
     _definition.update           2011-07-27
-    _description.text                   
+    _description.text
 ;
      The name of the category in which a category or item resides.
 ;
@@ -1691,11 +1689,11 @@ save_name.linked_item_id
     _definition.id               '_name.linked_item_id'
     _definition.class            Attribute
     _definition.update           2011-12-08
-    _description.text                   
+    _description.text
 ;
-     Dataname of an equivalent item in another category which has a 
+     Dataname of an equivalent item in another category which has a
      common set of values, or, in the definition of a type Su
-     item is the name of the associated Measurement item to 
+     item is the name of the associated Measurement item to
      which the standard uncertainty applies.
 ;
     _name.category_id            name
@@ -1713,9 +1711,9 @@ save_name.object_id
     _definition.id               '_name.object_id'
     _definition.class            Attribute
     _definition.update           2011-07-27
-    _description.text                   
+    _description.text
 ;
-     The object name of a category or name unique within the 
+     The object name of a category or name unique within the
      category or family of categories.
 ;
     _name.category_id            name
@@ -1735,7 +1733,7 @@ save_TYPE
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2011-06-26
-    _description.text                   
+    _description.text
 ;
     Attributes which specify the 'typing' of data items.
 ;
@@ -1750,9 +1748,9 @@ save_type.container
     _definition.id               '_type.container'
     _definition.class            Attribute
     _definition.update           2013-04-07
-    _description.text                   
+    _description.text
 ;
-     The CONTAINER type of the defined data item value. 
+     The CONTAINER type of the defined data item value.
 ;
     _name.category_id            type
     _name.object_id              container
@@ -1763,14 +1761,14 @@ save_type.container
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Single        'single value'       
-              Multiple      'values as List or by boolean ,|&!* or range : ops'         
+              Single        'single value'
+              Multiple      'values as List or by boolean ,|&!* or range : ops'
               List        '''ordered set of values. Elements need not be of same contents type.'''
               Array       '''ordered set of numerical values. Operations across arrays are
                              equivalent to operations across elements of the Array.'''
               Matrix      '''ordered set of numerical values for a tensor. Tensor operations such as
-                             dot and cross products, are valid cross matrix objects.'''       
-              Table         'An unordered set of id:value elements'      
+                             dot and cross products, are valid cross matrix objects.'''
+              Table         'An unordered set of id:value elements'
     _enumeration.default         Single
 
 save_
@@ -1781,14 +1779,14 @@ save_type.contents
     _definition.id               '_type.contents'
     _definition.class            Attribute
     _definition.update           2013-04-24
-    _description.text                   
+    _description.text
 ;
-     Syntax of the value elements within the container type. 
-     This may be a single enumerated code, or, in the case of a list, 
-     a comma-delimited sequence of codes, or, if there are alternate 
+     Syntax of the value elements within the container type.
+     This may be a single enumerated code, or, in the case of a list,
+     a comma-delimited sequence of codes, or, if there are alternate
      types, a boolean-linked (or range) sequence of codes.
-     The typing of elements is determined by the replication 
-     of the minimum set of states declared.   Where the definition is of
+     The typing of elements is determined by the replication
+     of the minimum set of states declared. Where the definition is of
      a 'Table' container this attribute describes
      the construction of the value elements within those (Table) values.
 ;
@@ -1801,27 +1799,27 @@ save_type.contents
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Text          'case-sens strings or lines of STAR characters'    
-              Code          'case-insens contig. string of STAR characters'    
-              Name          'case-insens contig. string of alpha-num chars or underscore'         
-              Tag           'case-insens contig. STAR string with leading underscore'   
+              Text          'case-sens strings or lines of STAR characters'
+              Code          'case-insens contig. string of STAR characters'
+              Name          'case-insens contig. string of alpha-num chars or underscore'
+              Tag           'case-insens contig. STAR string with leading underscore'
               Filename      'case-sens string identifying an external file'
-              Uri           'case-sens string as universal resource indicator of a file'          
-              Date          'ISO standard date format <yyyy>-<mm>-<dd>'        
-              Version       'version digit string of the form <major>.<version>.<update>'         
-              Dimension     'integer limits of an Array/Matrix/List in square brackets' 
-              Range         'inclusive range of numerical values min:max'      
-              Count         'unsigned integer number'      
-              Index         'unsigned non-zero integer number'       
-              Integer       'positive or negative integer number'    
-              Real          'floating-point real number'   
-              Imag          'floating-point imaginary number'        
-              Complex       'complex number <R>+j<I>'      
-              Binary        'binary number \b<N>'          
-              Hexadecimal   'hexadecimal number \x<N>'     
+              Uri           'case-sens string as universal resource indicator of a file'
+              Date          'ISO standard date format <yyyy>-<mm>-<dd>'
+              Version       'version digit string of the form <major>.<version>.<update>'
+              Dimension     'integer limits of an Array/Matrix/List in square brackets'
+              Range         'inclusive range of numerical values min:max'
+              Count         'unsigned integer number'
+              Index         'unsigned non-zero integer number'
+              Integer       'positive or negative integer number'
+              Real          'floating-point real number'
+              Imag          'floating-point imaginary number'
+              Complex       'complex number <R>+j<I>'
+              Binary        'binary number \b<N>'
+              Hexadecimal   'hexadecimal number \x<N>'
               Octal         'octal number \o<N>'
-	      Symop         'a string composed of an integer followed by an underscore and 3 or more digits'
-              Implied       'implied by the context of the attribute' 
+              Symop         'a string composed of an integer followed by an underscore and 3 or more digits'
+              Implied       'implied by the context of the attribute'
               ByReference
                             """The contents have the same form as those of the attribute referenced by
                             _type.contents_referenced_id."""
@@ -1829,10 +1827,10 @@ save_type.contents
     loop_
     _description_example.case
     _description_example.detail
-            "Integer"            'content is a single or multiple integer(s)'  
-            "Real,Integer"       'List elements of a real number and an integer'        
-            "List(Real,Code)"    'List of Lists of a real number and a code'   
-            "Text|Real"          'content is either text OR a real number' 
+            "Integer"            'content is a single or multiple integer(s)'
+            "Real,Integer"       'List elements of a real number and an integer'
+            "List(Real,Code)"    'List of Lists of a real number and a code'
+            "Text|Real"          'content is either text OR a real number'
 
 save_
 
@@ -1843,7 +1841,7 @@ save_type.contents_referenced_id
     _description.text
 ;
      The value of the _definition.id attribute of an attribute definition
-     whose type is to be used also as the type of this item.  Meaningful only
+     whose type is to be used also as the type of this item. Meaningful only
      when this item's _type.contents attribute has value 'ByReference'.
 ;
     _name.category_id           type
@@ -1858,9 +1856,9 @@ save_type.dimension
     _definition.id               '_type.dimension'
     _definition.class            Attribute
     _definition.update           2013-04-17
-    _description.text                   
+    _description.text
 ;
-     The dimensions of a list or matrix of elements as a text string 
+     The dimensions of a list or matrix of elements as a text string
      within bounding square brackets.
 ;
     _name.category_id            type
@@ -1872,9 +1870,9 @@ save_type.dimension
     loop_
     _description_example.case
     _description_example.detail
-            "[3,3]"              '3x3 matrix of elements'  
-            "[6]"                'list of 6 elements'      
-            "[]"                 'unknown number of list elements' 
+            "[3,3]"              '3x3 matrix of elements'
+            "[6]"                'list of 6 elements'
+            "[]"                 'unknown number of list elements'
 
 save_
 
@@ -1886,7 +1884,7 @@ save_type.indices
 ;
      Used to specify the syntax construction of indices of the entries in the
      defined object when the defined object has 'Table' as its
-     _type.container attribute.  Values are a subset of the codes and
+     _type.container attribute. Values are a subset of the codes and
      constructions defined for attribute _type.contents, accounting
      for the fact that syntactically, indices are always case-sensitive
      quoted strings.
@@ -1944,7 +1942,7 @@ save_type.purpose
     _definition.id               '_type.purpose'
     _definition.class            Attribute
     _definition.update           2013-03-06
-    _description.text                   
+    _description.text
 ;
      The primary purpose or function the defined data item serves in a
      dictionary or a specific data instance.
@@ -1958,92 +1956,92 @@ save_type.purpose
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Import        
+              Import
 ;                  >>> Applied ONLY in the DDLm Reference Dictionary <<<
                    Used to type the SPECIAL attribute "_import.get" that
                    is present in dictionaries to instigate the importation
                    of external dictionary definitions.
-;        
-              Method        
+;
+              Method
 ;                  >>> Applied ONLY in the DDLm Reference Dictionary <<<
-                   Used to type the attribute "_method.expression" that 
-                   is present in dictionary definitions to provide the 
+                   Used to type the attribute "_method.expression" that
+                   is present in dictionary definitions to provide the
                    text method expressing the defined item in terms of
                    other defined items.
-;        
-              Audit         
+;
+              Audit
 ;                  >>> Applied ONLY in the DDLm Reference Dictionary <<<
-                   Used to type attributes employed to record the audit 
+                   Used to type attributes employed to record the audit
                    definition information (creation date, update version and
                    cross reference codes) of items, categories and files.
-;        
-              Identify      
+;
+              Identify
 ;                  >>> Applied ONLY in the DDLm Reference Dictionary <<<
                    Used to type attributes that identify an item tag (or
-                   part thereof), save frame or the URI of an external file. 
-;        
-              Extend        
+                   part thereof), save frame or the URI of an external file.
+;
+              Extend
 ;                  *** Used to EXTEND the DDLm Reference Dictionary ***
-                   Used in a definition, residing in the "extensions" 
+                   Used in a definition, residing in the "extensions"
                    save frame of a domain dictionary, to specify a new
                    enumeration state using an Evaluation method.
-;        
-              Describe      
+;
+              Describe
 ;                  Used to type items with values that are descriptive
                    text intended for human interpretation.
-;        
-              Encode        
-;                  Used to type items with values that are text or codes 
+;
+              Encode
+;                  Used to type items with values that are text or codes
                    that are formatted to be machine parsable.
-;        
-              State         
-;                  Used to type items with values that are restricted to 
+;
+              State
+;                  Used to type items with values that are restricted to
                    codes present in their "enumeration_set.state" lists.
-;        
-              Key           
-;                  Used to type an item with a value that is unique within   
+;
+              Key
+;                  Used to type an item with a value that is unique within
                    the looped list of these items, and may be used as a
-                   reference "key" to identify a specific packet of items 
+                   reference "key" to identify a specific packet of items
                    within the category.
-;        
-              Link          
+;
+              Link
 ;                  Used to type an item with a value that is unique within
                    a looped list of items belonging to another category.
                    The definition of this item must contain the attribute
                    "_name.linked_item_id" specifying the data name of the
                    key item for this list. The defined item represents a
-                   a foreign key linking packets in this category list to 
+                   a foreign key linking packets in this category list to
                    packets in another category.
-;        
-              Composite     
+;
+              Composite
 ;                  Used to type items with value strings composed of
-                   separate parts. These will usually need to be separated 
+                   separate parts. These will usually need to be separated
                    and parsed for complete interpretation and application.
-;        
-              Number        
-;                  Used to type items that are numerical and exact (i.e. 
-                   no standard uncertainty value). 
-;        
-              Measurand     
-;                  Used to type an item with a numerically estimated value 
-                   that has been recorded by measurement or derivation. This 
-                   value must be accompanied by its standard uncertainty 
+;
+              Number
+;                  Used to type items that are numerical and exact (i.e.
+                   no standard uncertainty value).
+;
+              Measurand
+;                  Used to type an item with a numerically estimated value
+                   that has been recorded by measurement or derivation. This
+                   value must be accompanied by its standard uncertainty
                    (SU) value, expressed either as:
                      1) appended integers, in parentheses (), at the
                         precision of the trailing digits,       or
-                     2) a separately defined item with the same name as the 
+                     2) a separately defined item with the same name as the
                         measurand item but with an additional suffix '_su'.
-;        
-              SU            
-;                  Used to type an item with a numerical value that is the 
+;
+              SU
+;                  Used to type an item with a numerical value that is the
                    standard uncertainty of an item with the identical name
-                   except for the suffix '_su'. The definition of an SU item 
+                   except for the suffix '_su'. The definition of an SU item
                    must include the attribute "_name.linked_item_id" which
                    explicitly identifies the associated measurand item.
-; 
+;
               Internal
 ;                  Used to type items that serve only internal purposes of the dictionary
-                   in which they appear.  The particular purpose served is not defined by
+                   in which they appear. The particular purpose served is not defined by
                    this state.
 ;
     _enumeration.default         Describe
@@ -2056,9 +2054,9 @@ save_type.source
     _definition.id               '_type.source'
     _definition.class            Attribute
     _definition.update           2013-04-16
-    _description.text                   
+    _description.text
 ;
-     The origin or source of the defined data item, indicating by what 
+     The origin or source of the defined data item, indicating by what
      recording process it has been added to the domain instance.
 ;
     _name.category_id            type
@@ -2070,33 +2068,33 @@ save_type.source
     loop_
     _enumeration_set.state
     _enumeration_set.detail
-              Recorded      
+              Recorded
 ;               A value (numerical or otherwise) recorded by
-                observation or measurement during the experimental 
+                observation or measurement during the experimental
                 collection of data. This item is PRIMITIVE.
-;        
-              Assigned      
+;
+              Assigned
 ;               A value (numerical or otherwise) assigned as part of
                 the data collection, analysis or modelling required
-                for a specific domain instance. These assignments 
+                for a specific domain instance. These assignments
                 often represent a decision made that determines the
                 course of the experiment (and therefore may be deemed
                 PRIMITIVE) or a particular choice in the way the data
                 was analysed (and therefore may be considered NOT
-                PRIMITIVE). 
-;        
-              Related       
-;               A value or tag used in the construction of looped   
+                PRIMITIVE).
+;
+              Related
+;               A value or tag used in the construction of looped
                 lists of data. Typically identifying an item whose
                 unique value is the reference key for a loop category
-                and/or an item which as values in common with those 
+                and/or an item which as values in common with those
                 of another loop category and is considered a Link
                 between these lists.
-;        
-              Derived       
-;               A quantity derived from other data items within the 
+;
+              Derived
+;               A quantity derived from other data items within the
                 domain instance. This item is NOT PRIMITIVE.
-; 
+;
     _enumeration.default         Assigned
 
 save_
@@ -2109,7 +2107,7 @@ save_UNITS
     _definition.scope            Category
     _definition.class            Set
     _definition.update           2013-03-06
-    _description.text                   
+    _description.text
 ;
     The attributes for specifying units of measure.
 ;
@@ -2124,7 +2122,7 @@ save_units.code
     _definition.id               '_units.code'
     _definition.class            Attribute
     _definition.update           2012-01-25
-    _description.text                   
+    _description.text
 ;
      A code which identifies the units of measurement.
 ;
@@ -2147,31 +2145,31 @@ save_
     loop_
     _dictionary_valid.application
     _dictionary_valid.attributes
-  [Dictionary  Mandatory]       ['_dictionary.title'  '_dictionary.class'  
-                                 '_dictionary.version'  '_dictionary.date'  
-                                 '_dictionary.uri'  
-                                 '_dictionary.ddl_conformance'  
-                                 '_dictionary.namespace'] 
-  [Dictionary  Recommended]     ['_description.text'  
-                                 '_dictionary_audit.version'  
-                                 '_dictionary_audit.date'  
-                                 '_dictionary_audit.revision'] 
-  [Dictionary  Prohibited]      [ALIAS  CATEGORY  DEFINITION  ENUMERATION  LOOP  
-                                 METHOD  NAME  TYPE  UNITS] 
-  [Category  Mandatory]         ['_definition.id'  '_definition.scope'  
-                                 '_definition.class'  '_name.category_id'  
-                                 '_name.object_id'] 
-  [Category  Recommended]       ['_category.key_id'  '_category_key.name'  
-                                 '_description.text'] 
-  [Category  Prohibited]        [ALIAS  DICTIONARY  ENUMERATION  IMPORT  LOOP  
-                                 TYPE  UNITS] 
-  [Item  Mandatory]             ['_definition.id'  '_definition.update'  
-                                 '_name.object_id'  '_name.category_id'  
-                                 '_type.container'  '_type.contents'] 
-  [Item  Recommended]           ['_definition.scope'  '_definition.class'  
-                                 '_type.source'  '_type.purpose'  
-                                 '_description.text'  '_description.common'] 
-  [Item  Prohibited]            [CATEGORY  DICTIONARY] 
+  [Dictionary  Mandatory]       ['_dictionary.title'  '_dictionary.class'
+                                 '_dictionary.version'  '_dictionary.date'
+                                 '_dictionary.uri'
+                                 '_dictionary.ddl_conformance'
+                                 '_dictionary.namespace']
+  [Dictionary  Recommended]     ['_description.text'
+                                 '_dictionary_audit.version'
+                                 '_dictionary_audit.date'
+                                 '_dictionary_audit.revision']
+  [Dictionary  Prohibited]      [ALIAS  CATEGORY  DEFINITION  ENUMERATION  LOOP
+                                 METHOD  NAME  TYPE  UNITS]
+  [Category  Mandatory]         ['_definition.id'  '_definition.scope'
+                                 '_definition.class'  '_name.category_id'
+                                 '_name.object_id']
+  [Category  Recommended]       ['_category.key_id'  '_category_key.name'
+                                 '_description.text']
+  [Category  Prohibited]        [ALIAS  DICTIONARY  ENUMERATION  IMPORT  LOOP
+                                 TYPE  UNITS]
+  [Item  Mandatory]             ['_definition.id'  '_definition.update'
+                                 '_name.object_id'  '_name.category_id'
+                                 '_type.container'  '_type.contents']
+  [Item  Recommended]           ['_definition.scope'  '_definition.class'
+                                 '_type.source'  '_type.purpose'
+                                 '_description.text'  '_description.common']
+  [Item  Prohibited]            [CATEGORY  DICTIONARY]
 
 #=============================================================================
 #  The dictionary's audit trail and creation history.
@@ -2181,93 +2179,93 @@ save_
     _dictionary_audit.version
     _dictionary_audit.date
     _dictionary_audit.revision
-         3.3.00    2004-11-09           
+         3.3.00    2004-11-09
 ;
    Change definition.import_id to definition_import.id in many defs.
    Insert category DEFINITION_IMPORT and the items .id, .conflict,
    .protocol and .source.
-;        
-         3.3.01    2004-11-10           
+;
+         3.3.01    2004-11-10
 ;
    Make further changes to the DEFINITION_IMPORT definitions and
    introduce the DEFINITION_TEMPLATE category.
-;        
-         3.3.02    2004-11-11           
 ;
-   Introduce an IMPORT category containing IMPORT_DICTIONARY, 
+         3.3.02    2004-11-11
+;
+   Introduce an IMPORT category containing IMPORT_DICTIONARY,
    IMPORT_DEFINITION, IMPORT_CATEGORY, IMPORT_ATTRIBUTE.
    Change DEFINITION_TEMPLATE to IMPORT_TEMPLATE.
-;        
-         3.3.03    2004-11-12           
+;
+         3.3.03    2004-11-12
 ;
    Major changes to all the new attributes. Introduce categories
    DEFINITION_CONTEXT.
-;        
-         3.3.04    2004-11-13           
+;
+         3.3.04    2004-11-13
 ;
    Cleaned up the IMPORT changes and cases of enumerates.
-;        
-         3.3.05    2004-11-16           
+;
+         3.3.05    2004-11-16
 ;
    Further changes to IMPORT definitions.
-;        
-         3.3.06    2004-11-18           
+;
+         3.3.06    2004-11-18
 ;
   Some minor correction of typos
-;        
-         3.3.07    2005-11-22           
+;
+         3.3.07    2005-11-22
 ;
   Changed _dictionary.name to _dictionary.filename
   Changed _dictionary_xref.name to _dictionary_xref.filename
   Added _dictionary.title to describe the common name of the dictionary
-;        
-         3.3.08    2005-12-12           
+;
+         3.3.08    2005-12-12
 ;
   Changed ddl to ddl_attr
   Added Template and Function to _dictionary.class
-;        
-         3.3.09    2006-02-02           
+;
+         3.3.09    2006-02-02
 ;
   Add the definition of _dictionary_xref.source.
-;        
-         3.3.10    2006-02-07           
+;
+         3.3.10    2006-02-07
 ;
   Add import attribute definitions
-;        
-         3.4.01    2006-02-12           
+;
+         3.4.01    2006-02-12
 ;
   Remove save frames from dictionary attributes.
   Change the attribute _dictionary.parent_name to _dictionary.parent_id
-;        
-         3.4.02    2006-02-16           
 ;
-  In the import_*.conflict definitions change the enumeration state Unique 
+         3.4.02    2006-02-16
+;
+  In the import_*.conflict definitions change the enumeration state Unique
   to Ignore, and change the default state to Error.
   In the import_*.missing definitions change default enumeration state to
   Error.
-;        
-         3.5.01    2006-03-07           
+;
+         3.5.01    2006-03-07
 ;
   Structural changes to the file to conform with the import model 3.
   Move the template file for *.relational_id to com_att.dic
   Change all references to *.relational_id into the tuple format.
   Move the _codes_ddl.units_code to enum_set.dic and insert the
   import_enum_set.id tuples.
-;        
-         3.5.02    2006-03-22           
+;
+         3.5.02    2006-03-22
 ;
   Rename _enumeration.default_index_id to _enumeration.def_index_id.
   Correct the attributes _enumeration_default.index and *.value.
-;        
-         3.5.03    2006-05-09           
+;
+         3.5.03    2006-05-09
 ;
   Reword many of the import attributes.
   Correct the tuple description for import_dictionary.
   Insert all of the definitions for import_defaults attributes.
   Update _dictionary.class definition - change "Template" to "Import".
   Remove _enumeration.scope "open" from _definition_context.domain.
-;        
-         3.6.01    2006-06-16           
+;
+         3.6.01    2006-06-16
 ;
   Major revamp of TYPE attributes... changed:
      _type.value to _type.contents and expand enumeration list.
@@ -2278,65 +2276,65 @@ save_
   Added _dictionary.ddl_conformance attribute.
   Changed _category.join_set_id to _category.join_cat_id.
   Remove _enumeration.scope definition.
-;        
-         3.6.02    2006-06-17           
 ;
-  Change the states of _type.purpose.        
-;        
-         3.6.03    2006-06-18           
+         3.6.02    2006-06-17
 ;
-  Correct _type.contents value in import_dictionary.id.        
-;        
-         3.6.04    2006-06-20           
+  Change the states of _type.purpose.
+;
+         3.6.03    2006-06-18
+;
+  Correct _type.contents value in import_dictionary.id.
+;
+         3.6.04    2006-06-20
 ;
   Change state 'Point' to 'Link' in _type.contents definition.
   Add Formula to _type.contents
-;        
-         3.6.05    2006-06-27           
+;
+         3.6.05    2006-06-27
 ;
   Change all IMPORT attributes and apply.
   Add _dictionary.namespace attribute and apply.
   Add states to _definition.class and apply.
   Add _enumeration_set.scope.
   Add .context to ENUMERATE_SET, ENUMERATE_DEFAULT, DESCRIPTION_EXAMPLE
-;        
-         3.6.06    2006-07-18           
+;
+         3.6.06    2006-07-18
 ;
   Change the descriptions of the _type.container states.
   The _enumeration_set.scope removed (enumeration.mandatory used).
   In _type_array.dimension change _type.contents to List.
-;        
-         3.6.07    2006-08-30           
+;
+         3.6.07    2006-08-30
 ;
   Change 'att' to 'sta' in the imports of _type.contents and _units.code.
   Replace states 'vector' and 'matrix' in _type.container with 'array'.
   In _type.purpose change 'model' to 'assigned'; 'observe' to 'observed';
   and 'measure' to 'measured'.
-;        
-         3.6.08    2006-08-31           
+;
+         3.6.08    2006-08-31
 ;
   Remove the category TYPE_ARRAY and insert _type.dimension
   Replace _description.compact with _description.common
   Replace _description.abbreviated with _description.key_words
-;        
-         3.6.09    2006-10-31           
+;
+         3.6.09    2006-10-31
 ;
   Remove all attributes and categories referring to 'context'.
-;        
-         3.6.10    2006-11-09           
+;
+         3.6.10    2006-11-09
 ;
   Replace _method.id with method.purpose.
   Redefine the DICTIONARY_VALID values.
-;        
-         3.7.01    2006-11-16           
+;
+         3.7.01    2006-11-16
 ;
   Apply _definition.scope changes.
-  Add _category.parent_join.    
-  Add _dictionary.xref_code.            
+  Add _category.parent_join.
+  Add _dictionary.xref_code.
   Add _enumeration_set.xref_dictionary.
   Remove all relational keys.
-;        
-         3.7.02    2006-12-05           
+;
+         3.7.02    2006-12-05
 ;
   Rewording of description.text in DDL_ATTR and definition.namespace
   Rewording of category_mandatory.item_id
@@ -2344,205 +2342,205 @@ save_
   Removed dictionary.filename.
   Corrected examples in type.dimension.
   Remove dictionary.parent_id and dictionary.parent_uri.
-;        
-         3.7.03    2006-12-21           
+;
+         3.7.03    2006-12-21
 ;
   Default for _category.parent_join is now "No"
-;        
-         3.7.04    2007-02-06           
+;
+         3.7.04    2007-02-06
 ;
   Change _category_key.item_id to _category_key.generic
   Add _category_key.primitive
-;        
-         3.7.05    2007-02-08           
+;
+         3.7.05    2007-02-08
 ;
   Change the _type.purpose of _category_key.generic and .primitive
   to Identify
-;        
-         3.7.06    2007-03-18           
+;
+         3.7.06    2007-03-18
 ;
   Change the description for _name.linked_item_id
-;        
-         3.7.07    2007-10-11           
+;
+         3.7.07    2007-10-11
 ;
   Correct the _type.dimension assignments to [n[m]].
   Remove _type_array.dimension from _type.dimension definition.
-;        
-         3.7.08    2008-01-17           
 ;
-  Change 'Definition' to 'Evaluation' in import_list.id.      
+         3.7.08    2008-01-17
+;
+  Change 'Definition' to 'Evaluation' in import_list.id.
   Changed import.scope entries to leading uc character.
-;        
-         3.7.09    2008-02-12           
+;
+         3.7.09    2008-02-12
 ;
   Change 'Itm' to 'Def' in import.scope.
-;        
-         3.7.10    2008-03-28           
+;
+         3.7.10    2008-03-28
 ;
   Update the definition of _type.dimension.
-;        
-         3.7.11    2008-05-18           
+;
+         3.7.11    2008-05-18
 ;
   Changed 2 type.contents values from "Implied" to "Inherited"
   Change import_list.id to be ((.....))
 
-;        
-         3.7.12    2008-08-05           
+;
+         3.7.12    2008-08-05
 ;
   Correct _type.dimension definition.
-;        
-         3.7.13    2011-01-27           
+;
+         3.7.13    2011-01-27
 ;
   Change definition scope of Head category to "Dictionary"
   Remove all tabs and replace with blank string
-;        
-         3.7.14    2011-03-25           
+;
+         3.7.14    2011-03-25
 ;
   In the attribute import_list.id
-  Change _type.contents  Tuple(Code,Tag,Uri,Code,Code)  
+  Change _type.contents  Tuple(Code,Tag,Uri,Code,Code)
   To     _type.contents  Tuple(Code,Ctag,Uri,Code,Code)
  In the attribute import.block
   Change _type.contents    Tag
   To     _type.contents    Ctag
   And change the case examples
-;        
-         3.8.01    2011-06-07           
+;
+         3.8.01    2011-06-07
 ;
   Remove the Tuple and Array enumerations from _type.container
   Change category class enumeration from List to Loop; and change
   all invocations of _category.class in the definitions
   Introduce nested save frames for expressing nested categories.
-;        
-         3.8.02    2011-06-21           
+;
+         3.8.02    2011-06-21
 ;
 Reconfigure _dictionary_valid attributes into lists, and reset the
 attribute application criteria at the rear of the DDL dictionary.
-;        
-         3.8.03    2011-06-22           
+;
+         3.8.03    2011-06-22
 ;
 Change IMPORT_LIST to IMPORT_TABLE. Change the IMPORT arguments to
 match this. Change the import_list.id invocations to import_table
 equivalents. Add _enumeration_set.table_tag.
-;        
-         3.8.04    2011-06-23           
+;
+         3.8.04    2011-06-23
 ;
 Remove IMPORT_TABLE. Change the IMPORT to a set category.
 Insert a import.get attribute to replace import_table.id
 Rename the DDL_ATTR category as ATTRIBUTES
-;        
-         3.8.05    2011-06-27           
+;
+         3.8.05    2011-06-27
 ;
 Change the _name.category_id value to reflect the parent category.
-;        
-         3.8.06    2011-06-29           
+;
+         3.8.06    2011-06-29
 ;
 Change Reference in _type.purpose to Ref-key
-;        
-         3.8.07    2011-06-30           
+;
+         3.8.07    2011-06-30
 ;
 Change Reference in _definition.class to Ref-loop.
 Remove import from type.contents and insert enumeration_set list.
 Insert name.category_id into every category definition.
-;        
-         3.8.08    2011-07-28           
+;
+         3.8.08    2011-07-28
 ;
 Add name.category_id and name.object_id to category definitions.
 Remove category.parent_id from category definitions.
 Remove definitions for category.parent_id and the CATEGORY_KEY
 and CATEGORY_MANDATORY definitions. Define category.key_id
-;        
-         3.8.08    2011-08-15           
+;
+         3.8.08    2011-08-15
 ;
 Add the state "Extend" to the type.purpose" attribute.
-;        
-         3.9.01    2011-12-08           
+;
+         3.9.01    2011-12-08
 ;
 Add types "Array" and "Matrix" to type.container attribute definition.
 Add type "Su" to the type.purpose attribute definition.
-;        
-         3.9.02    2012-01-25           
+;
+         3.9.02    2012-01-25
 ;
 For import.get change the key "fram" to "save".
-;        
-         3.10.01   2012-05-07           
+;
+         3.10.01   2012-05-07
 ;
 Revamp the type.purpose states. Remove state "Limit"
 Add the new attribute type.source
 Change dictionary.class "Attribute" to "Reference"
 Removed attribute enumeration_set.construct
-;        
-         3.10.02   2012-10-16           
+;
+         3.10.02   2012-10-16
 ;
 Correct enum states for type.contents and type.container
-;        
-         3.10.03   2012-11-20           
 ;
-Remove "Implied" as an enumeration state for type.contents 
-;        
-         3.10.04   2013-02-12           
+         3.10.03   2012-11-20
+;
+Remove "Implied" as an enumeration state for type.contents
+;
+         3.10.04   2013-02-12
 ;
 Added missing loop statement to methods of dictionary_valid.application.
 Corrected the definition of the enumeration state 'Code' in type.contents.
-;        
-         3.10.05   2013-02-22           
 ;
-Add state value to enum_set loop of import.get defn as the key 
-;        
-         3.10.06   2013-02-25           
+         3.10.05   2013-02-22
 ;
-Remove the quotes from Multiple string in type.container definition 
+Add state value to enum_set loop of import.get defn as the key
+;
+         3.10.06   2013-02-25
+;
+Remove the quotes from Multiple string in type.container definition
 Add 'Functions' to the enumeration states of definition.class
-;        
-         3.10.07   2013-03-03           
+;
+         3.10.07   2013-03-03
 ;
 Added type.contents enum state "Implied" for category key definitions
-;        
-         3.10.08   2013-03-06           
+;
+         3.10.08   2013-03-06
 ;
 Added various attributes to conform with ALIGN requirements
-;        
-         3.11.01   2013-04-11           
+;
+         3.11.01   2013-04-11
 ;
 Added type.source to all definitions
 Change type.contents state "Table" to "Pairs"
-;        
-         3.11.02   2013-04-16           
+;
+         3.11.02   2013-04-16
 ;
 Removed 'Measured' as a state for type.source
-;        
-         3.11.03   2013-04-24           
+;
+         3.11.03   2013-04-24
 ;
    Changed type.source 'Quantity' to 'Number' or 'Encode'
    State 'Float' in type.contents removed.
-;        
-         3.11.04   2013-09-08           
+;
+         3.11.04   2013-09-08
 ;
    Attribute _alias.deprecation_date added.
    Attribute _category.key_list      added.
    The attribute _category.key_list added to all Loop category defs.
-;        
-         3.11.05   2014-09-18           
+;
+         3.11.05   2014-09-18
 ;
    Looped category _category_key replaces _category.key_list
-   Added _category_key.name and changed all occurrences of 
+   Added _category_key.name and changed all occurrences of
    _category.key_list to _category_key.name
    Changed _type.source and _type.purpose to Recommended (JRH)
-;        
-         3.11.06   2015-01-27           
+;
+         3.11.06   2015-01-27
 ;
    Replaced stub category names with full category names in _name.category_id
    and _name.object_id.
    Corrected all _category.key_name to _category_key.name (JRH)
-; 
+;
          3.11.07   2015-01-27
 ;
-   Converted to CIF2 format using automatic tool and post-editing for 
-   presentation (JRH). 
+   Converted to CIF2 format using automatic tool and post-editing for
+   presentation (JRH).
 ;
          3.11.08   2015-01-28
 ;
-   Created _dictionary_valid.scope and corrected dREL method for 
-   _dictionary_valid.application. 
+   Created _dictionary_valid.scope and corrected dREL method for
+   _dictionary_valid.application.
 ;
          3.11.09   2015-05-07
 ;
@@ -2557,6 +2555,6 @@ Removed 'Measured' as a state for type.source
          3.11.10   2017-01-25
 ;
    Adjusted definition of _import_details.mode to remove references to
-   save frames and add special 'Head' category treatment.  Added
+   save frames and add special 'Head' category treatment. Added
    _dictionary.formalism
 ;


### PR DESCRIPTION
This pull request contains the following changes:
1) The _type.dimension data items were enclosed with single quotation marks to specify that they are strings and not arrays;
2) The definition of URI was corrected (changed to "Uniform Resource Identifier");
3) Tab symbols were replaced with spaces;
4) The '_alias.definition_id' and '_category_key.name' data items were placed inside loops as required by the DDLm dictionary.
5) Adding the _symmetry_Int_Tables_number and _symmetry_equiv_pos_site_id aliases to the cif_core.dic,
6) Adding the _pd_instr_monochr_pre_spec and _pd_instr_monochr_post_spec aliases to the cif_pow.dic.