### PR TITLE
Cif2 dimmension notation fix up

### DIFF
--- a/cif_img.dic
+++ b/cif_img.dic
@@ -14,7 +14,7 @@ data_CIF_IMG
     _dictionary.title            CIF_IMG
     _dictionary.class            Instance
     _dictionary.version          3.00.02
-    _dictionary.date             2014-07-30
+    _dictionary.date             2019-04-01
     _dictionary.uri              www.iucr.org/cif/dic/cif_img.dic
     _dictionary.ddl_conformance  3.11.04
     _dictionary.namespace        CifImag
@@ -2187,7 +2187,7 @@ save_axis.equipment_component
 
 save_axis.offset
     _definition.id             '_axis.offset'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text
 ;
      The three-element vector used to specify the offset to the
@@ -2199,7 +2199,7 @@ save_axis.offset
     _type.source                derived
     _type.container             Matrix
     _type.contents              Real
-    _type.dimension             [3]
+    _type.dimension             '[3]'
     _units.code                 millimetres
      loop_
     _method.purpose
@@ -2397,7 +2397,7 @@ save_axis.type
 
 save_axis.vector
     _definition.id             '_axis.vector'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text
 ;
      The three-element vector used to specify the direction
@@ -2411,7 +2411,7 @@ save_axis.vector
     _type.source                Derived
     _type.container             Matrix
     _type.contents              Real
-    _type.dimension             [3]
+    _type.dimension             '[3]'
     _units.code                 none
      loop_
     _method.purpose

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -24,9 +24,9 @@ data_CIF_MS
     _dictionary.formalism        Modulated
     _dictionary.class            Instance
     _dictionary.version          3.2
-    _dictionary.date             2017-09-28
+    _dictionary.date             2019-04-01
     _dictionary.uri              http://www.iucr.org/cif/dic/cif_ms.dic
-    _dictionary.ddl_conformance  3.11.09
+    _dictionary.ddl_conformance  3.13.1
     _dictionary.namespace        ModStruct
     _description.text                   
 ;
@@ -1100,7 +1100,7 @@ save_
 save_atom_site_displace_special_func.sawtooth
 
     _definition.id               '_atom_site_displace_special_func.sawtooth'
-    _definition.update           2017-09-28
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1144,7 +1144,7 @@ save_atom_site_displace_special_func.sawtooth
     _type.container              Matrix
     _type.contents               Real
     _type.dimension              '[3]'
-    _enumeration.default         [0.0,0.0,0.0]
+    _enumeration.default         [0.0 0.0 0.0]
 # JRH notes
 # Does the dREL below take into account the use of matrix_seq_id?
 #
@@ -1166,7 +1166,7 @@ save_
 save_atom_site_displace_special_func.sawtooth_axyz
 
     _definition.id               '_atom_site_displace_special_func.sawtooth_axyz'
-    _definition.update           2017-09-28
+    _definition.update           2019-04-01
     _description.text
 ;
 
@@ -1180,8 +1180,8 @@ save_atom_site_displace_special_func.sawtooth_axyz
     _type.source                 Assigned
     _type.container              Array
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
     loop_
       _method.purpose
       _method.expression
@@ -1345,7 +1345,7 @@ save_
 save_atom_site_displace_special_func.zigzag
 
     _definition.id               '_atom_site_displace_special_func.zigzag'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1395,8 +1395,8 @@ save_atom_site_displace_special_func.zigzag
     _type.source                 Assigned
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
     loop_
       _method.purpose
       _method.expression
@@ -1415,7 +1415,7 @@ save_
 save_atom_site_displace_special_func.zigzag_axyz
 
     _definition.id               '_atom_site_displace_special_func.zigzag_axyz'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1429,8 +1429,8 @@ save_atom_site_displace_special_func.zigzag_axyz
     _type.source                 Assigned
     _type.container              Array
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
 
 save_
 
@@ -1754,7 +1754,7 @@ save_
 save_atom_site_Fourier_wave_vector.q_coeff
 
     _definition.id               '_atom_site_Fourier_wave_vector.q_coeff'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1782,7 +1782,7 @@ save_atom_site_Fourier_wave_vector.q_coeff
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              []
+    _type.dimension              '[]'
     _enumeration.default         [0]
 
 save_
@@ -1790,7 +1790,7 @@ save_
 save_atom_site_Fourier_wave_vector.q_coeff_seq_id
 
     _definition.id               '_atom_site_Fourier_wave_vector.q_coeff_seq_id'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1808,7 +1808,7 @@ save_atom_site_Fourier_wave_vector.q_coeff_seq_id
     _type.source                 Assigned
     _type.container              List
     _type.contents               Code
-    _type.dimension              []
+    _type.dimension              '[]'
     _enumeration.default         [1] 
 
 save_
