### PR TITLE
Deprecated 'Count' and 'Index' content types

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -2596,7 +2596,7 @@ _definition.id                          '_diffrn_reflns.number'
 loop_
   _alias.definition_id
          '_diffrn_reflns_number' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total number of measured intensities, excluding reflections that are
@@ -2608,7 +2608,7 @@ _name.object_id                         number
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -2993,7 +2993,7 @@ _definition.id                          '_diffrn_reflns_class.number'
 loop_
   _alias.definition_id
          '_diffrn_reflns_class_number' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of measured intensities for a reflection class, excluding
@@ -3004,7 +3004,7 @@ _name.object_id                         number
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -3593,7 +3593,7 @@ loop_
   _alias.definition_id
          '_diffrn_standards_interval_count'      
          '_diffrn_standards.interval_count' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Reflection count between the standard reflection measurements.
@@ -3603,7 +3603,7 @@ _name.object_id                         interval_count
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -3640,7 +3640,7 @@ loop_
   _alias.definition_id
          '_diffrn_standards_number'    
          '_diffrn_standards.number' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of unique standard reflections used in measurements.
@@ -3650,7 +3650,7 @@ _name.object_id                         number
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5167,7 +5167,7 @@ loop_
          '_reflns_number_observed'     
          '_reflns_number_obs'          
          '_reflns.number_obs' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
@@ -5181,7 +5181,7 @@ _name.object_id                         number_gt
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5195,7 +5195,7 @@ loop_
          '_reflns_number_total'        
          '_reflns_number_all'          
          '_reflns.number_all' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of reflections in the REFLN set (not the DIFFRN_REFLN set). It may
@@ -5208,7 +5208,7 @@ _name.object_id                         number_total
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5390,7 +5390,7 @@ loop_
   _alias.definition_id
          '_reflns_class_number_observed'         
          '_reflns_class_number_gt' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Count of reflections in this REFLN class (not the DIFFRN_REFLN set)
@@ -5404,7 +5404,7 @@ _name.object_id                         number_gt
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5416,7 +5416,7 @@ _definition.id                          '_reflns_class.number_total'
 loop_
   _alias.definition_id
          '_reflns_class_number_total' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Count of reflections in this REFLN class (not the DIFFRN_REFLN set). It
@@ -5429,7 +5429,7 @@ _name.object_id                         number_total
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5884,7 +5884,7 @@ _definition.id                          '_reflns_shell.number_measured_all'
 loop_
   _alias.definition_id
          '_reflns_shell_number_measured_all' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total count of reflections measured for this resolution shell.
@@ -5894,7 +5894,7 @@ _name.object_id                         number_measured_all
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5908,7 +5908,7 @@ loop_
          '_reflns_shell_number_measured_obs'     
          '_reflns_shell.number_measured_obs'     
          '_reflns_shell_number_measured_gt' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of reflections measured for this resolution shell which are
@@ -5919,7 +5919,7 @@ _name.object_id                         number_measured_gt
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5932,7 +5932,7 @@ loop_
   _alias.definition_id
          '_reflns_shell_number_possible'         
          '_reflns_shell.number_possible_all' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Count of symmetry-unique reflections possible in this reflection shell.
@@ -5942,7 +5942,7 @@ _name.object_id                         number_possible
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5954,7 +5954,7 @@ _definition.id                          '_reflns_shell.number_unique_all'
 loop_
   _alias.definition_id
          '_reflns_shell_number_unique_all' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Count of symmetry-unique reflections present in this reflection shell.
@@ -5964,7 +5964,7 @@ _name.object_id                         number_unique_all
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -5978,7 +5978,7 @@ loop_
          '_reflns_shell_number_unique_gt'        
          '_reflns_shell_number_unique_obs'       
          '_reflns_shell.number_unique_obs' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of symmetry-unique reflections present in this reflection shell
@@ -5989,7 +5989,7 @@ _name.object_id                         number_unique_gt
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -6190,7 +6190,7 @@ _definition.id                          '_exptl.crystals_number'
 loop_
   _alias.definition_id
          '_exptl_crystals_number' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total number of crystals used in the measurement of intensities.
@@ -6200,7 +6200,7 @@ _name.object_id                         crystals_number
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -6397,7 +6397,7 @@ _definition.id                          '_cell.formula_units_Z'
 loop_
   _alias.definition_id
          '_cell_formula_units_Z' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The number of the formula units in the unit cell as specified
