### PR TITLE
Assigned more descriptive _type.contents values to several id data items.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.11
-_dictionary.date                        2019-04-03
+_dictionary.date                        2019-06-04
 _dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
 _dictionary.namespace                   CifCore
@@ -11877,7 +11877,7 @@ save_geom_angle.id
     _definition.id             '_geom_angle.id'
      loop_
     _alias.definition_id       '_geom_angle.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Atom site labels and symmetry operators as pairs for each of the
@@ -11889,7 +11889,7 @@ save_geom_angle.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               List(Code,Symop)
     _type.dimension              '[3]'
      loop_
     _method.purpose
@@ -12189,7 +12189,7 @@ save_geom_bond.id
     _definition.id             '_geom_bond.id'
      loop_
     _alias.definition_id       '_geom_bond.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Identity of bond distance in terms of the atom site labels and
@@ -12200,7 +12200,7 @@ save_geom_bond.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               List(Code,Symop)
     _type.dimension              '[2]'
      loop_
     _method.purpose
@@ -12479,7 +12479,7 @@ save_geom_contact.id
     _definition.id             '_geom_contact.id'
      loop_
     _alias.definition_id       '_geom_contact.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Atom site labels and symmetry operators as pairs for each of the
@@ -12490,7 +12490,7 @@ save_geom_contact.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               List(Code,Symop)
     _type.dimension              '[2]'
      loop_
     _method.purpose
@@ -12898,7 +12898,7 @@ save_geom_hbond.id
     _definition.id             '_geom_hbond.id'
      loop_
     _alias.definition_id       '_geom_hbond.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Atom site labels and symmetry operators as pairs for each of the
@@ -12910,7 +12910,7 @@ save_geom_hbond.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               List(Code,Symop)
     _type.dimension              '[3]'
      loop_
     _method.purpose
@@ -13214,7 +13214,7 @@ save_geom_torsion.id
     _definition.id             '_geom_torsion.id'
      loop_
     _alias.definition_id       '_geom_torsion.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Atom site labels and symmetry operators as pairs for each of the
@@ -13225,7 +13225,7 @@ save_geom_torsion.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               List(Code,Symop)
     _type.dimension              '[4]'
      loop_
     _method.purpose
@@ -13566,7 +13566,7 @@ save_model_site.id
     _definition.id             '_model_site.id'
      loop_
     _alias.definition_id       '_model_site.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-06-04
     _description.text
 ;
      Identifier of model site in terms of the atom site label and
@@ -13577,7 +13577,7 @@ save_model_site.id
     _type.purpose                Composite
     _type.source                 Derived
     _type.container              List
-    _type.contents               List
+    _type.contents               Code,Symop
     _type.dimension              '[1]'
      loop_
     _method.purpose
@@ -24152,7 +24152,7 @@ loop_
 ;
      Added DATABASE_RELATED category (James Hester).
 ;
-         3.0.11    2019-04-03
+         3.0.11    2019-06-04
 ;
      Removed the _chemical_conn_bond.distance_su data item.
      Changed the purpose of the diffrn_radiation_wavelength.value data item
@@ -24173,4 +24173,10 @@ loop_
      and _atom_type_scat.symbol data items. Removed the _name.linked_item_id
      data item from the definitions of the _diffrn_scale_group.code and
      diffrn_standard_refln.code data items.
+
+     Changed the _type.contents from 'List' to 'List(Code,Symop)' in the
+     definitions of the _geom_angle.id, _geom_bond.id, _geom_contact.id,
+     _geom_hbond.id and _geom_torsion.id data items. Changed the _type.contents
+     from 'List' to 'Code,Symop' in the definition of the _model_site.id
+     data item.
 ;


### PR DESCRIPTION
Several id data items (``_geom_angle.id``, ``_geom_bond.id``, etc.) were assigned a ``List`` content type.
This PR replaces them with data type lists (i.e. ``List(Code,Symop)``, ``Code,Symop``) that are compatible with the data values assigned via the dREL evaluation methods.