### PR TITLE
Added the DEFINITION_REPLACED category

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19479,7 +19479,13 @@ _definition.id                          '_atom_site.refinement_flags'
 loop_
   _alias.definition_id
          '_atom_site_refinement_flags' 
-_definition.update                      2013-03-08
+_definition.update                      2019-04-02
+loop_
+  _definition_replaced.id
+  _definition_replaced.by
+         1 '_atom_site.refinement_flags_posn'
+         2 '_atom_site.refinement_flags_adp'
+         3 '_atom_site.refinement_flags_occupancy'
 _description.text                       
 ;
      A concatenated series of single-letter codes which indicate the
@@ -24151,6 +24157,11 @@ loop_
 ;
          3.0.11    2019-04-02
 ;
-     Replaced all instances of the _definition.replaced_by with data items
-     from the DEFINITION_REPLACED category.
+     Replaced all instances of the _definition.replaced_by data item with
+     data items from the DEFINITION_REPLACED category.
+
+     Marked the _atom_site.refinement_flags data item as deprecated and
+     replaced by the _atom_site.refinement_flags_posn,
+     _atom_site.refinement_flags_adp and _atom_site.refinement_flags_occupancy
+     data items.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -9,10 +9,10 @@ data_CORE_DIC
 
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
-_dictionary.version                     3.0.10
-_dictionary.date                        2019-03-26
+_dictionary.version                     3.0.11
+_dictionary.date                        2019-04-02
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
-_dictionary.ddl_conformance             3.11.11
+_dictionary.ddl_conformance             3.14.0
 _dictionary.namespace                   CifCore
 _description.text                       
 ;
@@ -3292,8 +3292,11 @@ loop_
          '_diffrn_source'    
          '_diffrn_radiation_source'    
          '_diffrn_source.source' 
-_definition.update                      2018-02-26
-_definition.replaced_by                 '_diffrn_source.device'
+_definition.update                      2019-04-02
+loop_
+  _definition_replaced.id
+  _definition_replaced.by
+         1 '_diffrn_source.device'
 _description.text                       
 ;
      The general class of the source of radiation. This is deprecated.
@@ -11250,8 +11253,11 @@ save_symmetry.cell_setting
     _definition.id               '_symmetry.cell_setting'
     loop_
     _alias.definition_id         '_symmetry_cell_setting'
-    _definition.update           2017-06-10
-    _definition.replaced_by      '_space_group.crystal_system'
+    _definition.update           2019-04-02
+    loop_
+    _definition_replaced.id
+    _definition_replaced.by
+                                 1 '_space_group.crystal_system'
     _description.text
 ;              
      This dataname should not be used and is DEPRECATED as it is
@@ -24142,4 +24148,9 @@ loop_
          3.0.10    2019-01-08
 ;
      Added DATABASE_RELATED category (James Hester).
+;
+         3.0.11    2019-04-02
+;
+     Replaced all instances of the _definition.replaced_by with data items
+     from the DEFINITION_REPLACED category.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -8,11 +8,11 @@ data_DDL_DIC
 
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
-    _dictionary.version          3.13.1
-    _dictionary.date             2017-10-26
+    _dictionary.version          3.14.0
+    _dictionary.date             2019-04-02
     _dictionary.uri              
              https://github.com/COMCIFS/cif_core/blob/cif2-conversion/ddl.dic
-    _dictionary.ddl_conformance  3.13.1
+    _dictionary.ddl_conformance  3.14.0
     _dictionary.namespace        DdlDic
     _description.text
 ;
@@ -298,26 +298,6 @@ save_definition.id
 
 save_
 
-save_definition.replaced_by
-
-    _definition.id               '_definition.replaced_by'
-    _definition.class            Attribute
-    _definition.update           2017-06-10
-    _description.text
-;
-     A dataname that should be used instead of the defined dataname.
-     The defined dataname is deprecated and should not be used.
-;
-    _name.category_id            definition
-    _name.object_id              replaced_by
-    _type.container              Single
-    _type.purpose                Encode
-    _type.contents               Tag
-    _type.source                 Assigned
-
-save_
-
-
 save_definition.scope
 
     _definition.id               '_definition.scope'
@@ -379,6 +359,61 @@ save_definition.xref_code
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Code
+
+save_
+
+#============================================================================
+
+save_DEFINITION_REPLACED
+
+    _definition.id               DEFINITION_REPLACED
+    _definition.scope            Category
+    _definition.class            Loop
+    _definition.update           2019-04-02
+    _description.text
+;
+     Attributes used to describe deprecated and replaced definitions.
+;
+    _name.category_id            DEFINITION
+    _name.object_id              DEFINITION_REPLACED
+    _category_key.name           '_definition_replaced.id'
+
+save_
+
+save_definition_replaced.id
+
+    _definition.id               '_definition_replaced.id'
+    _definition.class            Attribute
+    _definition.update           2019-04-02
+    _description.text
+;
+     An opaque identifier for the replacement.
+;
+    _name.category_id            definition_replaced
+    _name.object_id              id
+    _type.purpose                Key
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Code
+
+save_
+
+save_definition_replaced.by
+
+    _definition.id               '_definition_replaced.by'
+    _definition.class            Attribute
+    _definition.update           2019-04-02
+    _description.text
+;
+     Name of the data item that should be used instead of the defined data
+     item. The defined data item is deprecated and should not be used.
+;
+    _name.category_id            definition_replaced
+    _name.object_id              by
+    _type.container              Single
+    _type.purpose                Encode
+    _type.contents               Tag
+    _type.source                 Assigned
 
 save_
 
@@ -2650,4 +2685,9 @@ Removed 'Measured' as a state for type.source
 ;
    Added 'Implied' container type to allow examples and defaults to adjust
    to the item being defined. Changed relevant attribute definitions. (JRH)
+;
+         3.14.0    2019-04-02
+;
+   Replaced the _definition.replaced_by data item with a looped
+   DEFINITION_REPLACED category.
 ;


### PR DESCRIPTION
Implementing changes discussed in issue #104.

This entails:

- Addition of the DEFINITION_REPLACED category;
- Removal of the _definition.replaced_by data item;
- Modification of existing definitions in the 'cif_core.dic' dictionary in regards to the changes.

Please note, that the _definition_replaced.by description text has been slightly modified to refer to the data items themselves and not the data names as being deprecated.