@@ -6409,7 +6409,7 @@ _name.object_id                         formula_units_Z
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -6823,7 +6823,7 @@ _definition.id                          '_cell_measurement.reflns_used'
 loop_
   _alias.definition_id
          '_cell_measurement_reflns_used' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total number of reflections used to determine the unit cell.
@@ -6834,7 +6834,7 @@ _name.object_id                         reflns_used
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      3:
 
 save_
@@ -8595,7 +8595,7 @@ _definition.id                          '_chemical_conn_atom.NCA'
 loop_
   _alias.definition_id
          '_chemical_conn_atom_NCA' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total number of connected atoms excluding terminal hydrogen atoms.
@@ -8605,7 +8605,7 @@ _name.object_id                         NCA
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -8617,7 +8617,7 @@ _definition.id                          '_chemical_conn_atom.NH'
 loop_
   _alias.definition_id
          '_chemical_conn_atom_NH' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Total number of hydrogen atoms attached to this atom,
@@ -8631,7 +8631,7 @@ _name.object_id                         NH
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -10450,7 +10450,7 @@ save_space_group.Laue_class
 save_space_group.multiplicity
 
 _definition.id                          '_space_group.multiplicity'
-_definition.update                      2016-05-13
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of unique symmetry elements in the space group.
@@ -10460,7 +10460,7 @@ _name.object_id                         multiplicity
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      1:192
 loop_
   _method.purpose
@@ -12222,7 +12222,7 @@ _definition.id                          '_geom_bond.multiplicity'
 loop_
   _alias.definition_id
          '_geom_bond_multiplicity' 
-_definition.update                      2013-01-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The number of times the given bond appears in the environment
@@ -12236,7 +12236,7 @@ _name.object_id                         multiplicity
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -18751,7 +18751,7 @@ _definition.id                          '_atom_site.attached_hydrogens'
 loop_
   _alias.definition_id
          '_atom_site_attached_hydrogens' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of hydrogen atoms attached to the atom at this site
@@ -18763,7 +18763,7 @@ _name.object_id                         attached_hydrogens
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:8
 loop_
   _description_example.case
@@ -23208,7 +23208,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_constraints'         
          '_refine.ls_number_constraints' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of constrained (non-refined or dependent) parameters
@@ -23222,7 +23222,7 @@ _name.object_id                         number_constraints
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -23235,7 +23235,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_parameters'          
          '_refine.ls_number_parameters' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of parameters refined in the least-squares process. If
@@ -23252,7 +23252,7 @@ _name.object_id                         number_parameters
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -23265,7 +23265,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_reflns'    
          '_refine.ls_number_reflns_all' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of unique reflections used in the least-squares refinement.
@@ -23275,7 +23275,7 @@ _name.object_id                         number_reflns
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -23288,7 +23288,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_reflns_gt'
          '_refine.ls_number_reflns_obs'
-_definition.update                      2019-01-09
+_definition.update                      2019-09-25
 _description.text
 ;
      The number of reflections that satisfy the resolution limits
@@ -23301,7 +23301,7 @@ _name.object_id                         number_reflns_gt
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -23314,7 +23314,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_restraints'          
          '_refine.ls_number_restraints' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of restrained parameters in the least-squares refinement. These
@@ -23328,7 +23328,7 @@ _name.object_id                         number_restraints
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Count
+_type.contents                          Integer
 _enumeration.range                      0:
 
 save_
@@ -24190,6 +24190,6 @@ loop_
      Corrected a typo in the definitions of the _geom_contact.distance and
      _geom_torsion.angle and data items.
 
-     Changed the content type of multiple data items from 'Index' to 'Integer'
-     and assigned the appropriate enumeration range if needed.
+     Changed the content type of multiple data items from 'Index' or 'Count'
+     to 'Integer' and assigned the appropriate enumeration range if needed.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.11
-_dictionary.date                        2019-07-25
+_dictionary.date                        2019-09-25
 _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
@@ -4721,7 +4721,7 @@ _definition.id                          '_refln.symmetry_epsilon'
 loop_
   _alias.definition_id
          '_refln_symmetry_epsilon' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The symmetry reinforcement factor corresponding to the number of
