### PR TITLE
Converting cif_rho.dic and cif_img.dic dictionaries to CIF2

### DIFF
--- a/cif_img.dic
+++ b/cif_img.dic
@@ -15,7 +15,7 @@ data_CIF_IMG
     _dictionary.title            CIF_IMG
     _dictionary.class            Instance
     _dictionary.version          3.00.02
-    _dictionary.date             2014-07-30
+    _dictionary.date             2019-04-01
     _dictionary.uri              www.iucr.org/cif/dic/cif_img.dic
     _dictionary.ddl_conformance  3.11.04
     _dictionary.namespace        CifImag
@@ -2812,13 +2812,13 @@ save_
 
 save_diffrn_detector.details
     _definition.id             '_diffrn_detector.details'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.details'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.details'}]
      save_
 
 
 save_diffrn_detector.detector
     _definition.id             '_diffrn_detector.detector'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.description'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.description'}]
      save_
 
 
@@ -2843,7 +2843,7 @@ save_diffrn_detector.diffrn_id
 
 save_diffrn_detector.dtime
     _definition.id             '_diffrn_detector.dtime'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.dtime'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.dtime'}]
      save_
 
 
@@ -2936,7 +2936,7 @@ save_diffrn_detector.number_of_axes
 
 save_diffrn_detector.type
     _definition.id             '_diffrn_detector.type'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.make'}]
+     _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.make'}]
      save_
 
 
@@ -3236,19 +3236,19 @@ save_
 
 save_diffrn_measurement.device
     _definition.id             '_diffrn_measurement.device'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_class'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.device_class'}]
      save_
 
 
 save_diffrn_measurement.device_details
     _definition.id             '_diffrn_measurement.device_details'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_details'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.device_details'}]
      save_
 
 
 save_diffrn_measurement.device_type
     _definition.id             '_diffrn_measurement.device_type'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_make'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.device_make'}]
      save_
 
 
@@ -3271,7 +3271,7 @@ save_diffrn_measurement.diffrn_id
 
 save_diffrn_measurement.details
     _definition.id             '_diffrn_measurement.details'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.details'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.details'}]
      save_
 
 
@@ -3303,7 +3303,7 @@ save_diffrn_measurement.id
 
 save_diffrn_measurement.method
     _definition.id             '_diffrn_measurement.method'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.method'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.method'}]
      save_
 
 
@@ -3368,7 +3368,7 @@ save_diffrn_measurement.sample_detector_voffset
 
 save_diffrn_measurement.specimen_support
     _definition.id             '_diffrn_measurement.specimen_support'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.specimen_support'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_measurement.specimen_support'}]
      save_
 
 
@@ -3514,7 +3514,7 @@ save_
 
 save_diffrn_radiation.collimation
     _definition.id             '_diffrn_radiation.collimation'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.collimation'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.collimation'}]
      save_
 
 
@@ -3626,25 +3626,25 @@ save_diffrn_radiation.div_x_y_source
 
 save_diffrn_radiation.filter_edge
     _definition.id             '_diffrn_radiation.filter_edge'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.filter_edge'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.filter_edge'}]
      save_
 
 
 save_diffrn_radiation.inhomogeneity
     _definition.id             '_diffrn_radiation.inhomogeneity'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.inhomogeneity'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.inhomogeneity'}]
      save_
 
 
 save_diffrn_radiation.monochromator
     _definition.id             '_diffrn_radiation.monochromator'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.monochromator'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.monochromator'}]
      save_
 
 
 save_diffrn_radiation.polarisn_norm
     _definition.id             '_diffrn_radiation.polarisn_norm'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.polarisn_norm'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.polarisn_norm'}]
      save_
 
 
@@ -3673,7 +3673,7 @@ save_diffrn_radiation.polarisn_norm_esd
 
 save_diffrn_radiation.polarisn_ratio
     _definition.id             '_diffrn_radiation.polarisn_ratio'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.polarisn_ratio'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.polarisn_ratio'}]
      save_
 
 
@@ -4070,25 +4070,25 @@ save_diffrn_radiation.polarizn_Stokes_V_esd
 
 save_diffrn_radiation.probe
     _definition.id             '_diffrn_radiation.probe'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.probe'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.probe'}]
      save_
 
 
 save_diffrn_radiation.type
     _definition.id             '_diffrn_radiation.type'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.type'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.type'}]
      save_
 
 
 save_diffrn_radiation.xray_symbol
     _definition.id             '_diffrn_radiation.xray_symbol'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.xray_symbol'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation.xray_symbol'}]
      save_
 
 
 save_diffrn_radiation.wavelength_id
     _definition.id             '_diffrn_radiation.wavelength_id'
-    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation_wavelength.id'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_radiation_wavelength.id'}]
      save_
 
 

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -74,7 +74,7 @@ save_ARRAY_DATA
     _definition.id              array_data
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the ARRAY_DATA category are the containers for
@@ -94,9 +94,11 @@ save_ARRAY_DATA
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_DATA
-    _category.key_list       ['_array_data.array_id'
-                              '_array_data.binary_id'
-                              '_array_data.variant'] 
+    loop_
+    _category_key.name
+                                '_array_data.array_id'
+                                '_array_data.binary_id'
+                                '_array_data.variant'
 save_
 
 save_array_data.array_id
@@ -449,7 +451,7 @@ save_ARRAY_ELEMENT_SIZE
     _definition.id              array_element_size
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the ARRAY_ELEMENT_SIZE category record the physical
@@ -457,9 +459,11 @@ save_ARRAY_ELEMENT_SIZE
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_ELEMENT_SIZE
-    _category.key_list       ['_array_element_size.array_id'
-                              '_array_element_size.index'
-                              '_array_element_size.variant']  
+    loop_
+    _category_key.name
+                                '_array_element_size.array_id'
+                                '_array_element_size.index'
+                                '_array_element_size.variant'
 save_
 
 save_array_element_size.array_id
@@ -543,7 +547,7 @@ save_ARRAY_INTENSITIES
     _definition.id              ARRAY_INTENSITIES
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the ARRAY_INTENSITIES category record the
@@ -563,9 +567,11 @@ save_ARRAY_INTENSITIES
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_INTENSITIES
-    _category.key_list       ['_array_intensities.array_id'
-                              '_array_intensities.binary_id'
-                              '_array_intensities.variant'] 
+    loop_
+    _category_key.name
+                                '_array_intensities.array_id'
+                                '_array_intensities.binary_id'
+                                '_array_intensities.variant'
 save_
 
 save_array_intensities.array_id
@@ -912,7 +918,7 @@ save_ARRAY_STRUCTURE
     _definition.id              ARRAY_STRUCTURE
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the ARRAY_STRUCTURE category record the organization and
@@ -920,8 +926,10 @@ save_ARRAY_STRUCTURE
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE
-    _category.key_list       ['_array_structure.id'
-                              '_array_structure.variant'] 
+    loop_
+    _category_key.name
+                                '_array_structure.id'
+                                '_array_structure.variant' 
 save_
 
 save_array_structure.byte_order
@@ -1120,7 +1128,7 @@ save_ARRAY_STRUCTURE_LIST
     _definition.id              ARRAY_STRUCTURE_LIST
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      The ARRAY_STRUCTURE_LIST category record the size
@@ -1129,9 +1137,11 @@ save_ARRAY_STRUCTURE_LIST
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST
-    _category.key_list       ['_array_structure_list.array_id'
-                              '_array_structure_list.index'
-                              '_array_structure_list.variant']  
+    loop_
+    _category_key.name
+                                '_array_structure_list.array_id'
+                                '_array_structure_list.index'
+                                '_array_structure_list.variant'
 save_
 
 save_array_structure_list.array_id
