### PR TITLE
Bugfix: correcting a typo in a data name

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -16167,7 +16167,7 @@ _type.container         Single
 _type.contents          Text
 loop_
    _enumeration_set.state
-   _enumeration_set.details
+   _enumeration_set.detail
    Identical           'The dataset contents are identical'
    Subset              'The dataset contents are a proper subset of the contents of the data block'
    Superset            'The dataset contents include the contents of the data block'


### PR DESCRIPTION
The '_enumeration_set.detail' data name was spelled with an extra 's' at the end.