@@ -4733,7 +4733,7 @@ _name.object_id                         symmetry_epsilon
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:48
 
 save_
@@ -4745,7 +4745,7 @@ _definition.id                          '_refln.symmetry_multiplicity'
 loop_
   _alias.definition_id
          '_refln_symmetry_multiplicity' 
-_definition.update                      2012-11-26
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The number of reflections symmetry-equivalent under the Laue
@@ -4759,7 +4759,7 @@ _name.object_id                         symmetry_multiplicity
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:48
 
 save_
@@ -8643,7 +8643,7 @@ _definition.id                          '_chemical_conn_atom.number'
 loop_
   _alias.definition_id
          '_chemical_conn_atom_number' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The chemical sequence number to be associated with this atom.
@@ -8653,7 +8653,7 @@ _name.object_id                         number
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -8716,7 +8716,7 @@ loop_
   _alias.definition_id
          '_chemical_conn_bond_atom_1'  
          '_chem_comp_bond.atom_id_1' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Index id of first atom in a bond connecting two atom sites.
@@ -8727,7 +8727,7 @@ _name.linked_item_id                    '_chemical_conn_atom.number'
 _type.purpose                           Link
 _type.source                            Related
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -8740,7 +8740,7 @@ loop_
   _alias.definition_id
          '_chemical_conn_bond_atom_2'  
          '_chem_comp_bond.atom_id_2' 
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Index id of second atom in a bond connecting two atom sites.
@@ -8751,7 +8751,7 @@ _name.object_id                         atom_2
 _type.purpose                           Link
 _type.source                            Related
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -8785,7 +8785,7 @@ save_chemical_conn_bond.id
     _definition.id             '_chemical_conn_bond.id'
      loop_
     _alias.definition_id       '_chemical_conn_bond.id'
-    _definition.update           2012-11-22
+    _definition.update           2019-09-25
     _description.text
 ;
      Bond identifier composed of a list of two sequence indices
@@ -8796,7 +8796,8 @@ save_chemical_conn_bond.id
     _type.purpose                Number
     _type.source                 Derived
     _type.container              List
-    _type.contents               Index
+    _type.contents               Integer
+    _enumeration.range           1:
     _type.dimension              '[2]'
      loop_
     _method.purpose
@@ -10885,7 +10886,7 @@ loop_
          '_space_group_symop_id'
          '_symmetry_equiv.pos_site_id'
          '_symmetry_equiv_pos_site_id'
-_definition.update                      2019-01-09
+_definition.update                      2019-09-25
 _description.text 
 ;
      Index identifying each entry in the _space_group_symop.operation_xyz
@@ -10901,7 +10902,7 @@ _name.object_id                         id
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 loop_
   _method.purpose
@@ -11481,7 +11482,7 @@ save_
 save_function.SymKey
 
 _definition.id                          '_function.SymKey'
-_definition.update                      2012-12-17
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The function
@@ -11495,7 +11496,7 @@ _name.object_id                         SymKey
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:192
 loop_
   _method.purpose
@@ -13594,7 +13595,7 @@ save_model_site.id
 save_model_site.index
 
 _definition.id                          '_model_site.index'
-_definition.update                      2012-11-22
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Index number of an atomic site in the connected molecule.
@@ -13604,7 +13605,7 @@ _name.object_id                         index
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -13632,7 +13633,7 @@ save_
 save_model_site.mole_index
 
 _definition.id                          '_model_site.mole_index'
-_definition.update                      2013-03-09
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Index number of a distinct molecules in the cell, not related by
@@ -13643,7 +13644,9 @@ _name.object_id                         mole_index
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
+_enumeration.range                      1:
+
 
 save_
 
@@ -13922,7 +13925,7 @@ _definition.id                          '_valence_param.id'
 loop_
   _alias.definition_id
          '_valence_param_id' 
-_definition.update                      2012-12-13
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Unique index loop number of the valence parameter loop.
@@ -13932,7 +13935,7 @@ _name.object_id                         id
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -15085,7 +15088,7 @@ _definition.id                          '_citation.journal_issue'
 loop_
   _alias.definition_id
          '_citation_journal_issue' 
