### PR TITLE
Correcting SU-related issues

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.10
-_dictionary.date                        2019-03-26
+_dictionary.date                        2019-04-01
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
 _dictionary.ddl_conformance             3.11.11
 _dictionary.namespace                   CifCore
@@ -8753,32 +8753,6 @@ _enumeration.range                      0.0:
 _units.code                             angstroms
 
 save_
-
-
-save_chemical_conn_bond.distance_su
-
-_definition.id                          '_chemical_conn_bond.distance_su'
-loop_
-  _alias.definition_id
-         '_chem_comp_bond.value_dist_esd' 
-_definition.update                      2014-06-12
-_description.text                       
-;
-     The value that should be taken as the target for the chemical
-     bond associated with the specified atoms, expressed as a
-     distance.
-;
-_name.category_id                       chemical_conn_bond
-_name.linked_item_id                    '_chemical_conn_bond.distance'
-_name.object_id                         distance_su
-_type.purpose                           SU
-_type.source                            Derived
-_type.container                         Single
-_type.contents                          Real
-_units.code                             angstroms
-
-save_
-
  
 save_chemical_conn_bond.id
     _definition.id             '_chemical_conn_bond.id'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1632,12 +1632,37 @@ _description.text
 ;
 _name.category_id                       diffrn_radiation_wavelength
 _name.object_id                         value
-_type.purpose                           Number
+_type.purpose                           Measurand
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Real
 _enumeration.range                      0.0:
 _units.code                             angstroms
+
+save_
+
+
+save_diffrn_radiation_wavelength.value_su
+
+_definition.id                          '_diffrn_radiation_wavelength.value_su'
+loop_
+  _alias.definition_id
+         '_diffrn_radiation_wavelength_su'
+         '_diffrn_radiation_wavelength.wavelength_su'
+_definition.update                      2019-04-01
+_description.text
+;
+     Standard uncertainty of the wavelength of radiation used in diffraction
+     measurements.
+;
+_name.category_id                       diffrn_radiation_wavelength
+_name.object_id                         value_su
+_name.linked_item_id                    '_diffrn_radiation_wavelength.value'
+_type.purpose                           SU
+_type.source                            Related
+_type.container                         Single
+_type.contents                          Real
+_units.code                             none
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -9,8 +9,8 @@ data_CORE_DIC
 
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
-_dictionary.version                     3.0.10
-_dictionary.date                        2019-04-01
+_dictionary.version                     3.0.11
+_dictionary.date                        2019-04-02
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
 _dictionary.ddl_conformance             3.11.11
 _dictionary.namespace                   CifCore
@@ -1649,7 +1649,7 @@ loop_
   _alias.definition_id
          '_diffrn_radiation_wavelength_su'
          '_diffrn_radiation_wavelength.wavelength_su'
-_definition.update                      2019-04-01
+_definition.update                      2019-04-02
 _description.text
 ;
      Standard uncertainty of the wavelength of radiation used in diffraction
@@ -24141,4 +24141,11 @@ loop_
          3.0.10    2019-01-08
 ;
      Added DATABASE_RELATED category (James Hester).
+;
+         3.0.11    2019-04-02
+;
+    Removed the _chemical_conn_bond.distance_su data item.
+    Changed the purpose of the diffrn_radiation_wavelength.value data item
+    from 'Number' to 'Measurand'. Added the diffrn_radiation_wavelength.value_su
+    data item.
 ;


### PR DESCRIPTION
This PR corrects SU-related issues discussed in #82 

The solution includes:

- removing the '_chemical_conn_bond.distance_su' data item;
- changing the purpose of the '_diffrn_radiation_wavelength.value' data item from 'Number' to 'Measurand';
- adding the '_diffrn_radiation_wavelength.value_su' data item.

Please review if the definition of the '_diffrn_radiation_wavelength.value_su' data item seems sufficient.