@@ -1301,7 +1311,7 @@ save_ARRAY_STRUCTURE_LIST_SECTION
     _definition.id              ARRAY_STRUCTURE_LIST_SECTION
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the ARRAY_STRUCTURE_LIST_SECTION category identify
@@ -1330,10 +1340,12 @@ save_ARRAY_STRUCTURE_LIST_SECTION
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST_SECTION
-    _category.key_list       ['_array_structure_list_section.id'
-                              '_array_structure_list_section.array_id'
-                              '_array_structure_list_section.index'
-                              '_array_structure_list_section.variant'] 
+    loop_
+    _category_key.name
+                                '_array_structure_list_section.id'
+                                '_array_structure_list_section.array_id'
+                                '_array_structure_list_section.index'
+                                '_array_structure_list_section.variant'
 save_
 
 save_array_structure_list_section.array_id
@@ -1502,7 +1514,7 @@ save_ARRAY_STRUCTURE_LIST_AXIS
     _definition.id              ARRAY_STRUCTURE_LIST_AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the ARRAY_STRUCTURE_LIST_AXIS category describe
@@ -1521,9 +1533,11 @@ save_ARRAY_STRUCTURE_LIST_AXIS
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST_AXIS
-    _category.key_list       ['_array_structure_list_axis.axis_set_id'
-                              '_array_structure_list_axis.axis_id'
-                              '_array_structure_list_axis.variant'] 
+    loop_
+    _category_key.name
+                                '_array_structure_list_axis.axis_set_id'
+                                '_array_structure_list_axis.axis_id'
+                                '_array_structure_list_axis.variant'
 save_
 
 save_array_structure_list_axis.axis_id
@@ -1835,7 +1849,7 @@ save_AXIS
     _definition.id              AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the AXIS category record the information required
@@ -2099,9 +2113,11 @@ save_AXIS
 ;
     _name.category_id           AXIS_GROUP
     _name.object_id             AXIS
-    _category.key_list       ['_axis.id'
-                              '_axis.equipment'
-                              '_axis.variant'] 
+    loop_
+    _category_key.name
+                                '_axis.id'
+                                '_axis.equipment'
+                                '_axis.variant'
 save_
 
 save_axis.depends_on
@@ -2510,7 +2526,7 @@ save_DIFFRN_DATA_FRAME
     _definition.id              DIFFRN_DATA_FRAME
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the DIFFRN_DATA_FRAME category record
@@ -2522,9 +2538,11 @@ save_DIFFRN_DATA_FRAME
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DATA_FRAME
-    _category.key_list       ['_diffrn_data_frame.id'
-                              '_diffrn_data_frame.detector_element_id'
-                              '_diffrn_data_frame.variant']  
+    loop_
+    _category_key.name
+                                '_diffrn_data_frame.id'
+                                '_diffrn_data_frame.detector_element_id'
+                                '_diffrn_data_frame.variant'
 save_
 
 save_diffrn_data_frame.array_id