@@ -1858,7 +1858,7 @@ save_
 save_atom_site_Fourier_wave_vector.xyz
 
     _definition.id               '_atom_site_Fourier_wave_vector.xyz'
-    _definition.update           2017-09-28
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -1880,7 +1880,7 @@ save_atom_site_Fourier_wave_vector.xyz
     _type.source                 Derived
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
+    _type.dimension              '[3]'
 loop_
       _method.purpose
       _method.expression
@@ -2678,7 +2678,7 @@ save_
 save_atom_site_occ_special_func.crenel_ortho_eps
 
     _definition.id               '_atom_site_occ_special_func.crenel_ortho_eps'
-    _definition.update           2017-09-28
+    _definition.update           2019-04-01
     _description.text                   
 ;
       The set of harmonic functions used in the Fourier series describing the 
@@ -2713,7 +2713,7 @@ save_atom_site_occ_special_func.crenel_ortho_eps
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Real
-    _enumeration_default         0.95
+    _enumeration_default.value   0.95
 
 save_
 
@@ -3834,7 +3834,7 @@ save_
 save_atom_site_rot_special_func.sawtooth
 
     _definition.id               '_atom_site_rot_special_func.sawtooth'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -3876,8 +3876,8 @@ save_atom_site_rot_special_func.sawtooth
     _type.source                 Assigned
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
     loop_
       _method.purpose
       _method.expression
@@ -3896,7 +3896,7 @@ save_
 save_atom_site_rot_special_func.sawtooth_axyz
 
     _definition.id               '_atom_site_rot_special_func.sawtooth_axyz'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -3910,8 +3910,8 @@ save_atom_site_rot_special_func.sawtooth_axyz
     _type.source                 Assigned
     _type.container              Array
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
     _units.code                 degrees
     loop_
       _method.purpose
@@ -4076,7 +4076,7 @@ save_
 save_atom_site_rot_special_func.zigzag
 
     _definition.id               '_atom_site_rot_special_func.zigzag'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -4125,15 +4125,15 @@ save_atom_site_rot_special_func.zigzag
     _type.source                 Assigned
     _type.container              Matrix
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
 
 save_
 
 save_atom_site_rot_special_func.zigzag_axyz
 
     _definition.id               '_atom_site_rot_special_func.zigzag_axyz'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text
 ;
 
@@ -4147,8 +4147,8 @@ save_atom_site_rot_special_func.zigzag_axyz
     _type.source                 Assigned
     _type.container              Array
     _type.contents               Real
-    _type.dimension              [3]
-    _enumeration.default         [0.0,0.0,0.0]
+    _type.dimension              '[3]'
+    _enumeration.default         [0.0 0.0 0.0]
     _units.code                  degrees
     loop_
       _method.purpose
@@ -5194,7 +5194,7 @@ save_
 save_atom_sites_axes.matrix
 
     _definition.id               '_atom_sites_axes.matrix'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -5211,8 +5211,10 @@ save_atom_sites_axes.matrix
     _type.source                 Assigned
     _type.container              Matrix
     _type.contents               Real
-    _type_dimension              [3,3]
-    _enumeration_default         [[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]]
+    _type.dimension              '[3,3]'
+    _enumeration_default.value    [[1.0 0.0 0.0]
+                                  [0.0 1.0 0.0]
+                                  [0.0 0.0 1.0]]
 
 save_
 
@@ -5618,7 +5620,7 @@ save_
 save_atom_sites_ortho.coeff_cos_list
 
     _definition.id               '_atom_sites_ortho.coeff_cos_list'
-    _definition.update           2017-03-11
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -5632,7 +5634,7 @@ save_atom_sites_ortho.coeff_cos_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Real
-    _type.dimension              []
+    _type.dimension              '[]'
     _enumeration.default         [0.0]
 
 save_
@@ -5640,7 +5642,7 @@ save_
 save_atom_sites_ortho.coeff_sin_list
 
     _definition.id               '_atom_sites_ortho.coeff_sin_list'
-    _definition.update           2017-03-11
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -5654,7 +5656,7 @@ save_atom_sites_ortho.coeff_sin_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Real
-    _type.dimension              []
+    _type.dimension              '[]'
     _enumeration.default         [0.0]
 
 save_
@@ -5783,7 +5785,7 @@ save_
 
 save_cell.commen_supercell_matrix
     _definition.id               '_cell.commen_supercell_matrix'
-    _definition.update           2017-09-28
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -5802,8 +5804,10 @@ save_cell.commen_supercell_matrix
     _type.source                 Assigned
     _type.container              Matrix
     _type.contents               Integer
-    _type.dimension              [3,3]
-    _enumeration.default         [[1,0,0],[0,1,0],[0,0,1]]
+    _type.dimension              '[3,3]'
+    _enumeration.default         [[1 0 0]
+                                  [0 1 0]
+                                  [0 0 1]]
 
 save_
 
