### PR TITLE
Fix ATOM_SITES_CARTN_TRANSFORM description

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.0.14
-_dictionary.date                        2021-03-01
+_dictionary.date                        2021-03-03
 _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             3.14.0
@@ -21091,11 +21091,11 @@ save_ATOM_SITES_CARTN_TRANSFORM
 _definition.id                          ATOM_SITES_CARTN_TRANSFORM
 _definition.scope                       Category
 _definition.class                       Set
-_definition.update                      2012-11-20
-_description.text                       
+_definition.update                      2021-03-03
+_description.text
 ;
      The CATEGORY of data items used to describe the matrix elements
-     used to transform Cartesion coordinates into fractional coordinates
+     used to transform fractional coordinates into Cartesian coordinates
      of all atom sites in a crystal structure.
 ;
 _name.category_id                       ATOM_SITES
@@ -21451,11 +21451,11 @@ save_ATOM_SITES_FRACT_TRANSFORM
 _definition.id                          ATOM_SITES_FRACT_TRANSFORM
 _definition.scope                       Category
 _definition.class                       Set
-_definition.update                      2012-12-11
-_description.text                       
+_definition.update                      2021-03-03
+_description.text
 ;
      The CATEGORY of data items used to describe the matrix elements
-     used to transform Cartesion coordinates into fractional coordinates
+     used to transform Cartesian coordinates into fractional coordinates
      of all atom sites in a crystal structure.
 ;
 _name.category_id                       ATOM_SITES
@@ -21623,8 +21623,8 @@ _definition.id                          '_atom_sites_fract_transform.matrix'
 _definition.update                      2021-03-01
 _description.text
 ;
-     Matrix used to transform fractional coordinates in the ATOM_SITE
-     category to Cartesian  coordinates. The axial alignments of this
+     Matrix used to transform Cartesian coordinates in the ATOM_SITE
+     category to fractional coordinates. The axial alignments of this
      transformation are described in _atom_sites_fract_transform.axes.
      The 3 x 1 translation is defined in _atom_sites_fract_transform.vector.
  
@@ -24664,7 +24664,7 @@ loop_
      Validation method for _space_group.crystal_system removed as it contained
      undefined dREL functions "throw" and "alert".
 ;
-     3.0.14     2021-03-01
+     3.0.14     2021-03-03
 ;
      Added opaque author identifiers to audit_author and publ_author as well
      as relevant linking identifiers to audit_contact_author and 
@@ -24676,4 +24676,7 @@ loop_
      Added methods for determining the measurement units to the definitions
      of the _refine_diff.density_min_su, _refine_diff.density_max_su and
      _refine_diff.density_rms_su data items.
+
+     Corrected the definitions of the ATOM_SITES_CARTN_TRANSFORM category
+     and the _atom_sites_fract_transform.matrix data item.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -21620,7 +21620,7 @@ save_
 save_atom_sites_fract_transform.matrix
 
 _definition.id                          '_atom_sites_fract_transform.matrix'
-_definition.update                      2021-03-01
+_definition.update                      2021-03-03
 _description.text
 ;
      Matrix used to transform Cartesian coordinates in the ATOM_SITE

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -21337,7 +21337,7 @@ _definition.update                      2021-03-01
 _description.text
 ;
      Matrix used to transform fractional coordinates in the ATOM_SITE
-     category to Cartesian  coordinates. The axial alignments of this
+     category to Cartesian coordinates. The axial alignments of this
      transformation are described in _atom_sites_Cartn_transform.axes.
      The 3 x 1 translation is defined in _atom_sites_Cartn_transform.vector.
  
@@ -21421,7 +21421,7 @@ _definition.update                      2021-03-01
 _description.text
 ;
      The 3x1 translation is used with _atom_sites_Cartn_transform.matrix
-     used to transform fractional coordinates to Cartesian  coordinates.
+     used to transform fractional coordinates to Cartesian coordinates.
      The axial alignments of this transformation are described in
      _atom_sites_Cartn_transform.axes.
 ;
@@ -21708,7 +21708,7 @@ _definition.update                      2021-03-01
 _description.text
 ;
      The 3x1 translation is used with _atom_sites_fract_transform.matrix
-     used to transform Cartesian coordinates to fractional  coordinates.
+     used to transform Cartesian coordinates to fractional coordinates.
      The axial alignments of this transformation are described in
      _atom_sites_fract_transform.axes.
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -428,7 +428,7 @@ save_Cartn_matrix
     _description.text
 ;
      Matrix used to transform fractional coordinates in the ATOM_SITE
-     category to Cartesian  coordinates. The axial alignments of this
+     category to Cartesian coordinates. The axial alignments of this
      transformation are described in _atom_sites_Cartn_transform.axes.
      The 3x1 translation is defined in _atom_sites_Cartn_transform.vector.
 


### PR DESCRIPTION
This PR fixes a few minor issues in the descriptions of the `ATOM_SITES_CARTN_TRANSFORM` category and the `_atom_sites_fract_transform` data item. It seems that in these description the coordinate systems were accidentally switched. 