@@ -2796,7 +2814,7 @@ save_DIFFRN_DETECTOR
     _definition.id              DIFFRN_DETECTOR
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_DETECTOR category describe the
@@ -2805,9 +2823,11 @@ save_DIFFRN_DETECTOR
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR
-    _category.key_list       ['_diffrn_detector.diffrn_id'
-                              '_diffrn_detector.id'
-                              '_diffrn_detector.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_detector.diffrn_id'
+                                '_diffrn_detector.id'
+                                '_diffrn_detector.variant'
 save_
 
 save_diffrn_detector.details
@@ -2966,7 +2986,7 @@ save_DIFFRN_DETECTOR_AXIS
     _definition.id              DIFFRN_DETECTOR_AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_DETECTOR_AXIS category associate
@@ -2974,9 +2994,11 @@ save_DIFFRN_DETECTOR_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR_AXIS
-    _category.key_list       ['_diffrn_detector_axis.detector_id'
-                              '_diffrn_detector_axis.axis_id'
-                              '_diffrn_detector_axis.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_detector_axis.detector_id'
+                                '_diffrn_detector_axis.axis_id'
+                                '_diffrn_detector_axis.variant'
 save_
 
 save_diffrn_detector_axis.axis_id
@@ -3045,7 +3067,7 @@ save_DIFFRN_DETECTOR_ELEMENT
     _definition.id              DIFFRN_DETECTOR_ELEMENT
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the DIFFRN_DETECTOR_ELEMENT category record
@@ -3058,9 +3080,11 @@ save_DIFFRN_DETECTOR_ELEMENT
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR_ELEMENT
-    _category.key_list       ['_diffrn_detector_element.id'
-                              '_diffrn_detector_element.detector_id'
-                              '_diffrn_detector_element.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_detector_element.id'
+                                '_diffrn_detector_element.detector_id'
+                                '_diffrn_detector_element.variant'
 save_
 
 save_diffrn_detector_element.id
@@ -3218,7 +3242,7 @@ save_DIFFRN_MEASUREMENT
     _definition.id              DIFFRN_MEASUREMENT
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_MEASUREMENT category record details
@@ -3228,10 +3252,12 @@ save_DIFFRN_MEASUREMENT
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_MEASUREMENT
-    _category.key_list       ['_diffrn_measurement.device'
-                              '_diffrn_measurement.diffrn_id'
-                              '_diffrn_measurement.id'
-                              '_diffrn_measurement.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_measurement.device'
+                                '_diffrn_measurement.diffrn_id'
+                                '_diffrn_measurement.id'
+                                '_diffrn_measurement.variant'
 save_
 
 save_diffrn_measurement.device
@@ -3398,7 +3424,7 @@ save_DIFFRN_MEASUREMENT_AXIS
     _definition.id              DIFFRN_MEASUREMENT_AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_MEASUREMENT_AXIS category associate
@@ -3406,10 +3432,12 @@ save_DIFFRN_MEASUREMENT_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_MEASUREMENT_AXIS
-    _category.key_list  ['_diffrn_measurement_axis.measurement_device'
-                         '_diffrn_measurement_axis.measurement_id'
-                         '_diffrn_measurement_axis.axis_id'
-                         '_diffrn_measurement_axis.variant']
+    loop_
+    _category_key.name
+                                '_diffrn_measurement_axis.measurement_device'
+                                '_diffrn_measurement_axis.measurement_id'
+                                '_diffrn_measurement_axis.axis_id'
+                                '_diffrn_measurement_axis.variant'
 save_
 
 save_diffrn_measurement_axis.axis_id
@@ -3496,7 +3524,7 @@ save_DIFFRN_RADIATION
     _definition.id              DIFFRN_RADIATION
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_RADIATION category describe
@@ -3508,8 +3536,10 @@ save_DIFFRN_RADIATION
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_RADIATION
-    _category.key_list       ['_diffrn_radiation.diffrn_id'
-                              '_diffrn_radiation.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_radiation.diffrn_id'
+                                '_diffrn_radiation.variant'
 save_
 
 save_diffrn_radiation.collimation
@@ -4118,7 +4148,7 @@ save_DIFFRN_REFLN
     _definition.id              DIFFRN_REFLN
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      This category redefinition has been added to extend the key of
@@ -4135,10 +4165,12 @@ save_DIFFRN_REFLN
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_REFLN
-    _category.key_list       ['_diffrn_refln.diffrn_id'
-                              '_diffrn_refln.id'
-                              '_diffrn_refln.frame_id'
-                              '_diffrn_refln.variant']  
+    loop_
+    _category_key.name
+                                '_diffrn_refln.diffrn_id'
+                                '_diffrn_refln.id'
+                                '_diffrn_refln.frame_id'
+                                '_diffrn_refln.variant'
 save_
 
 save_diffrn_refln.frame_id
@@ -4221,7 +4253,7 @@ save_DIFFRN_SCAN
     _definition.id              DIFFRN_SCAN
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_SCAN category describe the parameters 
@@ -4229,8 +4261,10 @@ save_DIFFRN_SCAN
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN
-    _category.key_list       ['_diffrn_scan.id'
-                              '_diffrn_scan.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_scan.id'
+                                '_diffrn_scan.variant'
 save_
 
 save_diffrn_scan.id
@@ -4438,7 +4472,7 @@ save_DIFFRN_SCAN_AXIS
     _definition.id              DIFFRN_SCAN_AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
 items in the DIFFRN_SCAN_AXIS category describe the settings of
@@ -4447,9 +4481,11 @@ for particular scans.  Unspecified axes are assumed to be at
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_AXIS
-    _category.key_list       ['_diffrn_scan_axis.scan_id'
-                              '_diffrn_scan_axis.axis_id'
-                              '_diffrn_scan_axis.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_scan_axis.scan_id'
+                                '_diffrn_scan_axis.axis_id'
+                                '_diffrn_scan_axis.variant'
 save_
 
 save_diffrn_scan_axis.scan_id
@@ -4760,7 +4796,7 @@ save_DIFFRN_SCAN_FRAME
     _definition.id              DIFFRN_SCAN_FRAME
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_SCAN_FRAME category describe
@@ -4768,9 +4804,11 @@ save_DIFFRN_SCAN_FRAME
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME
-    _category.key_list       ['_diffrn_scan_frame.scan_id'
-                              '_diffrn_scan_frame.frame_id'
-                              '_diffrn_scan_frame.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_scan_frame.scan_id'
+                                '_diffrn_scan_frame.frame_id'
+                                '_diffrn_scan_frame.variant'
 save_
 
 save_diffrn_scan_frame.date
@@ -5185,7 +5223,7 @@ save_DIFFRN_SCAN_FRAME_AXIS
     _definition.id              DIFFRN_SCAN_FRAME_AXIS
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
      Data items in the DIFFRN_SCAN_FRAME_AXIS category describe the
@@ -5197,9 +5235,11 @@ save_DIFFRN_SCAN_FRAME_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME_AXIS
-    _category.key_list       ['_diffrn_scan_frame_axis.frame_id'
-                              '_diffrn_scan_frame_axis.axis_id'
-                              '_diffrn_scan_frame_axis.variant']
+    loop_
+    _category_key.name
+                                '_diffrn_scan_frame_axis.frame_id'
+                                '_diffrn_scan_frame_axis.axis_id'
+                                '_diffrn_scan_frame_axis.variant'
 save_
 
 save_diffrn_scan_frame_axis.axis_id
@@ -5452,7 +5492,7 @@ save_DIFFRN_SCAN_FRAME_MONITOR
     _definition.id              DIFFRN_SCAN_FRAME_MONITOR
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the DIFFRN_SCAN_FRAME_MONITOR category record
@@ -5479,11 +5519,13 @@ save_DIFFRN_SCAN_FRAME_MONITOR
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME_MONITOR
-    _category.key_list       ['_diffrn_scan_frame_monitor.id'
-                              '_diffrn_scan_frame_monitor.detector_id'
-                              '_diffrn_scan_frame_monitor.scan_id'
-                              '_diffrn_scan_frame_monitor.frame_id'
-                              '_diffrn_scan_frame_monitor.variant'] 
+    loop_
+    _category_key.name
+                                '_diffrn_scan_frame_monitor.id'
+                                '_diffrn_scan_frame_monitor.detector_id'
+                                '_diffrn_scan_frame_monitor.scan_id'
+                                '_diffrn_scan_frame_monitor.frame_id'
+                                '_diffrn_scan_frame_monitor.variant'
 save_
 
 save_diffrn_scan_frame_monitor.id
@@ -5645,7 +5687,7 @@ save_MAP
     _definition.id              MAP
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the MAP category record the details of a maps. 
@@ -5658,10 +5700,12 @@ save_MAP
 ;
     _name.category_id           MAP_GROUP
     _name.object_id             MAP
-    _category.key_list       ['_map.id'
-                              '_map.diffrn_id'
-                              '_map.entry_id'
-                              '_map.variant'] 
+    loop_
+    _category_key.name
+                                '_map.id'
+                                '_map.diffrn_id'
+                                '_map.entry_id'
+                                '_map.variant'
 save_
 
 save_map.details
@@ -5764,7 +5808,7 @@ save_MAP_SEGMENT
     _definition.id              MAP_SEGMENT
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the MAP_SEGMENT category record
@@ -5772,9 +5816,11 @@ save_MAP_SEGMENT
 ;
     _name.category_id           MAP_GROUP
     _name.object_id             MAP_SEGMENT
-    _category.key_list       ['_map_segment.id'
-                              '_map_segment.map_id'
-                              '_map_segment.variant'] 
+    loop_
+    _category_key.name
+                                '_map_segment.id'
+                                '_map_segment.map_id'
+                                '_map_segment.variant'
 save_
 
 save_map_segment.array_id
@@ -6001,7 +6047,7 @@ save_VARIANT
     _definition.id              VARIANT
     _definition.scope           Category
     _definition.class           Loop
-    _definition.update          2014-07-07
+    _definition.update          2019-04-01
     _description.text
 ;
     Data items in the VARIANT category record the details about 
@@ -6038,9 +6084,11 @@ save_VARIANT
 ;
     _name.category_id           VARIANT_GROUP
     _name.object_id             VARIANT
-    _category.key_list       ['_variant.variant'
-                              '_variant.diffrn_id'
-                              '_variant.entry_id'] 
+    loop_
+    _category_key.name
+                                '_variant.variant'
+                                '_variant.diffrn_id'
+                                '_variant.entry_id'
 save_
 
 save_variant.details

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -1,3 +1,4 @@
+#\#CIF_2.0
 ##############################################################################
 #                                                                            #
 #                       Image CIF Dictionary (imgCIF)                        #
@@ -48,6 +49,7 @@ save_IMAGE_DEFS
 ;
     _name.category_id           CIF_IMG
     _name.object_id             IMAGE_DEFS
+save_
 
 #===============================================================================
 
@@ -64,7 +66,7 @@ save_ARRAY_GROUP
 ;
     _name.category_id           IMAGE_DEFS
     _name.object_id             ARRAY_GROUP
-
+save_
 
 #-------------------------------------------------------------------------------
 
@@ -92,10 +94,10 @@ save_ARRAY_DATA
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_DATA
-    _category.key_list       ['_array_data.array_id',  
-                              '_array_data.binary_id',  
+    _category.key_list       ['_array_data.array_id'
+                              '_array_data.binary_id'
                               '_array_data.variant'] 
-
+save_
 
 save_array_data.array_id
     _definition.id             '_array_data.array_id'
@@ -441,8 +443,6 @@ save_array_data.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_DATA category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_ELEMENT_SIZE
@@ -457,10 +457,10 @@ save_ARRAY_ELEMENT_SIZE
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_ELEMENT_SIZE
-    _category.key_list       ['_array_element_size.array_id',
-                              '_array_element_size.index', 
+    _category.key_list       ['_array_element_size.array_id'
+                              '_array_element_size.index'
                               '_array_element_size.variant']  
-
+save_
 
 save_array_element_size.array_id
     _definition.id             '_array_element_size.array_id'
@@ -537,8 +537,6 @@ save_array_element_size.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_ELEMENT_SIZE category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_INTENSITIES
@@ -565,10 +563,10 @@ save_ARRAY_INTENSITIES
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_INTENSITIES
-    _category.key_list       ['_array_intensities.array_id', 
-                              '_array_intensities.binary_id', 
+    _category.key_list       ['_array_intensities.array_id'
+                              '_array_intensities.binary_id'
                               '_array_intensities.variant'] 
-
+save_
 
 save_array_intensities.array_id
     _definition.id             '_array_intensities.array_id'
@@ -908,8 +906,6 @@ save_array_intensities.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_INTENSITIES  category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_STRUCTURE
@@ -924,9 +920,9 @@ save_ARRAY_STRUCTURE
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE
-    _category.key_list       ['_array_structure.id', 
+    _category.key_list       ['_array_structure.id'
                               '_array_structure.variant'] 
-
+save_
 
 save_array_structure.byte_order
     _definition.id             '_array_structure.byte_order'
@@ -1118,8 +1114,6 @@ save_array_structure.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_STRUCTURE  category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_STRUCTURE_LIST
@@ -1135,10 +1129,10 @@ save_ARRAY_STRUCTURE_LIST
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST
-    _category.key_list       ['_array_structure_list.array_id', 
-                              '_array_structure_list.index', 
+    _category.key_list       ['_array_structure_list.array_id'
+                              '_array_structure_list.index'
                               '_array_structure_list.variant']  
-
+save_
 
 save_array_structure_list.array_id
     _definition.id             '_array_structure_list.array_id'
@@ -1301,8 +1295,6 @@ save_array_structure_list.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_STRUCTURE_LIST  category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_STRUCTURE_LIST_SECTION
@@ -1338,11 +1330,11 @@ save_ARRAY_STRUCTURE_LIST_SECTION
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST_SECTION
-    _category.key_list       ['_array_structure_list_section.id', 
-                              '_array_structure_list_section.array_id', 
-                              '_array_structure_list_section.index', 
+    _category.key_list       ['_array_structure_list_section.id'
+                              '_array_structure_list_section.array_id'
+                              '_array_structure_list_section.index'
                               '_array_structure_list_section.variant'] 
-
+save_
 
 save_array_structure_list_section.array_id
     _definition.id             '_array_structure_list_section.array_id'
@@ -1504,8 +1496,6 @@ save_array_structure_list_section.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_STRUCTURE_LIST_SECTION  category
-
 #-------------------------------------------------------------------------------
 
 save_ARRAY_STRUCTURE_LIST_AXIS
@@ -1531,10 +1521,10 @@ save_ARRAY_STRUCTURE_LIST_AXIS
 ;
     _name.category_id           ARRAY_GROUP
     _name.object_id             ARRAY_STRUCTURE_LIST_AXIS
-    _category.key_list       ['_array_structure_list_axis.axis_set_id', 
-                              '_array_structure_list_axis.axis_id', 
+    _category.key_list       ['_array_structure_list_axis.axis_set_id'
+                              '_array_structure_list_axis.axis_id'
                               '_array_structure_list_axis.variant'] 
-
+save_
 
 save_array_structure_list_axis.axis_id
     _definition.id             '_array_structure_list_axis.axis_id'
@@ -1822,10 +1812,6 @@ save_array_structure_list_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of ARRAY_STRUCTURE_LIST_AXIS  category
-
-     save_   #------ close of ARRAY_GROUP  category
-
 #===============================================================================
 
 
@@ -1841,6 +1827,7 @@ save_AXIS_GROUP
 ;
     _name.category_id           IMAGE_DEFS
     _name.object_id             AXIS_GROUP
+save_
 
 #-------------------------------------------------------------------------------
 
@@ -2112,10 +2099,10 @@ save_AXIS
 ;
     _name.category_id           AXIS_GROUP
     _name.object_id             AXIS
-    _category.key_list       ['_axis.id', 
-                              '_axis.equipment', 
+    _category.key_list       ['_axis.id'
+                              '_axis.equipment'
                               '_axis.variant'] 
-
+save_
 
 save_axis.depends_on
     _definition.id             '_axis.depends_on'
@@ -2500,11 +2487,6 @@ save_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of AXIS category
-
-     save_   #------ close of AXIS_GROUP  category
-
-
 #===============================================================================
 
 
@@ -2520,7 +2502,7 @@ save_DIFFRN_GROUP
 ;
     _name.category_id           IMAGE_DEFS
     _name.object_id             DIFFRN_GROUP
-
+save_
 
 #-------------------------------------------------------------------------------
 
@@ -2540,10 +2522,10 @@ save_DIFFRN_DATA_FRAME
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DATA_FRAME
-    _category.key_list       ['_diffrn_data_frame.id', 
-                              '_diffrn_data_frame.detector_element_id', 
+    _category.key_list       ['_diffrn_data_frame.id'
+                              '_diffrn_data_frame.detector_element_id'
                               '_diffrn_data_frame.variant']  
-
+save_
 
 save_diffrn_data_frame.array_id
     _definition.id             '_diffrn_data_frame.array_id'
@@ -2808,8 +2790,6 @@ save_diffrn_data_frame.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_DATA_FRAME category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_DETECTOR
@@ -2825,20 +2805,20 @@ save_DIFFRN_DETECTOR
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR
-    _category.key_list       ['_diffrn_detector.diffrn_id',  
-                              '_diffrn_detector.id', 
+    _category.key_list       ['_diffrn_detector.diffrn_id'
+                              '_diffrn_detector.id'
                               '_diffrn_detector.variant'] 
-
+save_
 
 save_diffrn_detector.details
     _definition.id             '_diffrn_detector.details'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_detector.details'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.details'}]
      save_
 
 
 save_diffrn_detector.detector
     _definition.id             '_diffrn_detector.detector'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_detector.description'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.description'}]
      save_
 
 
@@ -2863,7 +2843,7 @@ save_diffrn_detector.diffrn_id
 
 save_diffrn_detector.dtime
     _definition.id             '_diffrn_detector.dtime'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_detector.dtime'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.dtime'}]
      save_
 
 
@@ -2956,7 +2936,7 @@ save_diffrn_detector.number_of_axes
 
 save_diffrn_detector.type
     _definition.id             '_diffrn_detector.type'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_detector.make'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_detector.make'}]
      save_
 
 
@@ -2980,8 +2960,6 @@ save_diffrn_detector.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_DETECTOR category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_DETECTOR_AXIS
@@ -2996,10 +2974,10 @@ save_DIFFRN_DETECTOR_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR_AXIS
-    _category.key_list       ['_diffrn_detector_axis.detector_id', 
-                              '_diffrn_detector_axis.axis_id', 
+    _category.key_list       ['_diffrn_detector_axis.detector_id'
+                              '_diffrn_detector_axis.axis_id'
                               '_diffrn_detector_axis.variant'] 
-
+save_
 
 save_diffrn_detector_axis.axis_id
     _definition.id             '_diffrn_detector_axis.axis_id'
@@ -3061,8 +3039,6 @@ save_diffrn_detector_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_DETECTOR_AXIS category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_DETECTOR_ELEMENT
@@ -3082,10 +3058,10 @@ save_DIFFRN_DETECTOR_ELEMENT
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_DETECTOR_ELEMENT
-    _category.key_list       ['_diffrn_detector_element.id', 
-                              '_diffrn_detector_element.detector_id', 
+    _category.key_list       ['_diffrn_detector_element.id'
+                              '_diffrn_detector_element.detector_id'
                               '_diffrn_detector_element.variant'] 
-
+save_
 
 save_diffrn_detector_element.id
     _definition.id             '_diffrn_detector_element.id'
@@ -3236,8 +3212,6 @@ save_diffrn_detector_element.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_DETECTOR_ELEMENT category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_MEASUREMENT
@@ -3254,27 +3228,27 @@ save_DIFFRN_MEASUREMENT
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_MEASUREMENT
-    _category.key_list       ['_diffrn_measurement.device', 
-                              '_diffrn_measurement.diffrn_id', 
-                              '_diffrn_measurement.id', 
+    _category.key_list       ['_diffrn_measurement.device'
+                              '_diffrn_measurement.diffrn_id'
+                              '_diffrn_measurement.id'
                               '_diffrn_measurement.variant'] 
-
+save_
 
 save_diffrn_measurement.device
     _definition.id             '_diffrn_measurement.device'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.device_class'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_class'}]
      save_
 
 
 save_diffrn_measurement.device_details
     _definition.id             '_diffrn_measurement.device_details'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.device_details'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_details'}]
      save_
 
 
 save_diffrn_measurement.device_type
     _definition.id             '_diffrn_measurement.device_type'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.device_make'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.device_make'}]
      save_
 
 
@@ -3297,7 +3271,7 @@ save_diffrn_measurement.diffrn_id
 
 save_diffrn_measurement.details
     _definition.id             '_diffrn_measurement.details'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.details'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.details'}]
      save_
 
 
@@ -3329,7 +3303,7 @@ save_diffrn_measurement.id
 
 save_diffrn_measurement.method
     _definition.id             '_diffrn_measurement.method'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.method'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.method'}]
      save_
 
 
@@ -3394,7 +3368,7 @@ save_diffrn_measurement.sample_detector_voffset
 
 save_diffrn_measurement.specimen_support
     _definition.id             '_diffrn_measurement.specimen_support'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_measurement.specimen_support'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_measurement.specimen_support'}]
      save_
 
 
@@ -3418,8 +3392,6 @@ save_diffrn_measurement.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_MEASUREMENT category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_MEASUREMENT_AXIS
@@ -3434,11 +3406,11 @@ save_DIFFRN_MEASUREMENT_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_MEASUREMENT_AXIS
-    _category.key_list  ['_diffrn_measurement_axis.measurement_device', 
-                         '_diffrn_measurement_axis.measurement_id', 
-                         '_diffrn_measurement_axis.axis_id', 
-                         '_diffrn_measurement_axis.variant']  
-
+    _category.key_list  ['_diffrn_measurement_axis.measurement_device'
+                         '_diffrn_measurement_axis.measurement_id'
+                         '_diffrn_measurement_axis.axis_id'
+                         '_diffrn_measurement_axis.variant']
+save_
 
 save_diffrn_measurement_axis.axis_id
     _definition.id             '_diffrn_measurement_axis.axis_id'
@@ -3518,8 +3490,6 @@ save_diffrn_measurement_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_MEASUREMENT_AXIS category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_RADIATION
@@ -3538,13 +3508,13 @@ save_DIFFRN_RADIATION
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_RADIATION
-    _category.key_list       ['_diffrn_radiation.diffrn_id', 
+    _category.key_list       ['_diffrn_radiation.diffrn_id'
                               '_diffrn_radiation.variant'] 
-
+save_
 
 save_diffrn_radiation.collimation
     _definition.id             '_diffrn_radiation.collimation'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.collimation'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.collimation'}]
      save_
 
 
