### PR TITLE
Fix the description of the _exptl_absorpt.correction_t_min data item

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-08-03
+    _dictionary.date              2021-08-15
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.0.1
@@ -8735,15 +8735,15 @@ save_exptl_absorpt.correction_t_min
          '_exptl_absorpt_correction_T_min'
          '_exptl.absorpt_correction_T_min'
 
-    _definition.update            2012-11-22
+    _definition.update            2021-08-15
     _description.text
 ;
-    Maximum transmission factor for the crystal and radiation applied
+    Minimum transmission factor for the crystal and radiation applied
     to the measured intensities, it includes the correction for
     absorption by the specimen mount and diffractometer as well
     as by the specimen itself. These values give the transmission (T)
     factor by which measured intensities have been REDUCED due to
-    absorption. Sometimes referred to as absorption correction A ori
+    absorption. Sometimes referred to as absorption correction A or
     1/A* (see "Crystal Structure Analysis for Chemists and Biologists"
     by J.P. Glusker et al., Wiley)
 ;
@@ -24043,7 +24043,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-08-03
+         3.1.0                    2021-08-15
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -24073,5 +24073,6 @@ save_
        the _diffrn_radiation_wavelength.value_su data item from
        'none' to 'angstroms'.
 
-       Updated the description of the _diffrn_source.make data item.
+       Updated the description of the _diffrn_source.make and
+       _exptl_absorpt.correction_t_min data items.
 ;


### PR DESCRIPTION
This PR fixes the `_exptl_absorpt.correction_t_min` data item description which was most likely accidentally incorrectly copied form the `_exptl_absorpt.correction_t_max` data item.