### PR TITLE
Changed: changed the purpose of several data items to 'Measurand'

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -109,7 +109,7 @@ _description.text
 ;
 _name.category_id                       diffrn
 _name.object_id                         ambient_pressure
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Real
@@ -211,7 +211,7 @@ _description.text
 ;
 _name.category_id                       diffrn
 _name.object_id                         ambient_temperature
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Real
@@ -22322,7 +22322,7 @@ _description.text
 ;
 _name.category_id                       refine_diff
 _name.object_id                         density_max
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real
@@ -22378,7 +22378,7 @@ _description.text
 ;
 _name.category_id                       refine_diff
 _name.object_id                         density_min
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real
@@ -22439,7 +22439,7 @@ _description.text
 ;
 _name.category_id                       refine_diff
 _name.object_id                         density_rms
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real


### PR DESCRIPTION
Several data items contained seemingly incorrect type purpose based on the fact that the dictionary already contained associated standard uncertainty data items. This fixes several inconsistencies mentioned in #82.