@@ -3656,25 +3626,25 @@ save_diffrn_radiation.div_x_y_source
 
 save_diffrn_radiation.filter_edge
     _definition.id             '_diffrn_radiation.filter_edge'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.filter_edge'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.filter_edge'}]
      save_
 
 
 save_diffrn_radiation.inhomogeneity
     _definition.id             '_diffrn_radiation.inhomogeneity'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.inhomogeneity'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.inhomogeneity'}]
      save_
 
 
 save_diffrn_radiation.monochromator
     _definition.id             '_diffrn_radiation.monochromator'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.monochromator'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.monochromator'}]
      save_
 
 
 save_diffrn_radiation.polarisn_norm
     _definition.id             '_diffrn_radiation.polarisn_norm'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.polarisn_norm'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.polarisn_norm'}]
      save_
 
 
@@ -3703,7 +3673,7 @@ save_diffrn_radiation.polarisn_norm_esd
 
 save_diffrn_radiation.polarisn_ratio
     _definition.id             '_diffrn_radiation.polarisn_ratio'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.polarisn_ratio'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.polarisn_ratio'}]
      save_
 
 
@@ -4100,25 +4070,25 @@ save_diffrn_radiation.polarizn_Stokes_V_esd
 
 save_diffrn_radiation.probe
     _definition.id             '_diffrn_radiation.probe'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.probe'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.probe'}]
      save_
 
 
 save_diffrn_radiation.type
     _definition.id             '_diffrn_radiation.type'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.type'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.type'}]
      save_
 
 
 save_diffrn_radiation.xray_symbol
     _definition.id             '_diffrn_radiation.xray_symbol'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation.xray_symbol'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation.xray_symbol'}]
      save_
 
 
 save_diffrn_radiation.wavelength_id
     _definition.id             '_diffrn_radiation.wavelength_id'
