### PR TITLE
Remove default units code

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.14
-_dictionary.date                        2020-08-13
+_dictionary.date                        2021-03-01
 _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
@@ -1105,8 +1105,8 @@ save_
 save_diffrn_orient_matrix.UBIJ
 
 _definition.id                          '_diffrn_orient_matrix.UBIJ'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The 3x3 matrix specifying the orientation of the crystal with
      respect to the diffractometer axes.
@@ -1118,10 +1118,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With  o  as  diffrn_orient_matrix
  
@@ -1238,8 +1239,8 @@ save_
 save_diffrn_orient_refln.hkl
 
 _definition.id                          '_diffrn_orient_refln.hkl'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Miller indices of a reflection used to define the orientation matrix.
 ;
@@ -1250,10 +1251,12 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
+
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a as diffrn_orient_refln
  
@@ -2008,8 +2011,8 @@ save_
 save_diffrn_refln.hkl
 
 _definition.id                          '_diffrn_refln.hkl'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Miller indices of a measured reflection. These need not match the
      _refln.hkl values if a transformation of the original measured
@@ -2022,6 +2025,7 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
@@ -2575,8 +2579,8 @@ save_
 save_diffrn_reflns.limit_max
 
 _definition.id                          '_diffrn_reflns.limit_max'
-_definition.update                      2013-01-15
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Maximum Miller indices of measured diffraction reflections.
 ;
@@ -2587,10 +2591,11 @@ _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With t as diffrn_reflns
  
@@ -2603,10 +2608,10 @@ save_
 save_diffrn_reflns.limit_min
 
 _definition.id                          '_diffrn_reflns.limit_min'
-_definition.update                      2013-01-15
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
-     Minimum Miller indices of meas.ued diffraction reflections.
+     Minimum Miller indices of measured diffraction reflections.
 ;
 _name.category_id                       diffrn_reflns
 _name.object_id                         limit_min
@@ -2615,10 +2620,11 @@ _type.source                            Assigned
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With t as diffrn_reflns
  
@@ -2633,9 +2639,9 @@ save_diffrn_reflns.number
 _definition.id                          '_diffrn_reflns.number'
 loop_
   _alias.definition_id
-         '_diffrn_reflns_number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_diffrn_reflns_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total number of measured intensities, excluding reflections that are
      classed as systematically absent arising from translational symmetry
@@ -2648,6 +2654,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -3030,9 +3037,9 @@ save_diffrn_reflns_class.number
 _definition.id                          '_diffrn_reflns_class.number'
 loop_
   _alias.definition_id
-         '_diffrn_reflns_class_number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_diffrn_reflns_class_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of measured intensities for a reflection class, excluding
      the systematic absences arising from centring translations.
@@ -3044,6 +3051,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -3198,8 +3206,8 @@ save_
 save_diffrn_reflns_transf_matrix.TIJ
 
 _definition.id                          '_diffrn_reflns_transf_matrix.TIJ'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Elements of the matrix used to transform the diffraction reflection
      indices _diffrn_refln.hkl into the _refln.hkl indices.
@@ -3214,10 +3222,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With t as diffrn_reflns_transf_matrix
  
@@ -3669,10 +3678,10 @@ save_diffrn_standard.interval_count
 _definition.id                          '_diffrn_standard.interval_count'
 loop_
   _alias.definition_id
-         '_diffrn_standards_interval_count'      
-         '_diffrn_standards.interval_count' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_diffrn_standards_interval_count'
+         '_diffrn_standards.interval_count'
+_definition.update                      2021-03-01
+_description.text
 ;
      Reflection count between the standard reflection measurements.
 ;
@@ -3683,6 +3692,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -3716,10 +3726,10 @@ save_diffrn_standard.number
 _definition.id                          '_diffrn_standard.number'
 loop_
   _alias.definition_id
-         '_diffrn_standards_number'    
-         '_diffrn_standards.number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_diffrn_standards_number'
+         '_diffrn_standards.number'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of unique standard reflections used in measurements.
 ;
@@ -3730,6 +3740,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -3815,8 +3826,8 @@ save_
 save_diffrn_standard_refln.hkl
 
 _definition.id                          '_diffrn_standard_refln.hkl'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Miller indices of a standard reflection.
 ;
@@ -3827,10 +3838,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With d as diffrn_standard_refln
  
@@ -4345,8 +4357,8 @@ save_
 save_refln.fom
 
 _definition.id                          '_refln.fom'
-_definition.update                      2014-06-12
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The figure of merit m for this reflection.
  
@@ -4364,6 +4376,7 @@ _type.purpose                           Number
 _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real
+_units.code                             none
 
 save_
 
@@ -4426,8 +4439,8 @@ save_
 save_refln.hkl
 
 _definition.id                          '_refln.hkl'
-_definition.update                      2012-11-26
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The Miller indices as a reciprocal space vector.
 ;
@@ -4438,10 +4451,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With r  as  refln
  
@@ -4798,9 +4812,9 @@ save_refln.symmetry_epsilon
 _definition.id                          '_refln.symmetry_epsilon'
 loop_
   _alias.definition_id
-         '_refln_symmetry_epsilon' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refln_symmetry_epsilon'
+_definition.update                      2021-03-01
+_description.text
 ;
      The symmetry reinforcement factor corresponding to the number of
      times the reflection indices are generated identically from the
@@ -4813,6 +4827,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:48
+_units.code                             none
 
 save_
 
@@ -4822,9 +4837,9 @@ save_refln.symmetry_multiplicity
 _definition.id                          '_refln.symmetry_multiplicity'
 loop_
   _alias.definition_id
-         '_refln_symmetry_multiplicity' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refln_symmetry_multiplicity'
+_definition.update                      2021-03-01
+_description.text
 ;
      The number of reflections symmetry-equivalent under the Laue
      symmetry to the present reflection. In the Laue symmetry, Friedel
@@ -4839,6 +4854,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:48
+_units.code                             none
 
 save_
 
@@ -5241,12 +5257,12 @@ save_reflns.number_gt
 _definition.id                          '_reflns.number_gt'
 loop_
   _alias.definition_id