@@ -7604,7 +7608,7 @@ save_
 save_diffrn_refln.index_m_list
 
     _definition.id               '_diffrn_refln.index_m_list'
-    _definition.update           2016-11-17
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -7631,7 +7635,7 @@ save_diffrn_refln.index_m_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              []
+    _type.dimension              '[]'
     loop_
       _method.purpose
       _method.expression
@@ -7807,7 +7811,7 @@ save_
 save_diffrn_reflns.limit_index_m_max_list
 
     _definition.id               '_diffrn_reflns.limit_index_m_max_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -7823,7 +7827,7 @@ save_diffrn_reflns.limit_index_m_max_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -8001,7 +8005,7 @@ save_
 save_diffrn_reflns.limit_index_m_min_list
 
     _definition.id               '_diffrn_reflns.limit_index_m_min_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -8017,7 +8021,7 @@ save_diffrn_reflns.limit_index_m_min_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -8245,7 +8249,7 @@ save_
 save_diffrn_standard_refln.index_m_list
 
     _definition.id               '_diffrn_standard_refln.index_m_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -8264,7 +8268,7 @@ save_diffrn_standard_refln.index_m_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -8471,7 +8475,7 @@ save_
 save_exptl_crystal_face.index_m_list
 
     _definition.id               '_exptl_crystal_face.index_m_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -8488,7 +8492,7 @@ save_exptl_crystal_face.index_m_list
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -8729,7 +8733,7 @@ save_
 save_function.Sawtooth
 
     _definition.id               '_function.Sawtooth'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text
 ;
 
@@ -8753,7 +8757,7 @@ save_function.Sawtooth
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Array
-    _type_dimension              [3]
+    _type.dimension              '[3]'
     _type.contents               Real
     loop_
       _method.purpose
@@ -8805,7 +8809,7 @@ save_
 save_function.Zigzag
 
     _definition.id               '_function.Zigzag'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text
 ;
 
@@ -8834,7 +8838,7 @@ save_function.Zigzag
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Array
-    _type_dimension              [3]
+    _type.dimension              '[3]'
     _type.contents               Real
     loop_
       _method.purpose
@@ -9767,7 +9771,7 @@ save_
 save_refln.index_m_list
 
     _definition.id               '_refln.index_m_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -9783,7 +9787,7 @@ save_refln.index_m_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -9981,7 +9985,7 @@ save_
 save_reflns.limit_index_m_max_list
 
     _definition.id               '_reflns.limit_index_m_max_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -9998,7 +10002,7 @@ save_reflns.limit_index_m_max_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -10024,7 +10028,7 @@ save_
 save_reflns.limit_index_m_min_list
 
     _definition.id               '_reflns.limit_index_m_min_list'
-    _definition.update           2014-06-27
+    _definition.update           2019-04-01
     _description.text                   
 ;
 
@@ -10041,7 +10045,7 @@ save_reflns.limit_index_m_min_list
     _type.source                 Assigned
     _type.container              List
     _type.contents               Integer
-    _type.dimension              [8]
+    _type.dimension              '[8]'
     loop_
       _method.purpose
       _method.expression
@@ -10636,7 +10640,7 @@ save_
 save_geom_angle.distances
 
 _definition.id                          '_geom_angle.distances'
-_definition.update                      2012-11-22
+_definition.update                      2019-04-01
 _description.text                       
 ;
      The pair of distances between sites 1 - 2 and 2 - 3.
@@ -10647,7 +10651,7 @@ _type.purpose                           Measurand
 _type.source                            Derived
 _type.container                         List
 _type.contents                          Real
-_type.dimension                        [2]
+_type.dimension                        '[2]'
 _units.code                             angstroms
 
 save_

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -2713,7 +2713,7 @@ save_atom_site_occ_special_func.crenel_ortho_eps
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Real
-    _enumeration_default.value   0.95
+    _enumeration.default         0.95
 
 save_
 
@@ -5212,7 +5212,7 @@ save_atom_sites_axes.matrix
     _type.container              Matrix
     _type.contents               Real
     _type.dimension              '[3,3]'