-    _import.get  [{"file":'core_dic',"save":'_diffrn_radiation_wavelength.id'}]
+    _import.get  [{"file":'core_dic' "save":'_diffrn_radiation_wavelength.id'}]
      save_
 
 
@@ -4141,8 +4111,6 @@ save_diffrn_radiation.variant
     _type.container             Single
     _type.contents              Code
      save_
-
-     save_   #------ close of DIFFRN_RADIATION category
 
 #-------------------------------------------------------------------------------
 
@@ -4167,11 +4135,11 @@ save_DIFFRN_REFLN
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_REFLN
-    _category.key_list       ['_diffrn_refln.diffrn_id', 
-                              '_diffrn_refln.id', 
-                              '_diffrn_refln.frame_id',  
+    _category.key_list       ['_diffrn_refln.diffrn_id'
+                              '_diffrn_refln.id'
+                              '_diffrn_refln.frame_id'
                               '_diffrn_refln.variant']  
-
+save_
 
 save_diffrn_refln.frame_id
     _definition.id             '_diffrn_refln.frame_id'
@@ -4247,8 +4215,6 @@ save_diffrn_refln.diffrn_id
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_REFLN category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_SCAN
@@ -4263,9 +4229,9 @@ save_DIFFRN_SCAN
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN
-    _category.key_list       ['_diffrn_scan.id', 
+    _category.key_list       ['_diffrn_scan.id'
                               '_diffrn_scan.variant'] 
-
+save_
 
 save_diffrn_scan.id
     _definition.id             '_diffrn_scan.id'
@@ -4466,8 +4432,6 @@ save_diffrn_scan.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_SCAN category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_SCAN_AXIS
@@ -4483,10 +4447,10 @@ for particular scans.  Unspecified axes are assumed to be at
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_AXIS
-    _category.key_list       ['_diffrn_scan_axis.scan_id', 
-                              '_diffrn_scan_axis.axis_id', 
+    _category.key_list       ['_diffrn_scan_axis.scan_id'
+                              '_diffrn_scan_axis.axis_id'
                               '_diffrn_scan_axis.variant'] 
-
+save_
 
 save_diffrn_scan_axis.scan_id
     _definition.id             '_diffrn_scan_axis.scan_id'
@@ -4790,8 +4754,6 @@ save_diffrn_scan_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_SCAN_AXIS category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_SCAN_FRAME
@@ -4806,10 +4768,10 @@ save_DIFFRN_SCAN_FRAME
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME
-    _category.key_list       ['_diffrn_scan_frame.scan_id', 
-                              '_diffrn_scan_frame.frame_id', 
+    _category.key_list       ['_diffrn_scan_frame.scan_id'
+                              '_diffrn_scan_frame.frame_id'
                               '_diffrn_scan_frame.variant'] 
-
+save_
 
 save_diffrn_scan_frame.date
     _definition.id             '_diffrn_scan_frame.date'
@@ -5217,8 +5179,6 @@ save_diffrn_scan_frame.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_SCAN_FRAME category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_SCAN_FRAME_AXIS
@@ -5237,10 +5197,10 @@ save_DIFFRN_SCAN_FRAME_AXIS
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME_AXIS
-    _category.key_list       ['_diffrn_scan_frame_axis.frame_id', 
-                              '_diffrn_scan_frame_axis.axis_id', 
-                              '_diffrn_scan_frame_axis.variant'] 
-
+    _category.key_list       ['_diffrn_scan_frame_axis.frame_id'
+                              '_diffrn_scan_frame_axis.axis_id'
+                              '_diffrn_scan_frame_axis.variant']
+save_
 
 save_diffrn_scan_frame_axis.axis_id
     _definition.id             '_diffrn_scan_frame_axis.axis_id'
@@ -5486,8 +5446,6 @@ save_diffrn_scan_frame_axis.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_SCAN_FRAME_AXIS category
-
 #-------------------------------------------------------------------------------
 
 save_DIFFRN_SCAN_FRAME_MONITOR
@@ -5521,12 +5479,12 @@ save_DIFFRN_SCAN_FRAME_MONITOR
 ;
     _name.category_id           DIFFRN_GROUP
     _name.object_id             DIFFRN_SCAN_FRAME_MONITOR
-    _category.key_list       ['_diffrn_scan_frame_monitor.id', 
-                              '_diffrn_scan_frame_monitor.detector_id', 
-                              '_diffrn_scan_frame_monitor.scan_id', 
-                              '_diffrn_scan_frame_monitor.frame_id', 
+    _category.key_list       ['_diffrn_scan_frame_monitor.id'
+                              '_diffrn_scan_frame_monitor.detector_id'
+                              '_diffrn_scan_frame_monitor.scan_id'
+                              '_diffrn_scan_frame_monitor.frame_id'
                               '_diffrn_scan_frame_monitor.variant'] 
-
+save_
 
 save_diffrn_scan_frame_monitor.id
     _definition.id             '_diffrn_scan_frame_monitor.id'
@@ -5664,11 +5622,6 @@ save_diffrn_scan_frame_monitor.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of DIFFRN_FRAME_MONITOR category
-
-     save_   #------ close of DIFFRN_GROUP category
-
-
 #===============================================================================
 
 
@@ -5684,7 +5637,7 @@ save_MAP_GROUP
 ;
     _name.category_id           IMAGE_DEFS
     _name.object_id             MAP_GROUP
-
+save_
 
 #-------------------------------------------------------------------------------
 
@@ -5705,11 +5658,11 @@ save_MAP
 ;
     _name.category_id           MAP_GROUP
     _name.object_id             MAP
-    _category.key_list       ['_map.id', 
-                              '_map.diffrn_id', 
-                              '_map.entry_id', 
+    _category.key_list       ['_map.id'
+                              '_map.diffrn_id'
+                              '_map.entry_id'
                               '_map.variant'] 
-
+save_
 
 save_map.details
     _definition.id             '_map.details'
@@ -5805,8 +5758,6 @@ save_map.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of MAP category
-
 #-------------------------------------------------------------------------------
 
 save_MAP_SEGMENT
@@ -5821,10 +5772,10 @@ save_MAP_SEGMENT
 ;
     _name.category_id           MAP_GROUP
     _name.object_id             MAP_SEGMENT
-    _category.key_list       ['_map_segment.id', 
-                              '_map_segment.map_id', 
+    _category.key_list       ['_map_segment.id'
+                              '_map_segment.map_id'
                               '_map_segment.variant'] 
-
+save_
 
 save_map_segment.array_id
     _definition.id             '_map_segment.array_id'
@@ -6027,11 +5978,6 @@ save_map_segment.variant
     _type.contents              Code
      save_
 
-     save_   #------ close of MAP_SEGMENT category
-
-     save_   #------ close of MAP_GROUP category
-
-
 #===============================================================================
 
 
@@ -6047,7 +5993,7 @@ save_VARIANT_GROUP
 ;
     _name.category_id           IMAGE_DEFS
     _name.object_id             VARIANT_GROUP
-
+save_
 
 #-------------------------------------------------------------------------------
 
@@ -6092,10 +6038,10 @@ save_VARIANT
 ;
     _name.category_id           VARIANT_GROUP
     _name.object_id             VARIANT
-    _category.key_list       ['_variant.variant', 
-                              '_variant.diffrn_id', 
+    _category.key_list       ['_variant.variant'
+                              '_variant.diffrn_id'
                               '_variant.entry_id'] 
-
+save_
 
 save_variant.details
     _definition.id             '_variant.details'
@@ -6250,12 +6196,6 @@ save_variant.variant_of
     _type.contents              Code
      save_
 
-     save_   #------ close of VARIANT category
-
-     save_   #------ close of VARIANT_GROUP  category
-
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-     save_   #------ close of IMAGE_DEFS  category
 
 # ----- eof  ----- eof  ----- eof  ----- eof  ----- eof  ----- eof 

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -2956,7 +2956,7 @@ save_diffrn_detector.number_of_axes
 
 save_diffrn_detector.type
     _definition.id             '_diffrn_detector.type'
-     _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.make'}]
+    _import.get  [{"file":'cif_core.dic' "save":'diffrn_detector.make'}]
      save_
 
 

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -55,7 +55,9 @@ save_ATOM_SITE
 ;
     _name.category_id            RHO_GROUP
     _name.object_id              ATOM_SITE
-    _category.key_list        ['_atom_site.label']
+    loop_
+    _category_key.name
+                                '_atom_site.label'
 save_
 
 save_atom_site.label
@@ -137,7 +139,10 @@ save_ATOM_LOCAL_AXES
 ;
     _name.category_id           RHO_GROUP
     _name.object_id             ATOM_LOCAL_AXES
-    _category.key_list       ['_atom_local_axes.atom_label']
+    loop_
+    _category_key.name
+                                '_atom_local_axes.atom_label'
+
 save_
 
 
@@ -340,7 +345,10 @@ save_ATOM_RHO_MULTIPOLE
 ;
     _name.category_id           RHO_GROUP
     _name.object_id             ATOM_RHO_MULTIPOLE
-    _category.key_list       ['_atom_rho_multipole.atom_label']
+    loop_
+    _category_key.name
+                                '_atom_rho_multipole.atom_label'
+
 save_
  
 save_atom_rho_multipole.atom_label

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -60,37 +60,37 @@ save_
 
 save_atom_site.label
     _definition.id             '_atom_site.label'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.label'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.label'}]
      save_
 
 
 save_atom_site.fract_xyz
     _definition.id             '_atom_site.fract_xyz'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_xyz'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.fract_xyz'}]
      save_
 
 
 save_atom_site.fract_x
     _definition.id             '_atom_site.fract_x'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_x'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.fract_x'}]
      save_
 
 
 save_atom_site.fract_y
     _definition.id             '_atom_site.fract_y'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_y'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.fract_y'}]
      save_
 
 
 save_atom_site.fract_z
     _definition.id             '_atom_site.fract_z'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_z'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.fract_z'}]
      save_
 
 
 save_atom_site.occupancy
     _definition.id             '_atom_site.occupancy'