-_definition.update                      2012-12-11
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Issue number of the journal cited;  relevant for articles.
@@ -15095,7 +15098,7 @@ _name.object_id                         journal_issue
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 loop_
   _description_example.case
@@ -15110,7 +15113,7 @@ _definition.id                          '_citation.journal_volume'
 loop_
   _alias.definition_id
          '_citation_journal_volume' 
-_definition.update                      2012-12-11
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Volume number of the journal cited;  relevant for articles.
@@ -15120,7 +15123,7 @@ _name.object_id                         journal_volume
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 loop_
   _description_example.case
@@ -15385,7 +15388,7 @@ _definition.id                          '_citation_author.ordinal'
 loop_
   _alias.definition_id
          '_citation_author_ordinal' 
-_definition.update                      2012-12-11
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Ordinal code specifies the order of the author's name in the list
@@ -15396,7 +15399,8 @@ _name.object_id                         ordinal
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
+_enumeration.range                      1:
 
 save_
 
@@ -15507,7 +15511,7 @@ _definition.id                          '_citation_editor.ordinal'
 loop_
   _alias.definition_id
          '_citation_editor_ordinal' 
-_definition.update                      2014-06-12
+_definition.update                      2019-09-25
 _description.text                       
 ;
      This data item defines the order of the editor's name in the
@@ -15518,7 +15522,8 @@ _name.object_id                         ordinal
 _type.purpose                           Number
 _type.source                            Recorded
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
+_enumeration.range                      1:
 
 save_
 
@@ -17086,7 +17091,7 @@ _name.object_id                         id
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -19064,7 +19069,7 @@ _definition.id                          '_atom_site.chemical_conn_number'
 loop_
   _alias.definition_id
          '_atom_site_chemical_conn_number' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      This number links an atom site to the chemical connectivity list.
@@ -19076,7 +19081,7 @@ _name.linked_item_id                    '_chemical_conn_atom.number'
 _type.purpose                           Link
 _type.source                            Related
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:
 
 save_
@@ -19645,7 +19650,7 @@ loop_
          '_atom_site_site_symmetry_multiplicity'           
          '_atom_site_symmetry_multiplicity'      
          '_atom_site.symmetry_multiplicity' 
-_definition.update                      2013-04-28
+_definition.update                      2019-09-25
 _description.text                       
 ;
      The number of different sites that are generated by the
@@ -19661,7 +19666,7 @@ _name.object_id                         site_symmetry_multiplicity
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:192
 loop_
   _method.purpose
@@ -19690,7 +19695,7 @@ _definition.id                          '_atom_site.site_symmetry_order'
 loop_
   _alias.definition_id
          '_atom_site_site_symmetry_order' 
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
     The number of times application of the crystallographic symmetry
@@ -19705,7 +19710,7 @@ _name.object_id                         site_symmetry_order
 _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _enumeration.range                      1:48
 
 save_
@@ -21393,7 +21398,7 @@ save_
 save_atom_type.atomic_number
 
 _definition.id                          '_atom_type.atomic_number'
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Atomic number of this atom type.
@@ -21403,7 +21408,8 @@ _name.object_id                         atomic_number
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
+_enumeration.range                      1:
 _import.get [{'save':atomic_number  'file':templ_enum.cif}]
 _enumeration.def_index_id               '_atom_type.symbol'
 
@@ -21464,7 +21470,7 @@ save_
 save_atom_type.electron_count
 
 _definition.id                          '_atom_type.electron_count'
-_definition.update                      2012-11-20
+_definition.update                      2019-09-25
 _description.text                       
 ;
      Number of electrons in this atom type.
@@ -21474,7 +21480,7 @@ _name.object_id                         electron_count
 _type.purpose                           Number
 _type.source                            Assigned
 _type.container                         Single
-_type.contents                          Index
+_type.contents                          Integer
 _import.get [{'save':electron_count  'file':templ_enum.cif}]
 _enumeration.def_index_id               '_atom_type.symbol'
 _enumeration.range                      1:
@@ -24153,7 +24159,7 @@ loop_
 ;
      Added DATABASE_RELATED category (James Hester).
 ;
-         3.0.11    2019-07-25
+         3.0.11    2019-09-25
 ;
      Removed the _chemical_conn_bond.distance_su data item.
      Changed the purpose of the diffrn_radiation_wavelength.value data item