-         '_reflns_number_gt'           
-         '_reflns_number_observed'     
-         '_reflns_number_obs'          
+         '_reflns_number_gt'
+         '_reflns_number_observed'
+         '_reflns_number_obs'
          '_reflns.number_obs' 
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
      are significantly intense (see _reflns.threshold_expression). It may
@@ -5261,6 +5277,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -5270,11 +5287,11 @@ save_reflns.number_total
 _definition.id                          '_reflns.number_total'
 loop_
   _alias.definition_id
-         '_reflns_number_total'        
-         '_reflns_number_all'          
-         '_reflns.number_all' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_number_total'
+         '_reflns_number_all'
+         '_reflns.number_all'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of reflections in the REFLN set (not the DIFFRN_REFLN set). It may
      include Friedel equivalent reflections (i.e. those which are equivalent
@@ -5288,6 +5305,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -5466,10 +5484,10 @@ save_reflns_class.number_gt
 _definition.id                          '_reflns_class.number_gt'
 loop_
   _alias.definition_id
-         '_reflns_class_number_observed'         
-         '_reflns_class_number_gt' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_class_number_observed'
+         '_reflns_class_number_gt'
+_definition.update                      2021-03-01
+_description.text
 ;
      Count of reflections in this REFLN class (not the DIFFRN_REFLN set)
      which are significantly intense (see _reflns.threshold_expression). It may
@@ -5484,6 +5502,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -5493,9 +5512,9 @@ save_reflns_class.number_total
 _definition.id                          '_reflns_class.number_total'
 loop_
   _alias.definition_id
-         '_reflns_class_number_total' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_class_number_total'
+_definition.update                      2021-03-01
+_description.text
 ;
      Count of reflections in this REFLN class (not the DIFFRN_REFLN set). It
      may include Friedel equivalent reflections (those which are equivalent
@@ -5509,6 +5528,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -5961,9 +5981,9 @@ save_reflns_shell.number_measured_all
 _definition.id                          '_reflns_shell.number_measured_all'
 loop_
   _alias.definition_id
-         '_reflns_shell_number_measured_all' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_shell_number_measured_all'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total count of reflections measured for this resolution shell.
 ;
@@ -5974,6 +5994,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -5983,11 +6004,11 @@ save_reflns_shell.number_measured_gt
 _definition.id                          '_reflns_shell.number_measured_gt'
 loop_
   _alias.definition_id
-         '_reflns_shell_number_measured_obs'     
-         '_reflns_shell.number_measured_obs'     
-         '_reflns_shell_number_measured_gt' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_shell_number_measured_obs'
+         '_reflns_shell.number_measured_obs'
+         '_reflns_shell_number_measured_gt'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of reflections measured for this resolution shell which are
      significantly intense (see _reflns.threshold_expression).
@@ -5999,6 +6020,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -6008,10 +6030,10 @@ save_reflns_shell.number_possible
 _definition.id                          '_reflns_shell.number_possible'
 loop_
   _alias.definition_id
-         '_reflns_shell_number_possible'         
-         '_reflns_shell.number_possible_all' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_shell_number_possible'
+         '_reflns_shell.number_possible_all'
+_definition.update                      2021-03-01
+_description.text
 ;
      Count of symmetry-unique reflections possible in this reflection shell.
 ;
@@ -6022,6 +6044,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -6031,9 +6054,9 @@ save_reflns_shell.number_unique_all
 _definition.id                          '_reflns_shell.number_unique_all'
 loop_
   _alias.definition_id
-         '_reflns_shell_number_unique_all' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_shell_number_unique_all'
+_definition.update                      2021-03-01
+_description.text
 ;
      Count of symmetry-unique reflections present in this reflection shell.
 ;
@@ -6044,6 +6067,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -6053,11 +6077,11 @@ save_reflns_shell.number_unique_gt
 _definition.id                          '_reflns_shell.number_unique_gt'
 loop_
   _alias.definition_id
-         '_reflns_shell_number_unique_gt'        
-         '_reflns_shell_number_unique_obs'       
-         '_reflns_shell.number_unique_obs' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_reflns_shell_number_unique_gt'
+         '_reflns_shell_number_unique_obs'
+         '_reflns_shell.number_unique_obs'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of symmetry-unique reflections present in this reflection shell
      which are significantly intense (see _reflns.threshold_expression).
@@ -6069,6 +6093,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -6267,9 +6292,9 @@ save_exptl.crystals_number
 _definition.id                          '_exptl.crystals_number'
 loop_
   _alias.definition_id
-         '_exptl_crystals_number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_exptl_crystals_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total number of crystals used in the measurement of intensities.
 ;
@@ -6280,6 +6305,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -6474,9 +6500,9 @@ save_cell.formula_units_Z
 _definition.id                          '_cell.formula_units_Z'
 loop_
   _alias.definition_id
-         '_cell_formula_units_Z' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_cell_formula_units_Z'
+_definition.update                      2021-03-01
+_description.text
 ;
      The number of the formula units in the unit cell as specified
      by _chemical_formula.structural, _chemical_formula.moiety or
@@ -6489,6 +6515,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -6900,9 +6927,9 @@ save_cell_measurement.reflns_used
 _definition.id                          '_cell_measurement.reflns_used'
 loop_
   _alias.definition_id
-         '_cell_measurement_reflns_used' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_cell_measurement_reflns_used'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total number of reflections used to determine the unit cell.
      The reflections may be specified as cell_measurement_refln items.
@@ -6914,6 +6941,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      3:
+_units.code                             none
 
 save_
 
@@ -7068,8 +7096,8 @@ save_
 save_cell_measurement_refln.hkl
 
 _definition.id                          '_cell_measurement_refln.hkl'
-_definition.update                      2012-11-22
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Miller indices of a reflection used to measure the unit cell.
 ;
@@ -7080,10 +7108,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With c  as  cell_measurement_refln
  
@@ -8601,9 +8630,9 @@ save_chemical_conn_atom.charge
 _definition.id                          '_chemical_conn_atom.charge'
 loop_
   _alias.definition_id
-         '_chemical_conn_atom_charge' 
-_definition.update                      2012-11-22
-_description.text                       
+         '_chemical_conn_atom_charge'
+_definition.update                      2021-03-01
+_description.text
 ;
      The net integer charge assigned to this atom. This is the
      formal charge assignment normally found in chemical diagrams.
@@ -8615,6 +8644,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      -6:6
+_units.code                             none
 
 save_
 
@@ -8672,9 +8702,9 @@ save_chemical_conn_atom.NCA
 _definition.id                          '_chemical_conn_atom.NCA'
 loop_
   _alias.definition_id
-         '_chemical_conn_atom_NCA' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_chemical_conn_atom_NCA'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total number of connected atoms excluding terminal hydrogen atoms.
 ;
@@ -8685,6 +8715,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -8694,9 +8725,9 @@ save_chemical_conn_atom.NH
 _definition.id                          '_chemical_conn_atom.NH'
 loop_
   _alias.definition_id
-         '_chemical_conn_atom_NH' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_chemical_conn_atom_NH'
+_definition.update                      2021-03-01
+_description.text
 ;
      Total number of hydrogen atoms attached to this atom,
      regardless of whether they are included in the refinement or
@@ -8711,6 +8742,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -8720,9 +8752,9 @@ save_chemical_conn_atom.number
 _definition.id                          '_chemical_conn_atom.number'
 loop_
   _alias.definition_id
-         '_chemical_conn_atom_number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_chemical_conn_atom_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      The chemical sequence number to be associated with this atom.
 ;
@@ -8733,6 +8765,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -8792,10 +8825,10 @@ save_chemical_conn_bond.atom_1
 _definition.id                          '_chemical_conn_bond.atom_1'
 loop_
   _alias.definition_id
-         '_chemical_conn_bond_atom_1'  
-         '_chem_comp_bond.atom_id_1' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_chemical_conn_bond_atom_1'
+         '_chem_comp_bond.atom_id_1'
+_definition.update                      2021-03-01
+_description.text
 ;
      Index id of first atom in a bond connecting two atom sites.
 ;
@@ -8807,6 +8840,7 @@ _type.source                            Related
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -8816,10 +8850,10 @@ save_chemical_conn_bond.atom_2
 _definition.id                          '_chemical_conn_bond.atom_2'
 loop_
   _alias.definition_id
-         '_chemical_conn_bond_atom_2'  
-         '_chem_comp_bond.atom_id_2' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_chemical_conn_bond_atom_2'
+         '_chem_comp_bond.atom_id_2'
+_definition.update                      2021-03-01
+_description.text
 ;
      Index id of second atom in a bond connecting two atom sites.
 ;
@@ -8831,6 +8865,7 @@ _type.source                            Related
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -10130,8 +10165,8 @@ save_
 save_exptl_crystal_face.hkl
 
 _definition.id                          '_exptl_crystal_face.hkl'
-_definition.update                      2012-11-22
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Miller indices of the crystal face.
 ;
@@ -10142,10 +10177,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With f as exptl_crystal_face
  
@@ -10425,7 +10461,7 @@ loop_
          '_space_group_IT_number'
          '_symmetry.Int_Tables_number'
          '_symmetry_Int_Tables_number'
-_definition.update                      2016-05-09
+_definition.update                      2021-03-01
 _description.text
 ;
      The number as assigned in International Tables for Crystallography
@@ -10441,6 +10477,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:230
+_units.code                             none
 
 save_
 
@@ -10467,8 +10504,8 @@ save_space_group.Laue_class
 save_space_group.multiplicity
 
 _definition.id                          '_space_group.multiplicity'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of unique symmetry elements in the space group.
 ;
@@ -10479,10 +10516,11 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:192
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      n =  0
  
@@ -10903,8 +10941,8 @@ loop_
          '_space_group_symop_id'
          '_symmetry_equiv.pos_site_id'
          '_symmetry_equiv_pos_site_id'
-_definition.update                      2019-09-25
-_description.text 
+_definition.update                      2021-03-01
+_description.text
 ;
      Index identifying each entry in the _space_group_symop.operation_xyz
      list. It is normally the sequence number of the entry in that
@@ -10921,6 +10959,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
@@ -11034,8 +11073,8 @@ save_
 save_space_group_symop.RT
 
 _definition.id                          '_space_group_symop.RT'
-_definition.update                      2016-05-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The TRANSPOSE of the symmetry rotation matrix representing the point
      group opertions of the space group
@@ -11051,10 +11090,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
         _space_group_symop.RT =  Transpose (_space_group_symop.R)
 ; 
@@ -11065,8 +11105,8 @@ save_
 save_space_group_symop.Seitz_matrix
 
 _definition.id                          '_space_group_symop.Seitz_matrix'
-_definition.update                      2016-05-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      A matrix containing the symmetry operations of a space group
      in 4x4 Seitz format.
@@ -11083,10 +11123,12 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[4,4]'
+_units.code                             none
+
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
    _space_group_symop.Seitz_matrix =  SeitzFromJones (_space_group_symop.operation_xyz)
 ; 
@@ -11097,8 +11139,8 @@ save_
 save_space_group_symop.T
 
 _definition.id                          '_space_group_symop.T'
-_definition.update                      2016-05-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      A vector containing the symmetry translation operations of a space group.
 ;
@@ -11109,10 +11151,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
                        sm =  _space_group_symop.Seitz_matrix
  
@@ -11211,7 +11254,7 @@ save_space_group_Wyckoff.letter
 
 save_space_group_Wyckoff.multiplicity
     _definition.id             '_space_group_Wyckoff.multiplicity'
-    _definition.update          2014-06-12
+    _definition.update          2021-03-01
     _description.text
 ;
      The multiplicity of this Wyckoff position as given in
@@ -11228,6 +11271,7 @@ save_space_group_Wyckoff.multiplicity
     _type.source                Assigned
     _type.container             Single
     _type.contents              Integer
+    _units.code                 none
      save_
 
 save_space_group_Wyckoff.site_symmetry
@@ -11360,8 +11404,8 @@ save_
 save_function.Closest
 
 _definition.id                          '_function.Closest'
-_definition.update                      2019-09-30
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The function
                    d  =  Closest( v, w )
@@ -11377,10 +11421,12 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
+
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      Function Closest( v :[Matrix, Real],   # coord vector to be cell translated
                        w :[Matrix, Real]) { # target vector
@@ -11395,8 +11441,8 @@ save_
 save_function.SeitzFromJones
 
 _definition.id                          '_function.SeitzFromJones'
-_definition.update                      2013-04-24
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The function
                    s  =  SeitzFromJones( j )
@@ -11411,10 +11457,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[4,4]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      Function SeitzFromJones( j :[Single, Text])  { # Jones symmetry notation
  
@@ -11460,8 +11507,8 @@ save_
 save_function.SymEquiv
 
 _definition.id                          '_function.SymEquiv'
-_definition.update                      2016-05-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The function
                      xyz' =  SymEquiv( symop, xyz )
@@ -11477,10 +11524,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      Function SymEquiv( c :[Single, Symop],    # symop string n_pqr
                         x :[Matrix, Real]   ){  # fract coordinate vector
@@ -11496,8 +11544,8 @@ save_
 save_function.SymKey
 
 _definition.id                          '_function.SymKey'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The function
                    m  =  SymKey( s )
@@ -11512,10 +11560,11 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:192
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      Function SymKey( s :[Single, Symop])  {  # symop string
  
@@ -11532,8 +11581,8 @@ save_
 save_function.SymLat
 
 _definition.id                          '_function.SymLat'
-_definition.update                      2013-03-10
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The function
                    v  =  SymLat( s )
@@ -11548,10 +11597,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      Function SymLat( s :[Single, Symop])  {  # symop string
  
@@ -12212,9 +12262,9 @@ save_geom_bond.multiplicity
 _definition.id                          '_geom_bond.multiplicity'
 loop_
   _alias.definition_id
-         '_geom_bond_multiplicity' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_geom_bond_multiplicity'
+_definition.update                      2021-03-01
+_description.text
 ;
      The number of times the given bond appears in the environment
      of the atoms labelled _geom_bond.atom_site_label_1. In cases
@@ -12229,6 +12279,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -13374,8 +13425,8 @@ save_
 save_model_site.adp_eigen_system
 
 _definition.id                          '_model_site.adp_eigen_system'
-_definition.update                      2012-11-22
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The set of three adp eigenvales and associated eigenvectors
      in the form of 4 element List. Each list has the form
@@ -13394,10 +13445,11 @@ _type.source                            Derived
 _type.container                         Array
 _type.contents                          Real
 _type.dimension                         '[3,4]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
       A    =  _cell.orthogonal_matrix
       U    =  A * _model_site.adp_matrix_beta * Transpose(A) /(2*Pi**2)
@@ -13412,8 +13464,8 @@ save_
 save_model_site.adp_matrix_beta
 
 _definition.id                          '_model_site.adp_matrix_beta'
-_definition.update                      2013-03-08
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Matrix of dimensionless anisotropic atomic displacement parameters.
 ;
@@ -13424,10 +13476,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      with m as model_site
      a = atom_site[m.label]
@@ -13442,8 +13495,8 @@ save_
 save_model_site.Cartn_xyz
 
 _definition.id                          '_model_site.Cartn_xyz'
-_definition.update                      2012-11-22
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Vector of Cartesian (orthogonal angstrom) atom site coordinates.
 ;
@@ -13454,10 +13507,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With  m  as  model_site
  
@@ -13493,8 +13547,8 @@ save_
 save_model_site.fract_xyz
 
 _definition.id                          '_model_site.fract_xyz'
-_definition.update                      2012-12-14
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Vector of fractional atom site coordinates.
 ;
@@ -13505,10 +13559,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
         With  m  as  model_site
  
@@ -13539,8 +13594,8 @@ save_
 save_model_site.index
 
 _definition.id                          '_model_site.index'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Index number of an atomic site in the connected molecule.
 ;
@@ -13551,6 +13606,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -13577,8 +13633,8 @@ save_
 save_model_site.mole_index
 
 _definition.id                          '_model_site.mole_index'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Index number of a distinct molecules in the cell, not related by
      symmetry.
@@ -13590,6 +13646,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 
 save_
@@ -13755,8 +13812,8 @@ _definition.id                          '_valence_param.atom_1_valence'
 loop_
   _alias.definition_id
          '_valence_param_atom_1_valence' 
-_definition.update                      2012-12-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The formal charge of the atom 1 whose bond
      valence parameters are given in this category.
@@ -13768,6 +13825,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real
 _enumeration.range                      0.:
+_units.code                             none
 
 save_
 
@@ -13801,8 +13859,8 @@ _definition.id                          '_valence_param.atom_2_valence'
 loop_
   _alias.definition_id
          '_valence_param_atom_2_valence' 
-_definition.update                      2012-12-13
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The formal charge of the atom 2 whose bond
      valence parameters are given in this category.
@@ -13814,6 +13872,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Real
 _enumeration.range                      0.:
+_units.code                             none
 
 save_
 
@@ -13868,9 +13927,9 @@ save_valence_param.id
 _definition.id                          '_valence_param.id'
 loop_
   _alias.definition_id
-         '_valence_param_id' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_valence_param_id'
+_definition.update                      2021-03-01
+_description.text
 ;
      Unique index loop number of the valence parameter loop.
 ;
@@ -13881,6 +13940,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -15373,9 +15433,9 @@ save_citation.journal_issue
 _definition.id                          '_citation.journal_issue'
 loop_
   _alias.definition_id
-         '_citation_journal_issue' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_citation_journal_issue'
+_definition.update                      2021-03-01
+_description.text
 ;
      Issue number of the journal cited;  relevant for articles.
 ;
@@ -15386,6 +15446,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 loop_
   _description_example.case
          2 
@@ -15398,9 +15459,9 @@ save_citation.journal_volume
 _definition.id                          '_citation.journal_volume'
 loop_
   _alias.definition_id
-         '_citation_journal_volume' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_citation_journal_volume'
+_definition.update                      2021-03-01
+_description.text
 ;
      Volume number of the journal cited;  relevant for articles.
 ;
@@ -15411,6 +15472,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 loop_
   _description_example.case
          174 
@@ -15673,9 +15735,9 @@ save_citation_author.ordinal
 _definition.id                          '_citation_author.ordinal'
 loop_
   _alias.definition_id
-         '_citation_author_ordinal' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_citation_author_ordinal'
+_definition.update                      2021-03-01
+_description.text
 ;
      Ordinal code specifies the order of the author's name in the list
      of authors of the citation.
@@ -15687,6 +15749,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -15796,9 +15859,9 @@ save_citation_editor.ordinal
 _definition.id                          '_citation_editor.ordinal'
 loop_
   _alias.definition_id
-         '_citation_editor_ordinal' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_citation_editor_ordinal'
+_definition.update                      2021-03-01
+_description.text
 ;
      This data item defines the order of the editor's name in the
      list of editors of a citation.
@@ -15810,6 +15873,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -16576,8 +16640,8 @@ save_
 save_display_colour.RGB
 
 _definition.id                          '_display_colour.RGB'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The red-green-blue intensities, bases 256, for each colour code.
 ;
@@ -16588,10 +16652,11 @@ _type.source                            Derived
 _type.container                         List
 _type.contents                          Integer
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With c  as  display_colour
  
@@ -16856,9 +16921,9 @@ save_journal.suppl_publ_pages
 _definition.id                          '_journal.suppl_publ_pages'
 loop_
   _alias.definition_id
-         '_journal_suppl_publ_pages' 
-_definition.update                      2012-12-11
-_description.text                       
+         '_journal_suppl_publ_pages'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of pages in the supplementary publication.
 ;
@@ -16869,6 +16934,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -16896,9 +16962,9 @@ save_journal.volume
 _definition.id                          '_journal.volume'
 loop_
   _alias.definition_id
-         '_journal_volume' 
-_definition.update                      2012-12-11
-_description.text                       
+         '_journal_volume'
+_definition.update                      2021-03-01
+_description.text
 ;
      Volume number of the publication.
 ;
@@ -16909,6 +16975,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -16918,9 +16985,9 @@ save_journal.year
 _definition.id                          '_journal.year'
 loop_
   _alias.definition_id
-         '_journal_year' 
-_definition.update                      2012-12-11
-_description.text                       
+         '_journal_year'
+_definition.update                      2021-03-01
+_description.text
 ;
      Year of the publication.
 ;
@@ -16931,6 +16998,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1700:2100
+_units.code                             none
 
 save_
 
@@ -17366,9 +17434,9 @@ save_journal_index.id
 _definition.id                          '_journal_index.id'
 loop_
   _alias.definition_id
-         '_journal_index_id' 
-_definition.update                      2013-01-23
-_description.text                       
+         '_journal_index_id'
+_definition.update                      2021-03-01
+_description.text
 ;
      Index number identifier of the JOURNAL_INDEX category.
 ;
@@ -17379,6 +17447,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -19088,9 +19157,9 @@ save_atom_site.attached_hydrogens
 _definition.id                          '_atom_site.attached_hydrogens'
 loop_
   _alias.definition_id
-         '_atom_site_attached_hydrogens' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_atom_site_attached_hydrogens'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of hydrogen atoms attached to the atom at this site
      excluding any H atoms for which coordinates (measured or calculated)
@@ -19103,6 +19172,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:8
+_units.code                             none
 loop_
   _description_example.case
   _description_example.detail
@@ -19320,8 +19390,8 @@ save_
 save_atom_site.Cartn_xyz
 
 _definition.id                          '_atom_site.Cartn_xyz'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Vector of Cartesian (orthogonal angstrom) atom site coordinates.
 ;
@@ -19332,10 +19402,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
     With a  as  atom_site
  
@@ -19406,9 +19477,9 @@ save_atom_site.chemical_conn_number
 _definition.id                          '_atom_site.chemical_conn_number'
 loop_
   _alias.definition_id
-         '_atom_site_chemical_conn_number' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_atom_site_chemical_conn_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      This number links an atom site to the chemical connectivity list.
      It must match a number specified by _chemical_conn_atom.number.
@@ -19421,6 +19492,7 @@ _type.source                            Related
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -19574,8 +19646,8 @@ save_
 save_atom_site.fract_xyz
 
 _definition.id                          '_atom_site.fract_xyz'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Vector of atom site coordinates projected onto the crystal unit
      cell as fractions of the cell lengths.
@@ -19587,10 +19659,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a  as  atom_site
  
@@ -19985,11 +20058,11 @@ save_atom_site.site_symmetry_multiplicity
 _definition.id                          '_atom_site.site_symmetry_multiplicity'
 loop_
   _alias.definition_id
-         '_atom_site_site_symmetry_multiplicity'           
-         '_atom_site_symmetry_multiplicity'      
-         '_atom_site.symmetry_multiplicity' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_atom_site_site_symmetry_multiplicity'
+         '_atom_site_symmetry_multiplicity'
+         '_atom_site.symmetry_multiplicity'
+_definition.update                      2021-03-01
+_description.text
 ;
      The number of different sites that are generated by the
      application of the space-group symmetry to the coordinates
@@ -20006,10 +20079,11 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:192
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With  a  as  atom_site
  
@@ -20032,9 +20106,9 @@ save_atom_site.site_symmetry_order
 _definition.id                          '_atom_site.site_symmetry_order'
 loop_
   _alias.definition_id
-         '_atom_site_site_symmetry_order' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_atom_site_site_symmetry_order'
+_definition.update                      2021-03-01
+_description.text
 ;
     The number of times application of the crystallographic symmetry
     to the coordinates for this site generates the same coordinates.
@@ -20050,6 +20124,7 @@ _type.source                            Derived
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:48
+_units.code                             none
 
 save_
 
@@ -20057,8 +20132,8 @@ save_
 save_atom_site.tensor_beta
 
 _definition.id                          '_atom_site.tensor_beta'
-_definition.update                      2013-04-28
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The symmetric anisotropic atomic displacement tensor beta[I,J]
      appears in a structure factor expression as:
@@ -20077,10 +20152,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With  a  as  atom_site
  
@@ -20521,8 +20597,8 @@ save_
 save_atom_site_aniso.matrix_B
 
 _definition.id                          '_atom_site_aniso.matrix_B'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The symmetric anisotropic atomic displacement matrix B.
 ;
@@ -20533,10 +20609,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a as atom_site_aniso
  
@@ -20551,8 +20628,8 @@ save_
 save_atom_site_aniso.matrix_U
 
 _definition.id                          '_atom_site_aniso.matrix_U'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The symmetric anisotropic atomic displacement matrix U.
 ;
@@ -20563,10 +20640,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a as atom_site_aniso
  
@@ -21255,8 +21333,8 @@ save_
 save_atom_sites_Cartn_transform.matrix
 
 _definition.id                          '_atom_sites_Cartn_transform.matrix'
-_definition.update                      2012-12-11
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Matrix used to transform fractional coordinates in the ATOM_SITE
      category to Cartesian  coordinates. The axial alignments of this
@@ -21278,10 +21356,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a as atom_sites_Cartn_transform
  
@@ -21338,8 +21417,8 @@ save_
 save_atom_sites_Cartn_transform.vector
 
 _definition.id                          '_atom_sites_Cartn_transform.vector'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The 3x1 translation is used with _atom_sites_Cartn_transform.matrix
      used to transform fractional coordinates to Cartesian  coordinates.
@@ -21353,10 +21432,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With t as atom_sites_Cartn_transform
  
@@ -21540,8 +21620,8 @@ save_
 save_atom_sites_fract_transform.matrix
 
 _definition.id                          '_atom_sites_fract_transform.matrix'
-_definition.update                      2012-12-11
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Matrix used to transform fractional coordinates in the ATOM_SITE
      category to Cartesian  coordinates. The axial alignments of this
@@ -21563,10 +21643,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3,3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With a as atom_sites_fract_transform
  
@@ -21623,8 +21704,8 @@ save_
 save_atom_sites_fract_transform.vector
 
 _definition.id                          '_atom_sites_fract_transform.vector'
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      The 3x1 translation is used with _atom_sites_fract_transform.matrix
      used to transform Cartesian coordinates to fractional  coordinates.
@@ -21638,10 +21719,11 @@ _type.source                            Derived
 _type.container                         Matrix
 _type.contents                          Real
 _type.dimension                         '[3]'
+_units.code                             none
 loop_
   _method.purpose
   _method.expression
-         Evaluation          
+         Evaluation
 ;
      With t as atom_sites_fract_transform
  
@@ -21736,8 +21818,8 @@ save_
 save_atom_type.atomic_number
 
 _definition.id                          '_atom_type.atomic_number'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Atomic number of this atom type.
 ;
@@ -21748,6 +21830,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 _import.get [{'save':atomic_number  'file':templ_enum.cif}]
 _enumeration.def_index_id               '_atom_type.symbol'
 
@@ -21808,8 +21891,8 @@ save_
 save_atom_type.electron_count
 
 _definition.id                          '_atom_type.electron_count'
-_definition.update                      2019-09-25
-_description.text                       
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of electrons in this atom type.
 ;
@@ -21822,6 +21905,7 @@ _type.contents                          Integer
 _import.get [{'save':electron_count  'file':templ_enum.cif}]
 _enumeration.def_index_id               '_atom_type.symbol'
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -21917,9 +22001,9 @@ save_atom_type.oxidation_number
 _definition.id                          '_atom_type.oxidation_number'
 loop_
   _alias.definition_id
-         '_atom_type_oxidation_number' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_atom_type_oxidation_number'
+_definition.update                      2021-03-01
+_description.text
 ;
      Formal oxidation state of this atom type in the structure.
 ;
@@ -21930,6 +22014,7 @@ _type.source                            Assigned
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      -8:8
+_units.code                             none
 
 save_
 
@@ -22912,10 +22997,10 @@ save_refine_ls.abs_structure_Flack_su
 _definition.id                          '_refine_ls.abs_structure_Flack_su'
 loop_
   _alias.definition_id
-         '_refine_ls_abs_structure_Flack_su'     
-         '_refine.ls_abs_structure_Flack_esd' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_refine_ls_abs_structure_Flack_su'
+         '_refine.ls_abs_structure_Flack_esd'
+_definition.update                      2021-03-01
+_description.text
 ;
      Standard Uncertainty of the
      The measure of absolute structure as defined by Flack (1983).
@@ -22927,6 +23012,7 @@ _type.purpose                           SU
 _type.source                            Related
 _type.container                         Single
 _type.contents                          Real
+_units.code                             none
 
 save_
 
@@ -22965,10 +23051,10 @@ save_refine_ls.abs_structure_Rogers_su
 _definition.id                          '_refine_ls.abs_structure_Rogers_su'
 loop_
   _alias.definition_id
-         '_refine_ls_abs_structure_Rogers_su'    
-         '_refine.ls_abs_structure_Rogers_esd' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_refine_ls_abs_structure_Rogers_su'
+         '_refine.ls_abs_structure_Rogers_esd'
+_definition.update                      2021-03-01
+_description.text
 ;
      Standard Uncertainty of the
      The measure of absolute structure as defined by Rogers (1981).
@@ -22980,6 +23066,7 @@ _type.purpose                           SU
 _type.source                            Related
 _type.container                         Single
 _type.contents                          Real
+_units.code                             none
 
 save_
 
@@ -23544,10 +23631,10 @@ save_refine_ls.number_constraints
 _definition.id                          '_refine_ls.number_constraints'
 loop_
   _alias.definition_id
-         '_refine_ls_number_constraints'         
-         '_refine.ls_number_constraints' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refine_ls_number_constraints'
+         '_refine.ls_number_constraints'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of constrained (non-refined or dependent) parameters
      in the least-squares process. These may be due to symmetry or any
@@ -23562,6 +23649,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -23571,10 +23659,10 @@ save_refine_ls.number_parameters
 _definition.id                          '_refine_ls.number_parameters'
 loop_
   _alias.definition_id
-         '_refine_ls_number_parameters'          
-         '_refine.ls_number_parameters' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refine_ls_number_parameters'
+         '_refine.ls_number_parameters'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of parameters refined in the least-squares process. If
      possible this number should include the restrained parameters.
@@ -23592,6 +23680,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -23601,10 +23690,10 @@ save_refine_ls.number_reflns
 _definition.id                          '_refine_ls.number_reflns'
 loop_
   _alias.definition_id
-         '_refine_ls_number_reflns'    
-         '_refine.ls_number_reflns_all' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refine_ls_number_reflns'
+         '_refine.ls_number_reflns_all'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of unique reflections used in the least-squares refinement.
 ;
@@ -23615,6 +23704,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -23626,7 +23716,7 @@ loop_
   _alias.definition_id
          '_refine_ls_number_reflns_gt'
          '_refine.ls_number_reflns_obs'
-_definition.update                      2019-09-25
+_definition.update                      2021-03-01
 _description.text
 ;
      The number of reflections that satisfy the resolution limits
@@ -23641,6 +23731,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      1:
+_units.code                             none
 
 save_
 
@@ -23650,10 +23741,10 @@ save_refine_ls.number_restraints
 _definition.id                          '_refine_ls.number_restraints'
 loop_
   _alias.definition_id
-         '_refine_ls_number_restraints'          
-         '_refine.ls_number_restraints' 
-_definition.update                      2019-09-25
-_description.text                       
+         '_refine_ls_number_restraints'
+         '_refine.ls_number_restraints'
+_definition.update                      2021-03-01
+_description.text
 ;
      Number of restrained parameters in the least-squares refinement. These
      parameters do not directly dependent on another refined parameter. Often
@@ -23668,6 +23759,7 @@ _type.source                            Recorded
 _type.container                         Single
 _type.contents                          Integer
 _enumeration.range                      0:
+_units.code                             none
 
 save_
 
@@ -24545,9 +24637,12 @@ loop_
      Validation method for _space_group.crystal_system removed as it contained
      undefined dREL functions "throw" and "alert".
 ;
-     3.0.14     2020-08-13
+     3.0.14     2021-03-01
 ;
      Added opaque author identifiers to audit_author and publ_author as well
      as relevant linking identifiers to audit_contact_author and 
-     publ_contact_author. Added diffrn_measurement.specimen_attachment_type
+     publ_contact_author. Added diffrn_measurement.specimen_attachment_type.
+
+     Added the 'none' measurement units to the definitions of multiple
+     data items. 
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -22785,10 +22785,10 @@ save_refine_diff.density_max_su
 _definition.id                          '_refine_diff.density_max_su'
 loop_
   _alias.definition_id
-         '_refine_diff_density_max_su'           
-         '_refine.diff_density_max_esd' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_refine_diff_density_max_su'
+         '_refine.diff_density_max_esd'
+_definition.update                      2021-03-01
+_description.text
 ;
      Standard Uncertainty of the
      Maximum density value in a difference Fourier map.
@@ -22800,6 +22800,15 @@ _type.purpose                           SU
 _type.source                            Related
 _type.container                         Single
 _type.contents                          Real
+loop_
+  _method.purpose
+  _method.expression
+         Definition
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
 
 save_
 
@@ -22841,10 +22850,10 @@ save_refine_diff.density_min_su
 _definition.id                          '_refine_diff.density_min_su'
 loop_
   _alias.definition_id
-         '_refine_diff_density_min_su'           
-         '_refine.diff_density_min_esd' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_refine_diff_density_min_su'
+         '_refine.diff_density_min_esd'
+_definition.update                      2021-03-01
+_description.text
 ;
      Standard Uncertainty of the
      Miniumum density value in a difference Fourier map.
@@ -22856,6 +22865,15 @@ _type.purpose                           SU
 _type.source                            Related
 _type.container                         Single
 _type.contents                          Real
+loop_
+  _method.purpose
+  _method.expression
+         Definition
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
 
 save_
 
@@ -22902,10 +22920,10 @@ save_refine_diff.density_rms_su
 _definition.id                          '_refine_diff.density_rms_su'
 loop_
   _alias.definition_id
-         '_refine_diff_density_rms_su'           
-         '_refine.diff_density_rms_esd' 
-_definition.update                      2012-11-20
-_description.text                       
+         '_refine_diff_density_rms_su'
+         '_refine.diff_density_rms_esd'
+_definition.update                      2021-03-01
+_description.text
 ;
      Standard Uncertainty of the
      Root mean square density value in a difference Fourier map.
@@ -22917,6 +22935,15 @@ _type.purpose                           SU
 _type.source                            Related
 _type.container                         Single
 _type.contents                          Real
+loop_
+  _method.purpose
+  _method.expression
+         Definition
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
 
 save_
 
@@ -24644,5 +24671,9 @@ loop_
      publ_contact_author. Added diffrn_measurement.specimen_attachment_type.
 
      Added the 'none' measurement units to the definitions of multiple
-     data items. 
+     data items.
+
+     Added methods for determining the measurement units to the definitions
+     of the _refine_diff.density_min_su, _refine_diff.density_max_su and
+     _refine_diff.density_rms_su data items.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -1233,7 +1233,7 @@ save_
 save_import_details.order
     _definition.id               '_import_details.order'
     _definition.class            Attribute
-    _definition.update           2019-04-02
+    _definition.update           2021-02-28
     _description.text
 ;
      The order in which the import described by the referenced row should be
@@ -1245,6 +1245,7 @@ save_import_details.order
     _type.contents              Integer
     _type.source                Assigned
     _type.purpose               Encode
+    _units.code                 none
 
 save_
 
@@ -2454,4 +2455,7 @@ Removed 'Measured' as a state for type.source
    URI, but also to URI reference values.
 
    Removed the default enumeration value of the _units.code data item.
+
+   Added measurement units to the definition of the _import_details.order
+   data item.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          4.0.1
-    _dictionary.date             2021-02-03
+    _dictionary.date             2021-02-28
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance  4.0.1
@@ -1955,7 +1955,7 @@ save_units.code
 
     _definition.id               '_units.code'
     _definition.class            Attribute
-    _definition.update           2012-01-25
+    _definition.update           2021-02-28
     _description.text
 ;
      A code which identifies the units of measurement.
@@ -1966,7 +1966,6 @@ save_units.code
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Code
-    _enumeration.default         Arbitrary
 
     _import.get [{'save':units_code  'file':templ_enum.cif}]
 
@@ -2446,11 +2445,13 @@ Removed 'Measured' as a state for type.source
    Removed CATEGORY category and category.key_id
    Removed 'Index' and 'Count' content types
 ;
-         4.0.1     2021-02-03
+         4.0.1     2021-02-28
 ;
    Clarified use of 'SU' data items.
 
    Updated the _import_details.single_index data item description
    to explicitly state that the 'file' index can refer not only to
    URI, but also to URI reference values.
+
+   Removed the default enumeration value of the _units.code data item.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          4.0.1
-    _dictionary.date             2021-02-28
+    _dictionary.date             2021-03-01
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance  4.0.1
@@ -1233,7 +1233,7 @@ save_
 save_import_details.order
     _definition.id               '_import_details.order'
     _definition.class            Attribute
-    _definition.update           2021-02-28
+    _definition.update           2021-03-01
     _description.text
 ;
      The order in which the import described by the referenced row should be
@@ -1956,7 +1956,7 @@ save_units.code
 
     _definition.id               '_units.code'
     _definition.class            Attribute
-    _definition.update           2021-02-28
+    _definition.update           2021-03-01
     _description.text
 ;
      A code which identifies the units of measurement.
@@ -2446,7 +2446,7 @@ Removed 'Measured' as a state for type.source
    Removed CATEGORY category and category.key_id
    Removed 'Index' and 'Count' content types
 ;
-         4.0.1     2021-02-28
+         4.0.1     2021-03-01
 ;
    Clarified use of 'SU' data items.
 

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -9,8 +9,8 @@ data_TEMPL_ATTR
  
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
-    _dictionary.version          1.4.09
-    _dictionary.date             2019-09-25
+    _dictionary.version          1.4.10
+    _dictionary.date             2021-03-01
     _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
     _dictionary.ddl_conformance  3.14.0
     _description.text
@@ -87,7 +87,7 @@ save_atom_site_id
 
 save_rho_coeff
 
-    _definition.update           2014-06-20
+    _definition.update           2021-03-01
     _description.text
 ;
      Specifies a multipole population coefficientxs P(l,m) for
@@ -97,12 +97,13 @@ save_rho_coeff
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
+    _units.code                  none
      save_
 
 
 save_rho_kappa
 
-    _definition.update           2014-06-20
+    _definition.update           2021-03-01
     _description.text
 ;
       A radial function expansion-contraction coefficient
@@ -114,12 +115,13 @@ save_rho_kappa
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
+    _units.code                  none
      save_
 
 
 save_rho_slater
 
-    _definition.update           2014-06-20
+    _definition.update           2021-03-01
     _description.text
 ;
       Items used when the radial dependence of the valence
@@ -131,12 +133,13 @@ save_rho_slater
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
+    _units.code                  none
      save_
 
 
 save_matrix_pdb
 
-    _definition.update           2014-07-02
+    _definition.update           2021-03-01
     _description.text
 ;
      Element of the PDM ORIGX matrix or vector.
@@ -145,12 +148,13 @@ save_matrix_pdb
     _type.source                 Derived
     _type.container              Single
     _type.contents               Real
+    _units.code                  none
      save_
 
 
 save_matrix_w
 
-    _definition.update           2014-06-27
+    _definition.update           2021-03-01
     _description.text
 ;
      Element of the matrix W defined by van Smaalen (1991); (1995)
@@ -160,6 +164,7 @@ save_matrix_w
     _type.container              Single
     _type.contents               Real
     _name.category_id            cell_subsystem
+    _units.code                  none
      save_
 
 
@@ -181,7 +186,7 @@ save_ms_index
 
 save_index_limit_max
 
-    _definition.update           2014-06-27
+    _definition.update           2021-03-01
     _description.text
 ;
      Maximum value of the additional Miller indices appearing in 
@@ -191,12 +196,13 @@ save_index_limit_max
     _type.source                 Recorded
     _type.container              Single
     _type.contents               Integer
+    _units.code                  none
      save_
 
 
 save_index_limit_min
 
-    _definition.update           2014-06-27
+    _definition.update           2021-03-01
     _description.text
 ;
      Minimum value of the additional Miller indices appearing in 
@@ -206,6 +212,7 @@ save_index_limit_min
     _type.source                 Recorded
     _type.container              Single
     _type.contents               Integer
+    _units.code                  none
      save_
 
 
@@ -443,7 +450,7 @@ save_Cartn_matrix
 
 save_ncs_matrix_IJ      
 
-    _definition.update          2014-06-12
+    _definition.update          2021-03-01
     _description.text
 ;
      The [I][J] element of the 3x3 matrix component of a
@@ -453,12 +460,13 @@ save_ncs_matrix_IJ
     _type.source                Derived
     _type.container             Single
     _type.contents              Real
+    _units.code                 none
      save_
 
 
 save_rot_matrix_IJ
 
-    _definition.update          2014-06-12
+    _definition.update          2021-03-01
     _description.text
 ;
      The [I][J] element of the matrix used to rotate the subset of the
@@ -475,6 +483,7 @@ save_rot_matrix_IJ
     _type.source                Derived
     _type.container             Single
     _type.contents              Real
+    _units.code                 none
      save_
 
 
@@ -916,4 +925,10 @@ save_display_colour
 
    Changed the data type in the 'diffr_counts' save frame from 'Count' to
    'Integer'.
+;
+      1.4.10  2021-03-01
+;
+   Added the 'none' measurement units to the rho_coeff, rho_kappa, rho_slater,
+   matrix_pdb, matrix_w, index_limit_max, index_limit_min, ncs_matrix_IJ and
+   rot_matrix_IJ save frames.
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -928,7 +928,7 @@ save_display_colour
 ;
       1.4.10  2021-03-01
 ;
-   Added the 'none' measurement units to the rho_coeff, rho_kappa, rho_slater,
-   matrix_pdb, matrix_w, index_limit_max, index_limit_min, ncs_matrix_IJ and
-   rot_matrix_IJ save frames.
+   Added the 'none' measurement units to the 'rho_coeff', 'rho_kappa',
+   'rho_slater', 'matrix_pdb', 'matrix_w', 'index_limit_max', 'index_limit_min',
+   'ncs_matrix_IJ' and 'rot_matrix_IJ' save frames.
 ;


### PR DESCRIPTION
This PR solves issue #194 by removing the default value of the `_units.code` data item ('`arbitrary`') and adding the `none` units to the definitions of multiple dimensionless data items. The definitions of several `_refine_diff.density_*_su` data items were also modified by copying the dREL methods for measurement units resolution from the main items that they are linked to (`_refine_diff.density_*`).