### PR TITLE
Cif2 conversion type dimension fix

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -8799,7 +8799,7 @@ save_chemical_conn_bond.id
     _type.source                 Derived
     _type.container              List
     _type.contents               Index
-    _type.dimension              [2]
+    _type.dimension              '[2]'
      loop_
     _method.purpose
     _method.expression
@@ -11890,7 +11890,7 @@ save_geom_angle.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [3]
+    _type.dimension              '[3]'
      loop_
     _method.purpose
     _method.expression
@@ -12201,7 +12201,7 @@ save_geom_bond.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [2]
+    _type.dimension              '[2]'
      loop_
     _method.purpose
     _method.expression
@@ -12491,7 +12491,7 @@ save_geom_contact.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [2]
+    _type.dimension              '[2]'
      loop_
     _method.purpose
     _method.expression
@@ -12911,7 +12911,7 @@ save_geom_hbond.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [3]
+    _type.dimension              '[3]'
      loop_
     _method.purpose
     _method.expression
@@ -13226,7 +13226,7 @@ save_geom_torsion.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [4]
+    _type.dimension              '[4]'
      loop_
     _method.purpose
     _method.expression
@@ -13578,7 +13578,7 @@ save_model_site.id
     _type.source                 Derived
     _type.container              List
     _type.contents               List
-    _type.dimension              [1]
+    _type.dimension              '[1]'
      loop_
     _method.purpose
     _method.expression

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1078,7 +1078,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -3151,7 +3151,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -6406,7 +6406,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -6438,7 +6438,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -7079,7 +7079,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -7116,7 +7116,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -7149,7 +7149,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -7183,7 +7183,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -11000,7 +11000,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -11034,7 +11034,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -11066,7 +11066,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[4  4]'
+_type.dimension                         '[4,4]'
 loop_
   _method.purpose
   _method.expression
@@ -11394,7 +11394,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[4  4]'
+_type.dimension                         '[4,4]'
 loop_
   _method.purpose
   _method.expression
@@ -13466,7 +13466,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -19614,7 +19614,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -20070,7 +20070,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -20100,7 +20100,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -20815,7 +20815,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression
@@ -21100,7 +21100,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
-_type.dimension                         '[3  3]'
+_type.dimension                         '[3,3]'
 loop_
   _method.purpose
   _method.expression


### PR DESCRIPTION
Adding mandatory quotes around the values of the type dimension data item.
Adding commas instead of spaces as separators as discussed in issue #31.