-    _import.get     [{"file":'core_dic' "save":'_atom_site.occupancy'}]
+    _import.get     [{"file":'cif_core.dic' "save":'atom_site.occupancy'}]
      save_
 
 #===========================================================================

--- a/cif_rho.dic
+++ b/cif_rho.dic
@@ -1,3 +1,4 @@
+#\#CIF_2.0
 ######################################################################
 #                                                                    #
 #         CIF Dictionary for the Multipole Model of                  #
@@ -37,7 +38,7 @@ save_RHO_GROUP
 ;
     _name.category_id           CIF_RHO
     _name.object_id             RHO_GROUP
-
+save_
 
 #===========================================================================
 
@@ -55,45 +56,42 @@ save_ATOM_SITE
     _name.category_id            RHO_GROUP
     _name.object_id              ATOM_SITE
     _category.key_list        ['_atom_site.label']
-
+save_
 
 save_atom_site.label
     _definition.id             '_atom_site.label'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.label'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.label'}]
      save_
 
 
 save_atom_site.fract_xyz
     _definition.id             '_atom_site.fract_xyz'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.fract_xyz'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_xyz'}]
      save_
 
 
 save_atom_site.fract_x
     _definition.id             '_atom_site.fract_x'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.fract_x'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_x'}]
      save_
 
 
 save_atom_site.fract_y
     _definition.id             '_atom_site.fract_y'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.fract_y'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_y'}]
      save_
 
 
 save_atom_site.fract_z
     _definition.id             '_atom_site.fract_z'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.fract_z'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.fract_z'}]
      save_
 
 
 save_atom_site.occupancy
     _definition.id             '_atom_site.occupancy'
