### PR TITLE
Fix example of _atom_sites_Cartn_transform_axes

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -20596,7 +20596,7 @@ _type.container                         Single
 _type.contents                          Text
 loop_
   _description_example.case
-         'a parallel to x; b in the plane of y & z' 
+         'a parallel to x; b in the plane of x & y'
 
 save_
 
@@ -20954,7 +20954,7 @@ _type.container                         Single
 _type.contents                          Text
 loop_
   _description_example.case
-         'a parallel to x; b in the plane of y & z' 
+         'a parallel to x; b in the plane of x & y'
 
 save_
 

--- a/cif_core.star2.dic
+++ b/cif_core.star2.dic
@@ -12996,7 +12996,7 @@ save_atom_sites_Cartn_transform.axes
     _type.container              Single
     _type.contents               Text
      loop_
-    _description_example.case   'a parallel to x; b in the plane of y & z'
+    _description_example.case   'a parallel to x; b in the plane of x & y'
      save_
  
  
@@ -13334,7 +13334,7 @@ save_atom_sites_fract_transform.axes
     _type.container              Single
     _type.contents               Text
      loop_
-    _description_example.case   'a parallel to x; b in the plane of y & z'
+    _description_example.case   'a parallel to x; b in the plane of x & y'
      save_
  
  

--- a/cif_core_ddl1.dic
+++ b/cif_core_ddl1.dic
@@ -1610,7 +1610,7 @@ data_atom_sites_Cartn_transform_axes
     _name                      '_atom_sites_Cartn_transform_axes'
     _category                    atom_sites
     _type                        char
-    _example                    'a parallel to x; b in the plane of y and z'
+    _example                    'a parallel to x; b in the plane of x and y'
     _definition
 ;              A description of the relative alignment of the crystal cell
                axes to the  Cartesian orthogonal axes as applied in the


### PR DESCRIPTION
When `a` is parallel to `x`, `b` needs to be in the `xy` plane.
The `b in yz` orientation is impossible when gamma != 90deg.