@@ -24183,4 +24189,7 @@ loop_
 
      Corrected a typo in the definitions of the _geom_contact.distance and
      _geom_torsion.angle and data items.
+
+     Changed the content type of multiple data items from 'Index' to 'Integer'
+     and assigned the appropriate enumeration range if needed.
 ;

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -746,7 +746,7 @@ save_array_intensities.offset
 
 save_array_intensities.overload
     _definition.id             '_array_intensities.overload'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The saturation intensity level for this data array.
@@ -756,8 +756,9 @@ save_array_intensities.overload
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
-     save_
+    _type.contents              Integer
+    _enumeration.range          0:
+save_
 
 
 save_array_intensities.pixel_fast_bin_size
@@ -1208,7 +1209,7 @@ save_array_structure_list.axis_set_id
 
 save_array_structure_list.dimension
     _definition.id             '_array_structure_list.dimension'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The number of elements stored in the array structure in
@@ -1219,8 +1220,9 @@ save_array_structure_list.dimension
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
-     save_
+    _type.contents              Integer
+    _enumeration.range          0:
+save_
 
 
 save_array_structure_list.direction
@@ -3335,7 +3337,7 @@ save_diffrn_measurement.method
 
 save_diffrn_measurement.number_of_axes
     _definition.id             '_diffrn_measurement.number_of_axes'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The value of _diffrn_measurement.number_of_axes gives the
@@ -3349,8 +3351,9 @@ save_diffrn_measurement.number_of_axes
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
-     save_
+    _type.contents              Integer
+    _enumeration.range          0:
+save_
 
 
 save_diffrn_measurement.sample_detector_distance
@@ -4383,7 +4386,7 @@ save_diffrn_scan.frame_id_end
 
 save_diffrn_scan.frames
     _definition.id             '_diffrn_scan.frames'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The value is the number of frames in the scan.
@@ -4393,8 +4396,9 @@ save_diffrn_scan.frames
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
-     save_
+    _type.contents              Integer
+    _enumeration.range          0:
+save_
 
 
 save_diffrn_scan.time_period
@@ -4848,7 +4852,7 @@ save_diffrn_scan_frame.frame_id
 
 save_diffrn_scan_frame.frame_number
     _definition.id             '_diffrn_scan_frame.frame_number'
-    _definition.update           2014-07-07
+    _definition.update           2019-09-25
     _description.text
 ;
      The value of this data item is the number of the frame
@@ -4861,9 +4865,9 @@ save_diffrn_scan_frame.frame_number
     _type.purpose               Number
     _type.source                Derived
     _type.container             Single
-    _type.contents              Count
+    _type.contents              Integer
     _enumeration.range          1:
-     save_
+save_
 
 
 save_diffrn_scan_frame.integration_time

--- a/cif_img.dic
+++ b/cif_img.dic
@@ -6264,11 +6264,15 @@ loop_
          3.00.03      2019-04-01
 ;
      Updated the file to conform to the CIF2 syntax. (Antanas Vaitkus)
-         3.0.04    2019-09-25
+         3.0.04       2019-09-25
 ;
      Changed the content type of the _array_intensities.pixel_slow_bin_size
      and _array_intensities.pixel_fast_bin_size data items from 'Count' to
-     'Real'. (Antanas Vaitkus)
+     'Real'.
+
+     Changed the content type of multiple data items from 'Count'
+     to 'Integer' and assigned the appropriate enumeration range
+     where needed. (Antanas Vaitkus)
 ;
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/cif_ms.dic
+++ b/cif_ms.dic
@@ -24,7 +24,7 @@ data_CIF_MS
     _dictionary.formalism        Modulated
     _dictionary.class            Instance
     _dictionary.version          3.2.1
-    _dictionary.date             2019-07-25
+    _dictionary.date             2019-09-25
     _dictionary.uri              http://www.iucr.org/cif/dic/cif_ms.dic
     _dictionary.ddl_conformance  3.13.1
     _dictionary.namespace        ModStruct
@@ -796,7 +796,7 @@ save_
 save_atom_site_displace_Legendre.order
 
     _definition.id               '_atom_site_displace_Legendre.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -807,7 +807,8 @@ save_atom_site_displace_Legendre.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -1665,7 +1666,7 @@ save_
 save_atom_site_displace_xharm.order
 
     _definition.id               '_atom_site_displace_xharm.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -1676,7 +1677,8 @@ save_atom_site_displace_xharm.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -1730,7 +1732,7 @@ save_
 save_atom_site_Fourier_wave_vector.seq_id
 
     _definition.id               '_atom_site_Fourier_wave_vector.seq_id'
