### PR TITLE
Fix misspelt data names

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.14
-_dictionary.date                        2020-08-13
+_dictionary.date                        2021-03-01
 _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
@@ -3327,8 +3327,8 @@ save_
 save_diffrn_source.beamline
 
 _definition.id                       '_diffrn_source.beamline'
-_definition.update                   2020-09-18
-_definition
+_definition.update                   2021-03-01
+_description.text
 ;
          The name of the beamline at the synchrotron or other
          large-scale experimental facility at which the experiment
@@ -24545,9 +24545,12 @@ loop_
      Validation method for _space_group.crystal_system removed as it contained
      undefined dREL functions "throw" and "alert".
 ;
-     3.0.14     2020-08-13
+     3.0.14     2021-03-01
 ;
      Added opaque author identifiers to audit_author and publ_author as well
      as relevant linking identifiers to audit_contact_author and 
-     publ_contact_author. Added diffrn_measurement.specimen_attachment_type
+     publ_contact_author. Added diffrn_measurement.specimen_attachment_type.
+
+     Corrected a misspelt data name in the definition of
+     the _diffrn_source.beamline data item.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -884,7 +884,7 @@ save_
 save_diffrn_measurement.specimen_attachment_type
 
 _definition.id                '_diffrn_measurement.specimen_attachment_type'
-_definition.update            2020-08-13
+_definition.update            2021-03-01
 _description.text
 ;
 
@@ -905,8 +905,8 @@ _type.purpose                 State
 _type.source                  Recorded
 
 loop_
-     _enumerated_set.case
-     _enumerated_set.detail
+     _enumeration_set.state
+     _enumeration_set.detail
         epoxy            "An epoxy glue"
         oil              "An oil"
         grease           "A type of grease, for example hydrocarbon or silicone grease"
@@ -24551,6 +24551,7 @@ loop_
      as relevant linking identifiers to audit_contact_author and 
      publ_contact_author. Added diffrn_measurement.specimen_attachment_type.
 
-     Corrected a misspelt data name in the definition of
-     the _diffrn_source.beamline data item.
+     Corrected several misspelt data names in the definitions
+     of the _diffrn_measurement.specimen_attachment_type and
+     _diffrn_source.beamline data item.
 ;


### PR DESCRIPTION
This PR fixes a few misspelt data names in the newly added data item definitions.