### PR TITLE
Homogenise spelling of terms

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13318,7 +13318,7 @@ save_audit.update_record
 
     _definition.id                '_audit.update_record'
     _alias.definition_id          '_audit_update_record'
-    _definition.update            2012-11-29
+    _definition.update            2021-08-18
     _description.text
 ;
     A description of the revision applied to the data.
@@ -13329,7 +13329,7 @@ save_audit.update_record
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Text
-    _description_example.case     '1990-07-15 Updated by Co-editor'
+    _description_example.case     'Updated by coeditor'
 
 save_
 
@@ -15954,10 +15954,10 @@ save_JOURNAL_COEDITOR
     _definition.id                JOURNAL_COEDITOR
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2012-12-11
+    _definition.update            2021-08-18
     _description.text
 ;
-    Category of items recording co-editor details.
+    Category of items recording coeditor details.
 ;
     _name.category_id             JOURNAL
     _name.object_id               JOURNAL_COEDITOR
@@ -17562,10 +17562,10 @@ save_publ_requested.coeditor_name
          '_publ_requested_coeditor_name'
          '_publ.requested_coeditor_name'
 
-    _definition.update            2012-12-13
+    _definition.update            2021-08-18
     _description.text
 ;
-    The name of the Co-editor whom the authors would like to
+    The name of the coeditor whom the authors would like to
     process the submitted manuscript.
 ;
     _name.category_id             publ_requested

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -22044,12 +22044,12 @@ save_refine_ls.abs_structure_flack
          '_refine_ls_abs_structure_Flack'
          '_refine.ls_abs_structure_Flack'
 
-    _definition.update            2012-11-20
+    _definition.update            2021-08-18
     _description.text
 ;
     The measure of absolute structure as defined by Flack (1983).
-    For centrosymmetric structures, the only permitted value, if the
-    data name is present, is 'inapplicable', represented by '.' .
+    For centrosymmetric structures, the only permitted value, if
+    the data item is present, is 'inapplicable', represented by '.' .
     For noncentrosymmetric structures, the value must lie in the
     99.97% Gaussian confidence interval  -3u =< x =< 1 + 3u and a
     standard uncertainty (e.s.d.) u must be supplied. The

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3224,11 +3224,11 @@ save_diffrn_source.details
 
     _definition.id                '_diffrn_source.details'
     _alias.definition_id          '_diffrn_source_details'
-    _definition.update            2012-11-26
+    _definition.update            2021-08-18
     _description.text
 ;
     A description of special aspects of the source not covered by
-    other datanames.
+    other data items.
 ;
     _name.category_id             diffrn_source
     _name.object_id               details
@@ -9107,11 +9107,11 @@ save_exptl_crystal.description
 
     _definition.id                '_exptl_crystal.description'
     _alias.definition_id          '_exptl_crystal_description'
-    _definition.update            2012-11-22
+    _definition.update            2021-08-18
     _description.text
 ;
     Description of the quality and habit of the crystal. The crystal
-    dimensions should be provided using the exptl_crystal.size_* datanames.
+    dimensions should be provided using the exptl_crystal.size_* data items.
 ;
     _name.category_id             exptl_crystal
     _name.object_id               description
@@ -10250,10 +10250,10 @@ save_symmetry.cell_setting
     _definition_replaced.id       1
     _definition_replaced.by       '_space_group.crystal_system'
     _alias.definition_id          '_symmetry_cell_setting'
-    _definition.update            2019-04-02
+    _definition.update            2021-08-18
     _description.text
 ;
-    This dataname should not be used and is DEPRECATED as it is
+    This data item should not be used and is DEPRECATED as it is
     ambiguous.
 
     The original definition is as follows:
@@ -13262,7 +13262,7 @@ save_audit.schema
     _definition.update            2021-08-18
     _description.text
 ;
-    This dataname identifies the type of information contained in the
+    This data item identifies the type of information contained in the
     data block. Software written for one schema will not, in general,
     correctly interpret datafiles written against a different schema.
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-08-03
+    _dictionary.date              2021-08-18
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.0.1
@@ -13181,13 +13181,13 @@ save_audit.block_doi
 
     _definition.id                '_audit.block_doi'
     _alias.definition_id          '_audit_block_doi'
