### PR TITLE
Corrected the purpose of data items with links to other data items

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13940,7 +13940,7 @@ _definition.id                          '_valence_param.ref_id'
 loop_
   _alias.definition_id
          '_valence_param_ref_id'
-_definition.update                      2019-01-09
+_definition.update                      2019-04-01
 _description.text
 ;
      Code linking parameters to the key _valence_ref.id key
@@ -13949,7 +13949,7 @@ _description.text
 _name.category_id                       valence_param
 _name.object_id                         ref_id
 _name.linked_item_id                    '_valence_ref.id'
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Code

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.11
-_dictionary.date                        2019-04-02
+_dictionary.date                        2019-04-03
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
 _dictionary.namespace                   CifCore
@@ -3217,7 +3217,7 @@ _definition.id                          '_diffrn_scale_group.code'
 loop_
   _alias.definition_id
          '_diffrn_scale_group_code' 
-_definition.update                      2019-01-08
+_definition.update                      2019-04-03
 _description.text
 ;
      Code identifying a specific scale group of reflections (e.g. for
@@ -3226,7 +3226,6 @@ _description.text
 ;
 _name.category_id                       diffrn_scale_group
 _name.object_id                         code
-_name.linked_item_id                    '_diffrn_refln.scale_group_code'
 _type.purpose                           Encode
 _type.source                            Assigned
 _type.container                         Single
@@ -3714,7 +3713,7 @@ loop_
   _alias.definition_id
          '_diffrn_standard_refln_code'           
          '_diffrn_standard_refln.diffrn_id' 
-_definition.update                      2012-11-26
+_definition.update                      2019-04-03
 _description.text                       
 ;
      Code identifying a standard reflection used to monitor source
@@ -3723,7 +3722,6 @@ _description.text
 ;
 _name.category_id                       diffrn_standard_refln
 _name.object_id                         code
-_name.linked_item_id                    '_diffrn_refln.standard_code'
 _type.purpose                           Encode
 _type.source                            Assigned
 _type.container                         Single
@@ -11821,7 +11819,7 @@ save_
 save_geom_angle.atom_site_label_2
 
 _definition.id                          '_geom_angle.atom_site_label_2'
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text
 ;
      The unique identifier for the vertex atom of the angle.
@@ -13786,7 +13784,7 @@ _definition.id                          '_valence_param.atom_1'
 loop_
   _alias.definition_id
          '_valence_param_atom_1' 
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text                       
 ;
      Atom type symbol for atom 1 forming a bond whose
@@ -13832,7 +13830,7 @@ _definition.id                          '_valence_param.atom_2'
 loop_
   _alias.definition_id
          '_valence_param_atom_2' 
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text                       
 ;
      Atom type symbol for atom 2 forming a bond whose
@@ -13945,7 +13943,7 @@ _definition.id                          '_valence_param.ref_id'
 loop_
   _alias.definition_id
          '_valence_param_ref_id'
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text
 ;
      Code linking parameters to the key _valence_ref.id key
@@ -20157,7 +20155,7 @@ loop_
   _alias.definition_id
          '_atom_site_aniso_label'
          '_atom_site_anisotrop.id'
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text
 ;
      Anisotropic atomic displacement parameters are usually looped in
@@ -22219,7 +22217,7 @@ _definition.id                          '_atom_type_scat.symbol'
 loop_
   _alias.definition_id
          '_atom_type_scat_symbol' 
-_definition.update                      2019-04-01
+_definition.update                      2019-04-03
 _description.text                       
 ;
      The identity of the atom specie(s) representing this atom type.
@@ -24154,7 +24152,7 @@ loop_
 ;
      Added DATABASE_RELATED category (James Hester).
 ;
-         3.0.11    2019-04-02
+         3.0.11    2019-04-03
 ;
     Removed the _chemical_conn_bond.distance_su data item.
     Changed the purpose of the diffrn_radiation_wavelength.value data item
@@ -24167,4 +24165,11 @@ loop_
      replaced by the _atom_site.refinement_flags_posn,
      _atom_site.refinement_flags_adp and _atom_site.refinement_flags_occupancy
      data items.
+
+     Changed the _type.purpose from 'Encode' to 'Link' in the definitions of
+     the _geom_angle.atom_site_label_2, _valence_param_atom_1,
+     _valence_param_atom_2, _valence_param_ref_id, _atom_site_aniso.label
+     and _atom_type_scat.symbol data items. Removed the _name.linked_item_id
+     data item from the definitions of the _diffrn_scale_group.code and
+     diffrn_standard_refln.code data items.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.10
-_dictionary.date                        2019-03-26
+_dictionary.date                        2019-04-01
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
 _dictionary.ddl_conformance             3.11.11
 _dictionary.namespace                   CifCore
@@ -11816,7 +11816,7 @@ save_
 save_geom_angle.atom_site_label_2
 
 _definition.id                          '_geom_angle.atom_site_label_2'
-_definition.update                      2016-08-31
+_definition.update                      2019-04-01
 _description.text
 ;
      The unique identifier for the vertex atom of the angle.
@@ -11829,10 +11829,10 @@ loop_
 _name.category_id                       geom_angle
 _name.object_id                         atom_site_label_2
 _name.linked_item_id                    '_atom_site.label'
-_type.purpose                Encode
-_type.source                 Assigned
-_type.container              Single
-_type.contents               Code
+_type.purpose                           Link
+_type.source                            Assigned
+_type.container                         Single
+_type.contents                          Code
 
 save_
 
@@ -13781,7 +13781,7 @@ _definition.id                          '_valence_param.atom_1'
 loop_
   _alias.definition_id
          '_valence_param_atom_1' 
-_definition.update                      2012-12-13
+_definition.update                      2019-04-01
 _description.text                       
 ;
      Atom type symbol for atom 1 forming a bond whose
@@ -13790,7 +13790,7 @@ _description.text
 _name.category_id                       valence_param
 _name.object_id                         atom_1
 _name.linked_item_id                    '_atom_type.symbol'
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Code
@@ -13827,7 +13827,7 @@ _definition.id                          '_valence_param.atom_2'
 loop_
   _alias.definition_id
          '_valence_param_atom_2' 
-_definition.update                      2012-12-13
+_definition.update                      2019-04-01
 _description.text                       
 ;
      Atom type symbol for atom 2 forming a bond whose
@@ -13836,7 +13836,7 @@ _description.text
 _name.category_id                       valence_param
 _name.object_id                         atom_2
 _name.linked_item_id                    '_atom_type.symbol'
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Code
@@ -20146,7 +20146,7 @@ loop_
   _alias.definition_id
          '_atom_site_aniso_label'
          '_atom_site_anisotrop.id'
-_definition.update                      2019-01-09
+_definition.update                      2019-04-01
 _description.text
 ;
      Anisotropic atomic displacement parameters are usually looped in
@@ -20157,7 +20157,7 @@ _description.text
 _name.category_id                       atom_site_aniso
 _name.object_id                         label
 _name.linked_item_id                    '_atom_site.label'
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Code
@@ -22208,7 +22208,7 @@ _definition.id                          '_atom_type_scat.symbol'
 loop_
   _alias.definition_id
          '_atom_type_scat_symbol' 
-_definition.update                      2013-01-23
+_definition.update                      2019-04-01
 _description.text                       
 ;
      The identity of the atom specie(s) representing this atom type.
@@ -22217,7 +22217,7 @@ _description.text
 _name.category_id                       atom_type_scat
 _name.object_id                         symbol
 _name.linked_item_id                    '_atom_type.symbol'
-_type.purpose                           Encode
+_type.purpose                           Link
 _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Code

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -9,10 +9,10 @@ data_TEMPL_ATTR
  
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
-    _dictionary.version          1.4.08 
-    _dictionary.date             2019-04-01
+    _dictionary.version          1.4.09
+    _dictionary.date             2019-04-03
     _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
-    _dictionary.ddl_conformance  3.11.04
+    _dictionary.ddl_conformance  3.14.0
     _description.text
 ;
      This dictionary contains definition attribute sets that are common
@@ -23,7 +23,7 @@ data_TEMPL_ATTR
 
 save_atom_site_label
 
-    _definition.update           2019-04-01
+    _definition.update           2019-04-03
     _description.text
 ;
      This label is a unique identifier for a particular site in the
@@ -71,7 +71,7 @@ save_restr_label
 
 save_atom_site_id
 
-    _definition.update           2019-04-01
+    _definition.update           2019-04-03
     _description.text
 ;
      This label is a unique identifier for a particular site in the
@@ -905,4 +905,12 @@ save_display_colour
 ;
    Added attribute save frame "ms_index"
    Added attribute save frame "matrix_w"
+;
+      1.4.09  2019-04-03
+;
+   Change the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
+   save frame.
+
+   Removed the '_name.linked_item_id' data item from the 'atom_site_label'
+   save frame.
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -10,7 +10,7 @@ data_TEMPL_ATTR
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.08 
-    _dictionary.date             2014-06-27
+    _dictionary.date             2019-04-01
     _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
     _dictionary.ddl_conformance  3.11.04
     _description.text
@@ -72,14 +72,14 @@ save_restr_label
 
 save_atom_site_id
 
-    _definition.update           2014-06-16
+    _definition.update           2019-04-01
     _description.text
 ;
      This label is a unique identifier for a particular site in the
      asymmetric unit of the crystal unit cell.
 ;
     _name.linked_item_id       '_atom_site.label'
-    _type.purpose                Encode
+    _type.purpose                Link
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Code

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -23,7 +23,7 @@ data_TEMPL_ATTR
 
 save_atom_site_label
 
-    _definition.update           2012-10-16
+    _definition.update           2019-04-01
     _description.text
 ;
      This label is a unique identifier for a particular site in the
@@ -44,7 +44,6 @@ save_atom_site_label
      acceptable and represents the components C, 233, '', and ggg.
      Each label may have a different number of components.
 ;
-    _name.linked_item_id       '_atom_site.label'  
     _type.purpose                Encode
     _type.source                 Assigned
     _type.container              Single


### PR DESCRIPTION
Corrected multiple data item definitions to be compliant with the declared purpose. This included:

1. Changing the purpose of multiple data items from 'Encode' to 'Link';
2. Removing the _name.linked_item_id data item from the definition. The _diffrn_scale_group.code and _diffrn_standard_refln.code data items as well as the atom_site_label save frame were affected.

This PR solves issues #73 and #124.