### PR TITLE
Update the definition of the 'Uri' content type

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          4.0.1
-    _dictionary.date             2021-02-03
+    _dictionary.date             2021-02-27
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance  4.0.1
@@ -1596,7 +1596,7 @@ save_type.contents
 
     _definition.id               '_type.contents'
     _definition.class            Attribute
-    _definition.update           2019-09-25
+    _definition.update           2021-02-27
     _description.text
 ;
 
@@ -1641,10 +1641,10 @@ save_type.contents
                              characters or underscore'''
               Tag         '''case-insensitive CIF2 character sequence with leading 
                              underscore and no ASCII whitespace'''
-              Uri           'A Uniform Resource Identifier per RFC 3986'
+              Uri           'Uniform Resource Identifier reference as defined in RFC 3986 Section 4.1'
               Date          'ISO standard date format <yyyy>-<mm>-<dd>. Use DateTime for all new dictionaries'
               DateTime
-            'A timestamp. Text formats must use date-time or full-date productions of RFC3339 ABNF'
+            'A timestamp. Text formats must use date-time or full-date productions of RFC 3339 ABNF'
               Version       'version digit string of the form <major>.<version>.<update>'
               Dimension   '''Size of an Array/Matrix/List expressed as a text
                              string. The text string itself consists of zero
@@ -2446,11 +2446,14 @@ Removed 'Measured' as a state for type.source
    Removed CATEGORY category and category.key_id
    Removed 'Index' and 'Count' content types
 ;
-         4.0.1     2021-02-03
+         4.0.1     2021-02-27
 ;
    Clarified use of 'SU' data items.
 
    Updated the _import_details.single_index data item description
    to explicitly state that the 'file' index can refer not only to
    URI, but also to URI reference values.
+
+   Updated the definition of the 'Uri' content type to explicitly state
+   that it allows URI-reference values.
 ;


### PR DESCRIPTION
This PR updates the definition of 'Uri' content type to explicitly state that it allows URI-reference values as discussed in issue #191. Please also note, that changes proposed in this PR require some additional minor changes to the description of the `_alias.dictionary_uri` data item to indicate whether it refers to an absolute URI or an URI reference (see issue #191 for a more detailed explanation).