### PR TITLE
Improve dictionary valid description

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          4.0.1
-    _dictionary.date             2021-02-28
+    _dictionary.date             2021-03-01
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance  4.0.1
@@ -754,7 +754,7 @@ save_DICTIONARY_VALID
     _definition.id               DICTIONARY_VALID
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2021-02-28
+    _definition.update           2021-03-01
     _description.text
 ;
      Data items which are used to specify the contents of definitions in
@@ -2447,7 +2447,7 @@ Removed 'Measured' as a state for type.source
    Removed CATEGORY category and category.key_id
    Removed 'Index' and 'Count' content types
 ;
-         4.0.1     2021-02-28
+         4.0.1     2021-03-01
 ;
    Clarified use of 'SU' data items.
 

--- a/ddl.dic
+++ b/ddl.dic
@@ -9,7 +9,7 @@ data_DDL_DIC
     _dictionary.title            DDL_DIC
     _dictionary.class            Reference
     _dictionary.version          4.0.1
-    _dictionary.date             2021-02-03
+    _dictionary.date             2021-02-28
     _dictionary.uri              
              https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance  4.0.1
@@ -754,12 +754,13 @@ save_DICTIONARY_VALID
     _definition.id               DICTIONARY_VALID
     _definition.scope            Category
     _definition.class            Loop
-    _definition.update           2013-09-08
+    _definition.update           2021-02-28
     _description.text
 ;
      Data items which are used to specify the contents of definitions in
      the dictionary in terms of the _definition.scope and the required
-     and prohibited attributes.
+     and prohibited attributes. Validation rules described by data items
+     in this category apply only to Reference and Instance dictionaries.
 ;
     _name.category_id            DICTIONARY
     _name.object_id              DICTIONARY_VALID
@@ -2446,11 +2447,14 @@ Removed 'Measured' as a state for type.source
    Removed CATEGORY category and category.key_id
    Removed 'Index' and 'Count' content types
 ;
-         4.0.1     2021-02-03
+         4.0.1     2021-02-28
 ;
    Clarified use of 'SU' data items.
 
    Updated the _import_details.single_index data item description
    to explicitly state that the 'file' index can refer not only to
    URI, but also to URI reference values.
+
+   Updated the DICTIONARY_VALID category description to explicitly state
+   that the rules only apply to Reference and Instance dictionaries.
 ;


### PR DESCRIPTION
This PR improves the definition of the DICTIONARY_VALID category by explicitly stating that the validation rules described by data items in this category apply only to Reference and Instance dictionaries.