-    _enumeration_default.value    [[1.0 0.0 0.0]
+    _enumeration.default         [[1.0 0.0 0.0]
                                   [0.0 1.0 0.0]
                                   [0.0 0.0 1.0]]
 

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -12,9 +12,9 @@ data_CIF_RHO
     _dictionary.title            cif_rho
     _dictionary.class            Instance
     _dictionary.version          2.00.01
-    _dictionary.date             2014-06-20
+    _dictionary.date             2019-04-01
     _dictionary.uri              www.iucr.org/cif/dic/cif_rho.dic
-    _dictionary.ddl_conformance  3.11.04
+    _dictionary.ddl_conformance  3.13.1
     _dictionary.namespace        CifRho
     _description.text
 ;
@@ -526,7 +526,7 @@ save_atom_rho_multipole.scat_core_table
     _definition.id             '_atom_rho_multipole.scat_core_table'
      loop_
     _alias.definition_id       '_atom_rho_multipole_scat_core_table'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text
 ;
       This table gives the scattering factor for the core electrons
@@ -554,7 +554,7 @@ save_atom_rho_multipole.scat_core_table
     _type.source                 Assigned
     _type.container              Table
     _type.contents               Real
-    _type.dimension              []
+    _type.dimension              '[]'
      save_
 
  
@@ -598,7 +598,7 @@ save_atom_rho_multipole.scat_valence_table
     _definition.id             '_atom_rho_multipole.scat_valence_table'
      loop_
     _alias.definition_id       '_atom_rho_multipole_scat_valence_table'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text
 ;
       This table gives the scattering factor for the valence electrons
@@ -626,7 +626,7 @@ save_atom_rho_multipole.scat_valence_table
     _type.source                 Assigned
     _type.container              Table
     _type.contents               Real
-    _type.dimension              []
+    _type.dimension              '[]'
      save_
 
  
@@ -679,7 +679,7 @@ save_atom_rho_multipole_coeff.list
     _definition.id             '_atom_rho_multipole_coeff.list'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_list'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text             
 ;
       Specifies the multipole population coefficients P(l,m) for
@@ -738,7 +738,7 @@ save_atom_rho_multipole_coeff.list
     _type.source                 Derived
     _type.container              List   
     _type.contents               Real
-    _type.dimension              [27]
+    _type.dimension              '[27]'
      loop_
     _method.purpose
     _method.expression
@@ -1055,7 +1055,7 @@ save_atom_rho_multipole_kappa.list
     _definition.id             '_atom_rho_multipole_kappa.list'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_list'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text             
 ;
       Gives the radial function expansion-contraction coefficients
@@ -1113,7 +1113,7 @@ save_atom_rho_multipole_kappa.list
     _type.source                 Derived
     _type.container              List
     _type.contents               Real
-    _type.dimension              [6] 
+    _type.dimension              '[6]'
      loop_
     _method.purpose
     _method.expression
@@ -1207,7 +1207,7 @@ save_atom_rho_multipole_radial_slater.list
     _definition.id             '_atom_rho_multipole_radial_slater.list'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_list'
-    _definition.update           2014-06-20
+    _definition.update           2019-04-01
     _description.text             
 ;
       These items are used when the radial dependence of the valence
@@ -1276,7 +1276,7 @@ save_atom_rho_multipole_radial_slater.list
     _type.source                 Derived
     _type.container              List
     _type.contents               Real
-    _type.dimension              [10]
+    _type.dimension              '[10]'
      loop_
     _method.purpose
     _method.expression

--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          3.13.1
-    _dictionary.date             2017-10-26
+    _dictionary.date             2019-04-01
     _dictionary.uri              
              https://github.com/COMCIFS/cif_core/blob/cif2-conversion/ddl.dic
     _dictionary.ddl_conformance  3.13.1
@@ -1831,7 +1831,7 @@ save_type.contents
 
     _definition.id               '_type.contents'
     _definition.class            Attribute
-    _definition.update           2013-04-24
+    _definition.update           2019-04-01
     _description.text
 ;
 
@@ -1883,7 +1883,11 @@ save_type.contents
               DateTime
             'A timestamp. Text formats must use date-time or full-date productions of RFC3339 ABNF'
               Version       'version digit string of the form <major>.<version>.<update>'
-              Dimension     'integer limits of an Array/Matrix/List in square brackets'
+              Dimension   '''Size of an Array/Matrix/List expressed as a text
+                             string. The text string itself consists of zero
+                             or more non-negative integers separated by commas
+                             placed within bounding square brackets. Empty
+                             square brackets represent a list of unknown size'''
               Range         'inclusive range of numerical values min:max'
               Count         'unsigned integer number'
               Index         'unsigned non-zero integer number'
@@ -1929,11 +1933,10 @@ save_type.dimension
 
     _definition.id               '_type.dimension'
     _definition.class            Attribute
-    _definition.update           2013-04-17
+    _definition.update           2019-04-01
     _description.text
 ;
-     The dimensions of a list or matrix of elements as a text string
-     within bounding square brackets.
+     The dimensions of a list or matrix of elements expressed as a text string.
 ;
     _name.category_id            type
     _name.object_id              dimension


### PR DESCRIPTION
Slightly updated the description of the 'Dimension' content type.
Updated the rest of the dictionaries to adhere to agreed upon notation.
Corrected several list values in the cif_ms.dic  to adhere to the CIF2 syntax.