-    _import.get     [{"file":'core_dic',"save":'_atom_site.occupancy'}]
+    _import.get     [{"file":'core_dic' "save":'_atom_site.occupancy'}]
      save_
-
-     save_     #------ close ATOM_SITE category
-
 
 #===========================================================================
 
@@ -140,6 +138,7 @@ save_ATOM_LOCAL_AXES
     _name.category_id           RHO_GROUP
     _name.object_id             ATOM_LOCAL_AXES
     _category.key_list       ['_atom_local_axes.atom_label']
+save_
 
 
 save_atom_local_axes.atom_label
@@ -298,9 +297,6 @@ save_atom_local_axes.ax2
      x  X  y  Y  z  Z  +x  +X  +y  +Y  +z  +Z  -x  -X  -y  -Y  -z  -Z 
      save_
 
-     save_     #------ close ATOM_LOCAL_AXES category
- 
-
 #===============================================================================
  
 save_ATOM_RHO_MULTIPOLE
@@ -345,7 +341,7 @@ save_ATOM_RHO_MULTIPOLE
     _name.category_id           RHO_GROUP
     _name.object_id             ATOM_RHO_MULTIPOLE
     _category.key_list       ['_atom_rho_multipole.atom_label']
- 
+save_
  
 save_atom_rho_multipole.atom_label
     _definition.id             '_atom_rho_multipole.atom_label'
@@ -673,7 +669,7 @@ save_ATOM_RHO_MULTIPOLE_COEFF
 ;
     _name.category_id           ATOM_RHO_MULTIPOLE
     _name.object_id             ATOM_RHO_MULTIPOLE_COEFF
-
+save_
  
 save_atom_rho_multipole_coeff.list
     _definition.id             '_atom_rho_multipole_coeff.list'
@@ -759,7 +755,7 @@ save_atom_rho_multipole_coeff.Pc
     _definition.id             '_atom_rho_multipole_coeff.Pc'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_Pc'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}] 
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}] 
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              Pc
      save_
@@ -769,7 +765,7 @@ save_atom_rho_multipole_coeff.Pv
     _definition.id             '_atom_rho_multipole_coeff.Pv'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_Pv'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              Pv
      save_
@@ -779,7 +775,7 @@ save_atom_rho_multipole_coeff.P00
     _definition.id             '_atom_rho_multipole_coeff.P00'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P00'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P00
      save_
@@ -789,7 +785,7 @@ save_atom_rho_multipole_coeff.P10
     _definition.id             '_atom_rho_multipole_coeff.P10'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P10'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P10
      save_
@@ -799,7 +795,7 @@ save_atom_rho_multipole_coeff.P11
     _definition.id             '_atom_rho_multipole_coeff.P11'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P11'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P11
      save_
@@ -810,7 +806,7 @@ save_atom_rho_multipole_coeff.P1_1
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P1_1'
                                '_atom_rho_multipole_coeff_P1-1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P1_1
      save_
@@ -820,7 +816,7 @@ save_atom_rho_multipole_coeff.P20
     _definition.id             '_atom_rho_multipole_coeff.P20'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P20'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P20
      save_
@@ -830,7 +826,7 @@ save_atom_rho_multipole_coeff.P21
     _definition.id             '_atom_rho_multipole_coeff.P21'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P21'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P21
      save_
@@ -841,7 +837,7 @@ save_atom_rho_multipole_coeff.P2_1
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P2_1'
                                '_atom_rho_multipole_coeff_P2-1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P2_1
      save_
@@ -851,7 +847,7 @@ save_atom_rho_multipole_coeff.P22
     _definition.id             '_atom_rho_multipole_coeff.P22'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P22'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P22
      save_
@@ -862,7 +858,7 @@ save_atom_rho_multipole_coeff.P2_2
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P2_2'
                                '_atom_rho_multipole_coeff_P2-2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P2_2
      save_
@@ -872,7 +868,7 @@ save_atom_rho_multipole_coeff.P30
     _definition.id             '_atom_rho_multipole_coeff.P30'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P30'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P30
      save_
@@ -882,7 +878,7 @@ save_atom_rho_multipole_coeff.P31
     _definition.id             '_atom_rho_multipole_coeff.P31'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P31'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P31
      save_
@@ -893,7 +889,7 @@ save_atom_rho_multipole_coeff.P3_1
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P3_1'
                                '_atom_rho_multipole_coeff_P3-1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P3_1
      save_
@@ -903,7 +899,7 @@ save_atom_rho_multipole_coeff.P32
     _definition.id             '_atom_rho_multipole_coeff.P32'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P32'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P32
      save_