-    _definition.update           2017-03-11
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_atom_site_Fourier_wave_vector_seq_id'
@@ -1745,8 +1747,8 @@ save_atom_site_Fourier_wave_vector.seq_id
     _type.purpose                Key
     _type.source                 Related
     _type.container              Single
-    _type.contents               Count
-    _enumeration.range           [0:]
+    _type.contents               Integer
+    _enumeration.range           0:
     _enumeration.default         1
 
 save_
@@ -2422,7 +2424,7 @@ save_
 save_atom_site_occ_Legendre.order
 
     _definition.id               '_atom_site_occ_Legendre.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -2433,7 +2435,8 @@ save_atom_site_occ_Legendre.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -2830,7 +2833,7 @@ save_
 save_atom_site_occ_xharm.order
 
     _definition.id               '_atom_site_occ_xharm.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -2841,7 +2844,8 @@ save_atom_site_occ_xharm.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -3508,7 +3512,7 @@ save_
 save_atom_site_rot_Legendre.order
 
     _definition.id               '_atom_site_rot_Legendre.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -3519,7 +3523,8 @@ save_atom_site_rot_Legendre.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -4361,7 +4366,7 @@ save_
 save_atom_site_rot_xharm.order
 
     _definition.id               '_atom_site_rot_xharm.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -4372,7 +4377,8 @@ save_atom_site_rot_xharm.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -4838,7 +4844,7 @@ save_
 save_atom_site_U_Legendre.order
 
     _definition.id               '_atom_site_U_Legendre.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -4849,7 +4855,8 @@ save_atom_site_U_Legendre.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -5125,7 +5132,7 @@ save_
 save_atom_site_U_xharm.order
 
     _definition.id               '_atom_site_U_xharm.order'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -5136,7 +5143,8 @@ save_atom_site_U_xharm.order
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -5221,7 +5229,7 @@ save_
 save_atom_sites_axes.matrix_seq_id
 
     _definition.id               '_atom_sites_axes.matrix_seq_id'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -5233,7 +5241,8 @@ save_atom_sites_axes.matrix_seq_id
     _type.purpose                Key
     _type.source                 Related
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -5683,7 +5692,7 @@ save_
 save_atom_sites_ortho.wave_vector_seq_id
 
     _definition.id               '_atom_sites_ortho.wave_vector_seq_id'
-    _definition.update           2017-03-11
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -5697,8 +5706,8 @@ save_atom_sites_ortho.wave_vector_seq_id
     _type.purpose                Link
     _type.source                 Related
     _type.container              Single
-    _type.contents               Count
-    _enumeration.range           [0:]
+    _type.contents               Integer
+    _enumeration.range           0:
     _enumeration.default         0
 
 save_
@@ -5706,7 +5715,7 @@ save_
 save_atom_sites_ortho.wave_vector_seq_id_list
 
     _definition.id               '_atom_sites_ortho.wave_vector_seq_id_list'
-    _definition.update           2017-03-11
+    _definition.update           2019-09-25
     _description.text                   
 ;
 
@@ -5720,9 +5729,9 @@ save_atom_sites_ortho.wave_vector_seq_id_list
     _type.purpose                Link
     _type.source                 Related
     _type.container              List
-    _type.contents               Count
+    _type.contents               Integer
     _type.dimension              '[]'
-    _enumeration.range           [0:]
+    _enumeration.range           0:
     _enumeration.default         [0]
 
 save_
@@ -5814,7 +5823,7 @@ save_
 save_cell.modulation_dimension
 
     _definition.id               '_cell.modulation_dimension'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_cell_modulation_dimension' 
@@ -5829,7 +5838,7 @@ save_cell.modulation_dimension
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           1:8
 
 save_
@@ -7186,7 +7195,7 @@ save_
 save_cell_subsystems.number
 
     _definition.id               '_cell_subsystems.number'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_cell_subsystems_number' 
@@ -7201,7 +7210,7 @@ save_cell_subsystems.number
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           2:
 
 save_
