### PR TITLE
Clarify meaning of _dictionary_valid.attributes

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -772,11 +772,12 @@ save_dictionary_valid.attributes
 
     _definition.id                '_dictionary_valid.attributes'
     _definition.class             Attribute
-    _definition.update            2013-03-06
+    _definition.update            2021-07-21
     _description.text
 ;
     A list of the attribute names and categories that are assessed
-    for application in the item, category and dictionary definitions.
+    for application in the item, category and dictionary definitions. A
+    parent attribute category implicitly includes all child categories.
 ;
     _name.category_id             dictionary_valid
     _name.object_id               attributes

--- a/ddl.dic
+++ b/ddl.dic
@@ -777,7 +777,7 @@ save_dictionary_valid.attributes
 ;
     A list of the attribute names and categories that are assessed
     for application in the item, category and dictionary definitions. A
-    parent attribute category implicitly recursively includes all child 
+    parent attribute category implicitly recursively includes all child
     categories.
 ;
     _name.category_id             dictionary_valid

--- a/ddl.dic
+++ b/ddl.dic
@@ -777,7 +777,8 @@ save_dictionary_valid.attributes
 ;
     A list of the attribute names and categories that are assessed
     for application in the item, category and dictionary definitions. A
-    parent attribute category implicitly includes all child categories.
+    parent attribute category implicitly recursively includes all child 
+    categories.
 ;
     _name.category_id             dictionary_valid
     _name.object_id               attributes


### PR DESCRIPTION
Make sure it is clear that child categories are included when a category is given in the list of attributes in the dictionary_valid list.