### PR TITLE
Correction of an invalid dictionary audit date

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24156,10 +24156,11 @@ loop_
 ;
          3.0.11    2019-04-02
 ;
-    Removed the _chemical_conn_bond.distance_su data item.
-    Changed the purpose of the diffrn_radiation_wavelength.value data item
-    from 'Number' to 'Measurand'. Added the diffrn_radiation_wavelength.value_su
-    data item.
+     Removed the _chemical_conn_bond.distance_su data item.
+     Changed the purpose of the diffrn_radiation_wavelength.value data item
+     from 'Number' to 'Measurand'. Added the diffrn_radiation_wavelength.value_su
+     data item.
+
      Replaced all instances of the _definition.replaced_by data item with
      data items from the DEFINITION_REPLACED category.
 

--- a/ddl.dic
+++ b/ddl.dic
@@ -2690,16 +2690,14 @@ Removed 'Measured' as a state for type.source
    Added 'Implied' container type to allow examples and defaults to adjust
    to the item being defined. Changed relevant attribute definitions. (JRH)
 ;
-         3.13.2    2019-14-02
+         3.14.0    2019-04-02
 ;
    Updated the description of the _description_example.case data item.
 
    Updated the description of the 'Key' type purpose and changed the
    purpose of several data items in order to avoid conflicts with
    the new description.
-;
-         3.14.0    2019-04-02
-;
+
    Replaced the _definition.replaced_by data item with a looped
    DEFINITION_REPLACED category.
 ;


### PR DESCRIPTION
It seems that in one of the pull requests I have accidentally introduced a faulty date value (2019-14-02). Sorry for that. Also, since both the 3.13.2  and 3.14.0 revision were release on the same day, I have merged them into a single one (3.14.0).