### PR TITLE
Updated the _journal_index.type data item definition

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
 _dictionary.title                       CORE_DIC
 _dictionary.class                       Instance
 _dictionary.version                     3.1.0
-_dictionary.date                        2021-07-01
+_dictionary.date                        2021-07-07
 _dictionary.uri
 https://raw.githubusercontent.com/COMCIFS/cif_core/cif2-conversion/cif_core.dic
 _dictionary.ddl_conformance             4.0.1
@@ -17466,7 +17466,7 @@ _definition.id                          '_journal_index.type'
 loop_
   _alias.definition_id
          '_journal_index_type' 
-_definition.update                      2012-12-11
+_definition.update                      2021-07-07
 _description.text                       
 ;
      Type of index assigned for the publication.
@@ -17480,8 +17480,10 @@ _type.contents                          Text
 loop_
   _enumeration_set.state
   _enumeration_set.detail
-         O         '???????? formula ??????????????'       
-         S         '???????? structure description ???????' 
+         O         'organic formula index'
+         I         'inorganic formula index'
+         M         'metal-organic formula index'
+         S         'subject index'
 _enumeration.default                    O
 
 save_
@@ -24643,8 +24645,11 @@ loop_
      Removed all instances of the _category.key_id attribute since it is no
      longer defined in the DDLm reference dictionary.
 ;
-     3.1.0     2021-07-01
+     3.1.0     2021-07-07
 ;
      Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
      and _model_site.adp_eigenvalues.
+
+     Added additional enumeration values to the _journal_index.type data item
+     definition.
 ;


### PR DESCRIPTION
This PR updates the definition of the `_journal_index.type` data item to match the description in ITC Volume G (2005), section 3.2.5.4.

I would have also adapted the 3.2.5.2 example to the `JOURNAL_INDEX` category definition, however, I was unsure if this is allowed (the current definition of the `_description_example.case` data item seems to imply that this item should only be used in data item definitions).