### PR TITLE
Change the content type of pixel bin size data items to allow floating-point values

### DIFF
--- a/cif_img.dic
+++ b/cif_img.dic
@@ -14,8 +14,8 @@ data_CIF_IMG
 
     _dictionary.title            CIF_IMG
     _dictionary.class            Instance
-    _dictionary.version          3.00.02
-    _dictionary.date             2019-04-01
+    _dictionary.version          3.00.04
+    _dictionary.date             2019-09-25
     _dictionary.uri              www.iucr.org/cif/dic/cif_img.dic
     _dictionary.ddl_conformance  3.11.04
     _dictionary.namespace        CifImag
@@ -762,7 +762,7 @@ save_array_intensities.overload
 
 save_array_intensities.pixel_fast_bin_size
     _definition.id             '_array_intensities.pixel_fast_bin_size'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The value of _array_intensities.pixel_fast_bin_size specifies
@@ -780,7 +780,8 @@ save_array_intensities.pixel_fast_bin_size
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
+    _type.contents              Real
+    _enumeration.range          0.0:
     _enumeration.default        1.
     _units.code                 pixels_per_element
      save_
@@ -788,7 +789,7 @@ save_array_intensities.pixel_fast_bin_size
 
 save_array_intensities.pixel_slow_bin_size
     _definition.id             '_array_intensities.pixel_slow_bin_size'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The value of _array_intensities.pixel_slow_bin_size specifies
@@ -805,8 +806,8 @@ save_array_intensities.pixel_slow_bin_size
     _name.object_id             pixel_slow_bin_size
     _type.purpose               Number
     _type.source                Derived
-    _type.container             Single
-    _type.contents              Count
+    _type.contents              Real
+    _enumeration.range          0.0:
     _enumeration.default        1.
     _units.code                 pixels_per_element
      save_
@@ -6242,7 +6243,18 @@ save_variant.variant_of
     _type.source                Related
     _type.container             Single
     _type.contents              Code
-     save_
+save_
+
+loop_
+  _dictionary_audit.version
+  _dictionary_audit.date
+  _dictionary_audit.revision
+         3.0.04    2019-09-25
+;
+     Changed the content type of the _array_intensities.pixel_slow_bin_size
+     and _array_intensities.pixel_fast_bin_size data items from 'Count' to
+     'Real'. (Antanas Vaitkus)
+;
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This PR resolves issue #153.

It should be noted, that in addition to the content type change an enumeration range of ``0.0:`` was also added base on the restrictions of the ``Count`` content type. It is not entirely clear if the assigned range is a correct one.