-    _definition.update            2017-09-23
+    _definition.update            2021-08-18
     _description.text
 ;
     The digital object identifier (DOI) registered to identify
     the data set publication represented by the current
-    datablock. This can be used as a unique identifier for
-    the datablock so long as the code used is a valid DOI
+    data block. This can be used as a unique identifier for
+    the data block so long as the code used is a valid DOI
     (i.e. begins with a valid publisher prefix assigned by a
     Registration Agency and a suffix guaranteed to be unique
     by the publisher) and has had its metadata deposited
@@ -13259,11 +13259,11 @@ save_
 save_audit.schema
 
     _definition.id                '_audit.schema'
-    _definition.update            2016-09-08
+    _definition.update            2021-08-18
     _description.text
 ;
     This dataname identifies the type of information contained in the
-    datablock. Software written for one schema will not, in general,
+    data block. Software written for one schema will not, in general,
     correctly interpret datafiles written against a different schema.
 
     Specifically, each value of _audit.schema corresponds to a list
@@ -13274,8 +13274,8 @@ save_audit.schema
     multiple packets and do not need to be listed.
 
     The category list for each schema may instead be determined from
-    examination of the dictionaries that this datablock conforms to (see
-    _audit_conform.dict_name).
+    examination of the dictionaries that this data block conforms to
+    (see _audit_conform.dict_name).
 ;
     _name.category_id             audit
     _name.object_id               schema
@@ -13298,7 +13298,7 @@ save_audit.schema
          'Entry'
 ;
          entry category is defined and looped: information from multiple
-         datablocks in one block
+         data blocks in one block
 ;
          'Custom'
 ;
@@ -15066,12 +15066,12 @@ save_database.dataset_doi
 
     _definition.id                '_database.dataset_doi'
     _alias.definition_id          '_database_dataset_doi'
-    _definition.update            2017-09-23
+    _definition.update            2021-08-18
     _description.text
 ;
     The digital object identifier (DOI) registered to identify
     a data set publication associated with the structure
-    described in the current datablock. This should be used
+    described in the current data block. This should be used
     for a dataset obtained from a curated database such as
     CSD or PDB.
 
@@ -17187,11 +17187,11 @@ save_publ_contact_author.id_iucr
 
     _definition.id                '_publ_contact_author.id_iucr'
     _alias.definition_id          '_publ_contact_author_id_iucr'
-    _definition.update            2012-11-29
+    _definition.update            2021-08-18
     _description.text
 ;
     Identifier in the IUCr contact database of the author submitting