@@ -7234,7 +7243,7 @@ save_
 save_cell_wave_vector.seq_id
 
     _definition.id               '_cell_wave_vector.seq_id'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_cell_wave_vector_seq_id' 
@@ -7251,7 +7260,8 @@ save_cell_wave_vector.seq_id
     _type.purpose                Key
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -8199,7 +8209,7 @@ save_
 save_diffrn_reflns.satellite_order_max
 
     _definition.id               '_diffrn_reflns.satellite_order_max'
-    _definition.update           2014-06-27
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_diffrn_reflns_satellite_order_max' 
@@ -8213,7 +8223,8 @@ save_diffrn_reflns.satellite_order_max
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
+    _enumeration.range           0:
 
 save_
 
@@ -10872,7 +10883,10 @@ loop_
      Returned all additional indices to main dictionary, removed category_id
      from templates(James Hester)
 ;
-         3.2.1    2019-07-25
+         3.2.1    2019-09-25
 ;
-    Corrected a typo in the definition of the _geom_torsion.angle data item.
+     Corrected a typo in the definition of the _geom_torsion.angle data item.
+
+     Changed the content type of multiple data items from 'Count' to 'Integer'
+     and assigned the appropriate enumeration range if needed.
 ;

--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -14,8 +14,8 @@ data_CIF_POW
     _dictionary.title            CIF_POW
     _dictionary.formalism        Powder
     _dictionary.class            Instance
-    _dictionary.version          2.4
-    _dictionary.date             2017-04-05
+    _dictionary.version          2.4.1
+    _dictionary.date             2019-09-25
     _dictionary.uri              www.iucr.org/cif/dic/cif_pow.dic
     _dictionary.ddl_conformance  3.11.10
     _dictionary.namespace        CifPow
@@ -3127,7 +3127,7 @@ save_
 save__pd_meas.number_of_points
 
     _definition.id               '_pd_meas.number_of_points'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_number_of_points' 
@@ -3141,7 +3141,7 @@ save__pd_meas.number_of_points
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           1:
 
 save_
@@ -3371,7 +3371,7 @@ save_
 save__pd_meas.counts_background
 
     _definition.id               '_pd_meas.counts_background'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_counts_background' 
@@ -3401,7 +3401,7 @@ save__pd_meas.counts_background
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
 
 save_
@@ -3410,7 +3410,7 @@ save_
 save__pd_meas.counts_container
 
     _definition.id               '_pd_meas.counts_container'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_counts_container' 
@@ -3439,7 +3439,7 @@ save__pd_meas.counts_container
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
 
 save_
@@ -3448,7 +3448,7 @@ save_
 save__pd_meas.counts_monitor
 
     _definition.id               '_pd_meas.counts_monitor'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_counts_monitor' 
@@ -3477,7 +3477,7 @@ save__pd_meas.counts_monitor
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
 
 save_
@@ -3486,7 +3486,7 @@ save_
 save__pd_meas.counts_total
 
     _definition.id               '_pd_meas.counts_total'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_counts_total' 
@@ -3516,7 +3516,7 @@ save__pd_meas.counts_total
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
 
 save_
@@ -3760,7 +3760,7 @@ save_
 save__pd_meas.step_count_time
 
     _definition.id               '_pd_meas.step_count_time'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_step_count_time' 
@@ -3775,7 +3775,7 @@ save__pd_meas.step_count_time
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
     _units.code                             seconds
 
@@ -3784,7 +3784,7 @@ save_
 save__pd_meas.time_of_flight
 
     _definition.id               '_pd_meas.time_of_flight'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_meas_time_of_flight' 
@@ -3800,7 +3800,7 @@ save__pd_meas.time_of_flight
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           0:
     _units.code                             microseconds
 
@@ -4581,7 +4581,7 @@ save_
 save__pd_proc.number_of_points
 
     _definition.id               '_pd_proc.number_of_points'
-    _definition.update           2014-06-20
+    _definition.update           2019-09-25
     loop_
       _alias.definition_id
           '_pd_proc_number_of_points' 
@@ -4595,7 +4595,7 @@ save__pd_proc.number_of_points
     _type.purpose                Number
     _type.source                 Derived
     _type.container              Single
-    _type.contents               Count
+    _type.contents               Integer
     _enumeration.range           1:
 
 save_
