### PR TITLE
Using a resolving URI for cif_core.dic

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,8 @@ _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.11
 _dictionary.date                        2019-04-03
-_dictionary.uri                         www.iucr.org/cif/dic/cif_core.dic
+_dictionary.uri
+https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
 _dictionary.namespace                   CifCore
 _description.text                       


### PR DESCRIPTION
`cif_core.dic` has `_dictionary.uri` of `www.iucr.org/cif/dic/cif_core.dic`, which lacks a scheme prefix (i.e. `http://`) to conform to [RFC 3986](https://tools.ietf.org/html/rfc3986). Moreover, this URI does not resolve. Thus I suggest using GitHub URI (`https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic`) as `_dictionary.uri` for this dictionary.