-    the manuscript and datablock. This identifier may be available
+    the manuscript and data block. This identifier may be available
     from the World Directory of Crystallographers (http://wdc.iucr.org).
 ;
     _name.category_id             publ_contact_author
@@ -24043,7 +24043,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-08-03
+         3.1.0                    2021-08-18
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -24074,4 +24074,6 @@ save_
        'none' to 'angstroms'.
 
        Updated the description of the _diffrn_source.make data item.
+
+       Unified the spelling of certain words.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -129,12 +129,12 @@ save_category_key.name
 
     _definition.id                '_category_key.name'
     _definition.class             Attribute
-    _definition.update            2019-01-09
+    _definition.update            2021-08-18
     _description.text
 ;
     A minimal list of tag(s) that together constitute a compound key
     to access other items in a Loop category. In other words, the combined
-    values of the datanames listed in this loop must be unique, so that
+    values of the data items listed in this loop must be unique, so that
     unambiguous access to a packet (row) in the table of values is possible.
 ;
     _name.category_id             category_key
@@ -550,11 +550,11 @@ save_dictionary.formalism
 
     _definition.id                '_dictionary.formalism'
     _definition.class             Attribute
-    _definition.update            2017-01-25
+    _definition.update            2021-08-18
     _description.text
 ;
     The definitions contained in this dictionary are associated
-    with the value of this attribute. Datanames may only be
+    with the value of this attribute. Data items may only be
     redefined if the value of this attribute is also changed, and
     any such redefinitions must include the original behaviour as
     a particular case.
@@ -1478,10 +1478,10 @@ save_name.linked_item_id
 
     _definition.id                '_name.linked_item_id'
     _definition.class             Attribute
-    _definition.update            2011-12-08
+    _definition.update            2021-08-18
     _description.text
 ;
-    Dataname of an equivalent item which has a
+    Data name of an equivalent item which has a
     common set of values, or, in the definition of a type SU
     item is the name of the associated Measurement item to
     which the standard uncertainty applies.
@@ -1845,7 +1845,7 @@ save_type.purpose
 
     _definition.id                '_type.purpose'
     _definition.class             Attribute
-    _definition.update            2019-04-02
+    _definition.update            2021-08-18
     _description.text
 ;
     The primary purpose or function the defined data item serves in a
@@ -1942,7 +1942,7 @@ save_type.purpose
          SU
 ;
          Used to type an item with a numerical value that is the standard
-         uncertainty of another dataname. The definition of an SU item must
+         uncertainty of another data item. The definition of an SU item must
          include the attribute "_name.linked_item_id" which explicitly
          identifies the associated measurand item. SU values must be
          non-negative.

--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.0.2
-    _dictionary.date              2021-07-28
+    _dictionary.date              2021-08-18
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.0.2
@@ -1168,10 +1168,10 @@ save_import_details.frame_id
 
     _definition.id                '_import_details.frame_id'
     _definition.class             Attribute
-    _definition.update            2015-05-06
+    _definition.update            2021-08-18
     _description.text
 ;
-    The framecode of the definition frame to be imported.
+    The save frame code of the definition frame to be imported.
 ;
     _name.category_id             import_details
     _name.object_id               frame_id
@@ -1334,7 +1334,7 @@ save_import_details.single_index
 
     _definition.id                '_import_details.single_index'
     _definition.class             Attribute
-    _definition.update            2021-02-03
+    _definition.update            2021-08-18
     _description.text
 ;
     One of the indices permitted in the entries of values of attribute
@@ -1361,7 +1361,7 @@ save_import_details.single_index
 ;
          save
 ;
-         save framecode of source definition
+         save frame code of source definition
 ;
          mode
 ;
@@ -2536,7 +2536,7 @@ save_
 
        Clarified use of DESCRIPTION_EXAMPLE category and _description.text.
 ;
-         4.0.2                    2021-07-28
+         4.0.2                    2021-08-18
 ;
        Deprecated _dictionary_valid.application.
 
@@ -2545,4 +2545,6 @@ save_
 
        Updated the descriptions of the _type.dimension and _type.container
        data items to be more consistent with the rest of the dictionary.
+
+       Unified the spelling of certain words.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -863,11 +863,11 @@ save_enumeration.def_index_id
 
     _definition.id                '_enumeration.def_index_id'
     _definition.class             Attribute
-    _definition.update            2012-05-07
+    _definition.update            2021-08-18
     _description.text
 ;
-    Specifies the data name with a value used as an index to the
-    DEFAULT enumeration list (in category enumeration_default)
+    Specifies the data name of the item with a value used as an index
+    to the DEFAULT enumeration list (in category enumeration_default)
     in order to select the default enumeration value for the
     defined item. The value of the identified data item must match
     one of the _enumeration_default.index values.
@@ -1931,7 +1931,7 @@ save_type.purpose
          Measurand
 ;
          Used to type an item with a numerically estimated value that has been
-         recorded by measurement or derivation. A data name definition for the
+         recorded by measurement or derivation. A data item definition for the
          standard uncertainty (SU) of this item must be provided in a separate
          definition with _type.purpose of 'SU'. The value of a measurand item
          should be accompanied by a value of its associated SU item, either: 1)


### PR DESCRIPTION
This PR unifies the spelling of certain *(mostly CIF-related)* words to match the one presented in the CIF 2.0 paper [1]. Additional notes:
- In a few places the term "data name" (CIF tag) was changed to "data item" (CIF tag + CIF value).
- The date was removed from the usage example of the `_audit.update_record` data item since a separate looped data item (`_audit.creation_date`) is now the preferred way of specifying the date.

[1] http://scripts.iucr.org/cgi-bin/paper?aj5269