@@ -914,7 +910,7 @@ save_atom_rho_multipole_coeff.P3_2
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P3_2'
                                '_atom_rho_multipole_coeff_P3-2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P3_2
      save_
@@ -924,7 +920,7 @@ save_atom_rho_multipole_coeff.P33
     _definition.id             '_atom_rho_multipole_coeff.P33'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P33'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P33
      save_
@@ -935,7 +931,7 @@ save_atom_rho_multipole_coeff.P3_3
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P3_3'
                                '_atom_rho_multipole_coeff_P3-3'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P3_3
      save_
@@ -945,7 +941,7 @@ save_atom_rho_multipole_coeff.P40
     _definition.id             '_atom_rho_multipole_coeff.P40'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P40'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P40
      save_
@@ -955,7 +951,7 @@ save_atom_rho_multipole_coeff.P41
     _definition.id             '_atom_rho_multipole_coeff.P41'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P41'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P41
      save_
@@ -966,7 +962,7 @@ save_atom_rho_multipole_coeff.P4_1
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P4_1'
                                '_atom_rho_multipole_coeff_P4-1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P4_1
      save_
@@ -976,7 +972,7 @@ save_atom_rho_multipole_coeff.P42
     _definition.id             '_atom_rho_multipole_coeff.P42'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P42'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P42
      save_
@@ -987,7 +983,7 @@ save_atom_rho_multipole_coeff.P4_2
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P4_2'
                                '_atom_rho_multipole_coeff_P4-2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P4_2
      save_
@@ -997,7 +993,7 @@ save_atom_rho_multipole_coeff.P43
     _definition.id             '_atom_rho_multipole_coeff.P43'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P43'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P43
      save_
@@ -1008,7 +1004,7 @@ save_atom_rho_multipole_coeff.P4_3
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P4_3'
                                '_atom_rho_multipole_coeff_P4-3'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P4_3
      save_
@@ -1018,7 +1014,7 @@ save_atom_rho_multipole_coeff.P44
     _definition.id             '_atom_rho_multipole_coeff.P44'
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P44'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P44
      save_
@@ -1029,12 +1025,10 @@ save_atom_rho_multipole_coeff.P4_4
      loop_
     _alias.definition_id       '_atom_rho_multipole_coeff_P4_4'
                                '_atom_rho_multipole_coeff_P4-4'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_coeff'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_coeff'}]
     _name.category_id            atom_rho_multipole_coeff
     _name.object_id              P4_4
      save_
-
-     save_     #------ close ATOM_RHO_MULTIPOLE_COEFF category
  
 #--------------------------------------------------------------------------
 
@@ -1049,6 +1043,7 @@ save_ATOM_RHO_MULTIPOLE_KAPPA
 ;
     _name.category_id           ATOM_RHO_MULTIPOLE
     _name.object_id             ATOM_RHO_MULTIPOLE_KAPPA
+save_
 
  
 save_atom_rho_multipole_kappa.list
@@ -1131,7 +1126,7 @@ save_atom_rho_multipole_kappa.base
     _definition.id             '_atom_rho_multipole_kappa.base'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              base
      save_
@@ -1141,7 +1136,7 @@ save_atom_rho_multipole_kappa.prime0
     _definition.id             '_atom_rho_multipole_kappa.prime0'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_prime0'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              prime0
      save_
@@ -1151,7 +1146,7 @@ save_atom_rho_multipole_kappa.prime1
     _definition.id             '_atom_rho_multipole_kappa.prime1'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_prime1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              prime1
      save_
@@ -1161,7 +1156,7 @@ save_atom_rho_multipole_kappa.prime2
     _definition.id             '_atom_rho_multipole_kappa.prime2'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_prime2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              prime2
      save_
@@ -1171,7 +1166,7 @@ save_atom_rho_multipole_kappa.prime3
     _definition.id             '_atom_rho_multipole_kappa.prime3'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_prime3'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              prime3
      save_
@@ -1181,12 +1176,10 @@ save_atom_rho_multipole_kappa.prime4
     _definition.id             '_atom_rho_multipole_kappa.prime4'
      loop_
     _alias.definition_id       '_atom_rho_multipole_kappa_prime4'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_kappa'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_kappa'}]
     _name.category_id            atom_rho_multipole_kappa
     _name.object_id              prime4
      save_
-
-     save_     #------ close ATOM_RHO_MULTIPOLE_KAPPA category
 
 #--------------------------------------------------------------------------
 
@@ -1201,7 +1194,7 @@ save_ATOM_RHO_MULTIPOLE_RADIAL_SLATER
 ;
     _name.category_id           ATOM_RHO_MULTIPOLE
     _name.object_id             ATOM_RHO_MULTIPOLE_RADIAL_SLATER
-
+save_
  
 save_atom_rho_multipole_radial_slater.list
     _definition.id             '_atom_rho_multipole_radial_slater.list'
@@ -1296,7 +1289,7 @@ save_atom_rho_multipole_radial_slater.n0
     _definition.id             '_atom_rho_multipole_radial_slater.n0'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_n0'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              n0
      save_
@@ -1306,7 +1299,7 @@ save_atom_rho_multipole_radial_slater.n1
     _definition.id             '_atom_rho_multipole_radial_slater.n1'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_n1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              n1
      save_
@@ -1316,7 +1309,7 @@ save_atom_rho_multipole_radial_slater.n2
     _definition.id             '_atom_rho_multipole_radial_slater.n2'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_n2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              n2
      save_
@@ -1326,7 +1319,7 @@ save_atom_rho_multipole_radial_slater.n3
     _definition.id             '_atom_rho_multipole_radial_slater.n3'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_n3'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              n3
      save_
@@ -1336,7 +1329,7 @@ save_atom_rho_multipole_radial_slater.zeta0
     _definition.id             '_atom_rho_multipole_radial_slater.zeta0'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_zeta0'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              zeta0
      save_
@@ -1346,7 +1339,7 @@ save_atom_rho_multipole_radial_slater.zeta1
     _definition.id             '_atom_rho_multipole_radial_slater.zeta1'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_zeta1'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              zeta1
      save_
@@ -1356,7 +1349,7 @@ save_atom_rho_multipole_radial_slater.zeta2
     _definition.id             '_atom_rho_multipole_radial_slater.zeta2'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_zeta2'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              zeta2
      save_
@@ -1366,18 +1359,12 @@ save_atom_rho_multipole_radial_slater.zeta3
     _definition.id             '_atom_rho_multipole_radial_slater.zeta3'
      loop_
     _alias.definition_id       '_atom_rho_multipole_radial_slater_zeta3'
-    _import.get    [{"file":'templ_attr.cif',"save":'rho_slater'}]
+    _import.get    [{"file":'templ_attr.cif' "save":'rho_slater'}]
     _name.category_id            atom_rho_multipole_radial_slater
     _name.object_id              zeta3
      save_
 
-     save_     #------ close ATOM_RHO_MULTIPOLE_RADIAL_SLATER category
-
 #---------------------------------------------------------------------------
-
-     save_     #------ close ATOM_RHO_MULTIPOLE category
-
-     save_     #------ close RHO_GROUP category
 
 #---- eof---- eof---- eof---- eof---- eof---- eof---- eof---- eof---- eof-
 


### PR DESCRIPTION
The cif_rho.dic and cif_img.dic were updated to adhere to the CIF2 format syntax.
Minor data modifications in regards to the recent changes in DDLm were also applied.