@@ -6126,4 +6126,10 @@ loop_
 ;
      Added definition for _refln.F_meas after consultation with
      PD DMG. (James Hester)
+;
+         2.4.1    2019-09-25
+;
+     Changed the content type of multiple data items from 'Count'
+     to 'Integer' and assigned the appropriate enumeration range
+     if needed.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -1870,7 +1870,7 @@ save_type.contents
 
     _definition.id               '_type.contents'
     _definition.class            Attribute
-    _definition.update           2019-04-01
+    _definition.update           2019-09-25
     _description.text
 ;
 
@@ -1928,8 +1928,8 @@ save_type.contents
                              placed within bounding square brackets. Empty
                              square brackets represent a list of unknown size'''
               Range         'inclusive range of numerical values min:max'
-              Count         'unsigned integer number'
-              Index         'unsigned non-zero integer number'
+              Count         'unsigned integer number (deprecated)'
+              Index         'unsigned non-zero integer number (deprecated)'
               Integer       'positive or negative integer number'
               Real          'floating-point real number'
               Imag          'floating-point imaginary number'
@@ -2711,4 +2711,6 @@ Removed 'Measured' as a state for type.source
 
    Changed the content type of the _loop.level data item from
    'Index' to 'Integer'.
+
+   Deprecated the 'Index' and 'Count' content types.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          3.14.0
-    _dictionary.date             2019-07-25
+    _dictionary.date             2019-09-25
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/ddl.dic
     _dictionary.ddl_conformance  3.14.0
@@ -1650,7 +1650,7 @@ save_loop.level
 
     _definition.id               '_loop.level'
     _definition.class            Attribute
-    _definition.update           2012-05-07
+    _definition.update           2019-09-25
     _description.text
 ;
      Specifies the level of the loop structure in which a defined
@@ -1661,7 +1661,7 @@ save_loop.level
     _type.purpose                Number
     _type.source                 Assigned
     _type.container              Single
-    _type.contents               Index
+    _type.contents               Integer
     _enumeration.default         1
     _enumeration.range           1:
 
@@ -2692,7 +2692,7 @@ Removed 'Measured' as a state for type.source
    Added 'Implied' container type to allow examples and defaults to adjust
    to the item being defined. Changed relevant attribute definitions. (JRH)
 ;
-         3.14.0    2019-07-25
+         3.14.0    2019-09-25
 ;
    Updated the description of the _description_example.case data item.
 
@@ -2708,4 +2708,7 @@ Removed 'Measured' as a state for type.source
    Changed the purpose of a dREL method in the definition of the
    _dictionary_valid.application data item from 'Definition' to
    'Evaluation'.
+
+   Changed the content type of the _loop.level data item from
+   'Index' to 'Integer'.
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -10,7 +10,7 @@ data_TEMPL_ATTR
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.09
-    _dictionary.date             2019-04-03
+    _dictionary.date             2019-09-25
     _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
     _dictionary.ddl_conformance  3.14.0
     _description.text

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -751,7 +751,7 @@ save_diffr_angle
 
 save_diffr_counts
 
-    _definition.update           2012-10-16
+    _definition.update           2019-09-25
     _description.text
 ;
      The set of data items which specify the diffractometer counts.
@@ -762,7 +762,7 @@ save_diffr_counts
     _type.purpose                Measurand
     _type.source                 Recorded
     _type.container              Single 
-    _type.contents               Count 
+    _type.contents               Integer
     _enumeration.range           0:
     _units.code                  none
      save_
@@ -906,11 +906,14 @@ save_display_colour
    Added attribute save frame "ms_index"
    Added attribute save frame "matrix_w"
 ;
-      1.4.09  2019-04-03
+      1.4.09  2019-09-25
 ;
-   Change the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
+   Changed the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
    save frame.
 
    Removed the '_name.linked_item_id' data item from the 'atom_site_label'
    save frame.
+
+   Changed the data type in the 'diffr_counts' save frame from 'Count' to
+   'Integer'.
 ;


### PR DESCRIPTION
This PR implements changes outlined in issue #150.

The types were marked as deprecated in the ``type.contents`` definitions by simply adding a '(deprecated)' string to their human-readable descriptions. Please modify accordingly if this is insufficient.