### PR TITLE
Fix colours in 'templ_enum'

### DIFF
--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -551,6 +551,7 @@ save_colour_RGB
      gray                             '[ 192, 192, 192 ]' #prefer 'grey'
      grey_light                       '[ 211, 211, 211 ]'
      grey_slate                       '[ 112, 128, 144 ]'
+     grey_steel                       '[ 136, 139, 141 ]'
      blue                             '[ 000, 000, 255 ]'
      blue_light                       '[ 176, 224, 230 ]'
      blue_medium                      '[ 000, 000, 205 ]'
@@ -2000,7 +2001,7 @@ save_colour_hue
          _enumeration_default.index 
          _enumeration_default.value
      H     white   D     blue_light H1-   white   He    unknown Li    unknown 
-     Li1+  unknown Be    unknown Be2+  unknown B     unknown C     steel_grey
+     Li1+  unknown Be    unknown Be2+  unknown B     unknown C     grey_steel
      N     blue    O     red     O1-   red     F     green   F1-   green   
      Ne    unknown Na    magenta Na1+  magenta Mg    magenta Mg2+  magenta 
      Al    magenta Al3+  magenta Si    unknown Si4+  unknown P     magenta 
@@ -2155,4 +2156,9 @@ save_colour_hue
       1.4.8   2021-03-18
 ;
    Corrected a few typos in the 'units_code' save frame.
+
+   Corrected several discrepancies in the 'colour_hue' save frame.
+   Colour 'steel_grey' was renamed to 'grey_steel'.
+
+   Added the 'grey_steel' colour to the 'colour_RGB' save frame.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -1992,58 +1992,225 @@ save_hi_ang_Fox_c3
      U4+   0.05060 U6+   0.05060 Np    -0.06566 Np3+  -0.06566 Np4+  -0.06566
      Np6+  -0.06566 Pu    -0.18080 Pu3+  -0.18080 Pu4+  -0.18080 Pu6+  -0.18080
      Am    -0.29112 Cm    -0.40588 Bk    -0.51729 Cf    -0.62981
-     save_
- 
- 
-save_colour_hue                                                         
 
-     loop_        
-         _enumeration_default.index 
-         _enumeration_default.value
-     H     white   D     blue_light H1-   white   He    unknown Li    unknown 
-     Li1+  unknown Be    unknown Be2+  unknown B     unknown C     grey_steel
-     N     blue    O     red     O1-   red     F     green   F1-   green   
-     Ne    unknown Na    magenta Na1+  magenta Mg    magenta Mg2+  magenta 
-     Al    magenta Al3+  magenta Si    unknown Si4+  unknown P     magenta 
-     S     yellow  Cl    green   Cl1-  green   Ar    unknown K     magenta 
-     K1+   magenta Ca    magenta Ca2+  magenta Sc    unknown Sc3+  unknown 
-     Ti    magenta Ti2+  magenta Ti3+  magenta Ti4+  magenta V     magenta 
-     V2+   magenta V3+   magenta V5+   magenta Cr    magenta Cr2+  magenta 
-     Cr3+  magenta Mn    magenta Mn2+  magenta Mn3+  magenta Mn4+  magenta 
-     Fe    magenta Fe2+  magenta Fe3+  magenta Co    magenta Co2+  magenta 
-     Co3+  magenta Ni    magenta Ni2+  magenta Ni3+  magenta Cu    magenta 
-     Cu1+  magenta Cu2+  magenta Zn    magenta Zn2+  magenta Ga    magenta 
-     Ga3+  magenta Ge    magenta Ge4+  magenta As    magenta Se    yellow  
-     Br    green   Br1-  green   Kr    unknown Rb    unknown Rb1+  unknown 
-     Sr    unknown Sr2+  unknown Y     unknown Y3+   unknown Zr    unknown 
-     Zr4+  unknown Nb    unknown Nb3+  unknown Nb5+  unknown Mo    unknown 
-     Mo3+  magenta Mo5+  magenta Mo6+  magenta Tc    unknown Ru    unknown 
-     Ru3+  unknown Ru4+  unknown Rh    unknown Rh3+  unknown Rh4+  unknown 
-     Pd    unknown Pd2+  unknown Pd4+  unknown Ag    magenta Ag1+  magenta 
-     Ag2+  magenta Cd    magenta Cd2+  magenta In    unknown In3+  unknown 
-     Sn    magenta Sn2+  magenta Sn4+  magenta Sb    magenta Sb3+  magenta 
-     Sb5+  magenta Te    unknown I     green   I1-   green   Xe    unknown 
-     Cs    unknown Cs1+  unknown Ba    unknown Ba2+  unknown La    unknown 
-     La3+  unknown Ce    unknown Ce3+  unknown Ce4+  unknown Pr    unknown 
-     Pr3+  unknown Pr4+  unknown Nd    unknown Nd3+  unknown Pm    unknown 
-     Sm    unknown Sm3+  unknown Eu    unknown Eu2+  unknown Eu3+  unknown 
-     Gd    unknown Gd3+  unknown Tb    unknown Tb3+  unknown Dy    unknown 
-     Dy3+  unknown Ho    unknown Ho3+  unknown Er    unknown Er3+  unknown 
-     Tm    unknown Tm3+  unknown Yb    unknown Yb2+  unknown Yb3+  unknown 
-     Lu    unknown Lu3+  unknown Hf    unknown Hf4+  unknown Ta    unknown 
-     Ta5+  unknown W     unknown W6+   unknown Re    unknown Os    unknown 
-     Os4+  unknown Ir    unknown Ir3+  unknown Ir4+  unknown Pt    magenta 
-     Pt2+  magenta Pt4+  magenta Au    magenta Au1+  magenta Au3+  magenta 
-     Hg    magenta Hg1+  magenta Hg2+  magenta Tl    unknown TL1+  unknown 
-     Tl3+  unknown Pb    magenta Pb2+  magenta Pb4+  magenta Bi    magenta 
-     Bi3+  magenta Bi5+  magenta Po    unknown At    unknown Rn    unknown 
-     Fr    unknown Ra    unknown Ra2+  unknown Ac    unknown Ac3+  unknown 
-     Th    unknown Th4+  unknown Pa    unknown U     unknown U3+   unknown 
-     U4+   unknown U6+   unknown Np    unknown Np3+  unknown Np4+  unknown 
-     Np6+  unknown Pu    unknown Pu3+  unknown Pu4+  unknown Pu6+  unknown 
-     Am    unknown Cm    unknown Bk    unknown Cf    unknown 
-     save_
- 
+save_
+
+save_colour_hue
+
+    loop_
+      _enumeration_default.index
+      _enumeration_default.value
+         H                        white
+         D                        blue_light
+         H1-                      white
+         He                       ?
+         Li                       ?
+         Li1+                     ?
+         Be                       ?
+         Be2+                     ?
+         B                        ?
+         C                        grey_steel
+         N                        blue
+         O                        red
+         O1-                      red
+         F                        green
+         F1-                      green
+         Ne                       ?
+         Na                       magenta
+         Na1+                     magenta
+         Mg                       magenta
+         Mg2+                     magenta
+         Al                       magenta
+         Al3+                     magenta
+         Si                       ?
+         Si4+                     ?
+         P                        magenta
+         S                        yellow
+         Cl                       green
+         Cl1-                     green
+         Ar                       ?
+         K                        magenta
+         K1+                      magenta
+         Ca                       magenta
+         Ca2+                     magenta
+         Sc                       ?
+         Sc3+                     ?
+         Ti                       magenta
+         Ti2+                     magenta
+         Ti3+                     magenta
+         Ti4+                     magenta
+         V                        magenta
+         V2+                      magenta
+         V3+                      magenta
+         V5+                      magenta
+         Cr                       magenta
+         Cr2+                     magenta
+         Cr3+                     magenta
+         Mn                       magenta
+         Mn2+                     magenta
+         Mn3+                     magenta
+         Mn4+                     magenta
+         Fe                       magenta
+         Fe2+                     magenta
+         Fe3+                     magenta
+         Co                       magenta
+         Co2+                     magenta
+         Co3+                     magenta
+         Ni                       magenta
+         Ni2+                     magenta
+         Ni3+                     magenta
+         Cu                       magenta
+         Cu1+                     magenta
+         Cu2+                     magenta
+         Zn                       magenta
+         Zn2+                     magenta
+         Ga                       magenta
+         Ga3+                     magenta
+         Ge                       magenta
+         Ge4+                     magenta
+         As                       magenta
+         Se                       yellow
+         Br                       green
+         Br1-                     green
+         Kr                       ?
+         Rb                       ?
+         Rb1+                     ?
+         Sr                       ?
+         Sr2+                     ?
+         Y                        ?
+         Y3+                      ?
+         Zr                       ?
+         Zr4+                     ?
+         Nb                       ?
+         Nb3+                     ?
+         Nb5+                     ?
+         Mo                       ?
+         Mo3+                     magenta
+         Mo5+                     magenta
+         Mo6+                     magenta
+         Tc                       ?
+         Ru                       ?
+         Ru3+                     ?
+         Ru4+                     ?
+         Rh                       ?
+         Rh3+                     ?
+         Rh4+                     ?
+         Pd                       ?
+         Pd2+                     ?
+         Pd4+                     ?
+         Ag                       magenta
+         Ag1+                     magenta
+         Ag2+                     magenta
+         Cd                       magenta
+         Cd2+                     magenta
+         In                       ?
+         In3+                     ?
+         Sn                       magenta
+         Sn2+                     magenta
+         Sn4+                     magenta
+         Sb                       magenta
+         Sb3+                     magenta
+         Sb5+                     magenta
+         Te                       ?
+         I                        green
+         I1-                      green
+         Xe                       ?
+         Cs                       ?
+         Cs1+                     ?
+         Ba                       ?
+         Ba2+                     ?
+         La                       ?
+         La3+                     ?
+         Ce                       ?
+         Ce3+                     ?
+         Ce4+                     ?
+         Pr                       ?
+         Pr3+                     ?
+         Pr4+                     ?
+         Nd                       ?
+         Nd3+                     ?
+         Pm                       ?
+         Sm                       ?
+         Sm3+                     ?
+         Eu                       ?
+         Eu2+                     ?
+         Eu3+                     ?
+         Gd                       ?
+         Gd3+                     ?
+         Tb                       ?
+         Tb3+                     ?
+         Dy                       ?
+         Dy3+                     ?
+         Ho                       ?
+         Ho3+                     ?
+         Er                       ?
+         Er3+                     ?
+         Tm                       ?
+         Tm3+                     ?
+         Yb                       ?
+         Yb2+                     ?
+         Yb3+                     ?
+         Lu                       ?
+         Lu3+                     ?
+         Hf                       ?
+         Hf4+                     ?
+         Ta                       ?
+         Ta5+                     ?
+         W                        ?
+         W6+                      ?
+         Re                       ?
+         Os                       ?
+         Os4+                     ?
+         Ir                       ?
+         Ir3+                     ?
+         Ir4+                     ?
+         Pt                       magenta
+         Pt2+                     magenta
+         Pt4+                     magenta
+         Au                       magenta
+         Au1+                     magenta
+         Au3+                     magenta
+         Hg                       magenta
+         Hg1+                     magenta
+         Hg2+                     magenta
+         Tl                       ?
+         TL1+                     ?
+         Tl3+                     ?
+         Pb                       magenta
+         Pb2+                     magenta
+         Pb4+                     magenta
+         Bi                       magenta
+         Bi3+                     magenta
+         Bi5+                     magenta
+         Po                       ?
+         At                       ?
+         Rn                       ?
+         Fr                       ?
+         Ra                       ?
+         Ra2+                     ?
+         Ac                       ?
+         Ac3+                     ?
+         Th                       ?
+         Th4+                     ?
+         Pa                       ?
+         U                        ?
+         U3+                      ?
+         U4+                      ?
+         U6+                      ?
+         Np                       ?
+         Np3+                     ?
+         Np4+                     ?
+         Np6+                     ?
+         Pu                       ?
+         Pu3+                     ?
+         Pu4+                     ?
+         Pu6+                     ?
+         Am                       ?
+         Cm                       ?
+         Bk                       ?
+         Cf                       ?
+
+save_
 
 #=============================================================================
 #  The dictionary's creation history.
@@ -2157,8 +2324,9 @@ save_colour_hue
 ;
    Corrected a few typos in the 'units_code' save frame.
 
-   Corrected several discrepancies in the 'colour_hue' save frame.
-   Colour 'steel_grey' was renamed to 'grey_steel'.
+   Corrected several discrepancies in the 'colour_hue' save frame:
+   replaced colour value 'unknown' with CIF special value '?',
+   renamed colour 'steel_grey' to 'grey_steel'.
 
    Added the 'grey_steel' colour to the 'colour_RGB' save frame.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -2016,59 +2016,59 @@ save_colour_hue
          F                        green
          F1-                      green
          Ne                       ?
-         Na                       magenta
-         Na1+                     magenta
-         Mg                       magenta
-         Mg2+                     magenta
-         Al                       magenta
-         Al3+                     magenta
+         Na                       violet_magenta
+         Na1+                     violet_magenta
+         Mg                       violet_magenta
+         Mg2+                     violet_magenta
+         Al                       violet_magenta
+         Al3+                     violet_magenta
          Si                       ?
          Si4+                     ?
-         P                        magenta
+         P                        violet_magenta
          S                        yellow
          Cl                       green
          Cl1-                     green
          Ar                       ?
-         K                        magenta
-         K1+                      magenta
-         Ca                       magenta
-         Ca2+                     magenta
+         K                        violet_magenta
+         K1+                      violet_magenta
+         Ca                       violet_magenta
+         Ca2+                     violet_magenta
          Sc                       ?
          Sc3+                     ?
-         Ti                       magenta
-         Ti2+                     magenta
-         Ti3+                     magenta
-         Ti4+                     magenta
-         V                        magenta
-         V2+                      magenta
-         V3+                      magenta
-         V5+                      magenta
-         Cr                       magenta
-         Cr2+                     magenta
-         Cr3+                     magenta
-         Mn                       magenta
-         Mn2+                     magenta
-         Mn3+                     magenta
-         Mn4+                     magenta
-         Fe                       magenta
-         Fe2+                     magenta
-         Fe3+                     magenta
-         Co                       magenta
-         Co2+                     magenta
-         Co3+                     magenta
-         Ni                       magenta
-         Ni2+                     magenta
-         Ni3+                     magenta
-         Cu                       magenta
-         Cu1+                     magenta
-         Cu2+                     magenta
-         Zn                       magenta
-         Zn2+                     magenta
-         Ga                       magenta
-         Ga3+                     magenta
-         Ge                       magenta
-         Ge4+                     magenta
-         As                       magenta
+         Ti                       violet_magenta
+         Ti2+                     violet_magenta
+         Ti3+                     violet_magenta
+         Ti4+                     violet_magenta
+         V                        violet_magenta
+         V2+                      violet_magenta
+         V3+                      violet_magenta
+         V5+                      violet_magenta
+         Cr                       violet_magenta
+         Cr2+                     violet_magenta
+         Cr3+                     violet_magenta
+         Mn                       violet_magenta
+         Mn2+                     violet_magenta
+         Mn3+                     violet_magenta
+         Mn4+                     violet_magenta
+         Fe                       violet_magenta
+         Fe2+                     violet_magenta
+         Fe3+                     violet_magenta
+         Co                       violet_magenta
+         Co2+                     violet_magenta
+         Co3+                     violet_magenta
+         Ni                       violet_magenta
+         Ni2+                     violet_magenta
+         Ni3+                     violet_magenta
+         Cu                       violet_magenta
+         Cu1+                     violet_magenta
+         Cu2+                     violet_magenta
+         Zn                       violet_magenta
+         Zn2+                     violet_magenta
+         Ga                       violet_magenta
+         Ga3+                     violet_magenta
+         Ge                       violet_magenta
+         Ge4+                     violet_magenta
+         As                       violet_magenta
          Se                       yellow
          Br                       green
          Br1-                     green
@@ -2085,9 +2085,9 @@ save_colour_hue
          Nb3+                     ?
          Nb5+                     ?
          Mo                       ?
-         Mo3+                     magenta
-         Mo5+                     magenta
-         Mo6+                     magenta
+         Mo3+                     violet_magenta
+         Mo5+                     violet_magenta
+         Mo6+                     violet_magenta
          Tc                       ?
          Ru                       ?
          Ru3+                     ?
@@ -2098,19 +2098,19 @@ save_colour_hue
          Pd                       ?
          Pd2+                     ?
          Pd4+                     ?
-         Ag                       magenta
-         Ag1+                     magenta
-         Ag2+                     magenta
-         Cd                       magenta
-         Cd2+                     magenta
+         Ag                       violet_magenta
+         Ag1+                     violet_magenta
+         Ag2+                     violet_magenta
+         Cd                       violet_magenta
+         Cd2+                     violet_magenta
          In                       ?
          In3+                     ?
-         Sn                       magenta
-         Sn2+                     magenta
-         Sn4+                     magenta
-         Sb                       magenta
-         Sb3+                     magenta
-         Sb5+                     magenta
+         Sn                       violet_magenta
+         Sn2+                     violet_magenta
+         Sn4+                     violet_magenta
+         Sb                       violet_magenta
+         Sb3+                     violet_magenta
+         Sb5+                     violet_magenta
          Te                       ?
          I                        green
          I1-                      green
@@ -2164,24 +2164,24 @@ save_colour_hue
          Ir                       ?
          Ir3+                     ?
          Ir4+                     ?
-         Pt                       magenta
-         Pt2+                     magenta
-         Pt4+                     magenta
-         Au                       magenta
-         Au1+                     magenta
-         Au3+                     magenta
-         Hg                       magenta
-         Hg1+                     magenta
-         Hg2+                     magenta
+         Pt                       violet_magenta
+         Pt2+                     violet_magenta
+         Pt4+                     violet_magenta
+         Au                       violet_magenta
+         Au1+                     violet_magenta
+         Au3+                     violet_magenta
+         Hg                       violet_magenta
+         Hg1+                     violet_magenta
+         Hg2+                     violet_magenta
          Tl                       ?
          TL1+                     ?
          Tl3+                     ?
-         Pb                       magenta
-         Pb2+                     magenta
-         Pb4+                     magenta
-         Bi                       magenta
-         Bi3+                     magenta
-         Bi5+                     magenta
+         Pb                       violet_magenta
+         Pb2+                     violet_magenta
+         Pb4+                     violet_magenta
+         Bi                       violet_magenta
+         Bi3+                     violet_magenta
+         Bi5+                     violet_magenta
          Po                       ?
          At                       ?
          Rn                       ?
@@ -2326,7 +2326,8 @@ save_
 
    Corrected several discrepancies in the 'colour_hue' save frame:
    replaced colour value 'unknown' with CIF special value '?',
-   renamed colour 'steel_grey' to 'grey_steel'.
+   renamed colour 'steel_grey' to 'grey_steel', renamed colour
+   'violet' to 'violet_magenta'.
 
    Added the 'grey_steel' colour to the 'colour_RGB' save frame.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -1,16 +1,16 @@
 #\#CIF_2.0
 ##############################################################################
 #                                                                            #
-#         TEMPLATE DICTIONARY OF COMMONLY USER ENUMERATIONS                  #
+#         TEMPLATE DICTIONARY OF COMMONLY USED ENUMERATIONS                  #
 #                                                                            #
 ##############################################################################
- 
+
 data_COM_VAL
  
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.8
-    _dictionary.date             2021-03-18
+    _dictionary.date             2021-08-19
     _dictionary.uri              www.iucr.org/cif/dic/com_val.dic
     _dictionary.ddl_conformance  3.11.04
     _description.text
@@ -538,67 +538,69 @@ save_Schoenflies
                O.1 O.2 O.3 O.4 O.5 O.6 O.7 O.8
                Td.1 Td.2 Td.3 Td.4 Td.5 Td.6
                Oh.1 Oh.2 Oh.3 Oh.4 Oh.5 Oh.6 Oh.7 Oh.8 Oh.9 Oh.10
-               save_
-               
+
+save_
+
 save_colour_RGB
 
     loop_
-        _enumeration_set.state
-        _enumeration_set.detail
-     black                            '[ 000, 000, 000 ]'
-     white                            '[ 255, 255, 255 ]'
-     grey                             '[ 192, 192, 192 ]'
-     gray                             '[ 192, 192, 192 ]' #prefer 'grey'
-     grey_light                       '[ 211, 211, 211 ]'
-     grey_slate                       '[ 112, 128, 144 ]'
-     grey_steel                       '[ 136, 139, 141 ]'
-     blue                             '[ 000, 000, 255 ]'
-     blue_light                       '[ 176, 224, 230 ]'
-     blue_medium                      '[ 000, 000, 205 ]'
-     blue_dark                        '[ 025, 025, 112 ]'
-     blue_navy                        '[ 000, 000, 128 ]'
-     blue_royal                       '[ 065, 105, 225 ]'
-     blue_sky                         '[ 135, 206, 235 ]'
-     blue_steel                       '[ 070, 130, 180 ]'
-     turquoise                        '[ 064, 224, 208 ]'
-     colourless                       '[   .,   .,   . ]'
-     cyan                             '[ 000, 255, 255 ]'
-     cyan_light                       '[ 224, 255, 255 ]'
-     green                            '[ 000, 255, 000 ]'
-     green_light                      '[ 152, 251, 152 ]'
-     green_dark                       '[ 000, 100, 000 ]'
-     green_sea                        '[ 046, 139, 087 ]'
-     green_lime                       '[ 050, 205, 050 ]'
-     green_olive                      '[ 107, 142, 035 ]'
-     green_khaki                      '[ 240, 230, 140 ]'
-     yellow                           '[ 255, 255, 000 ]'
-     yellow_light                     '[ 255, 255, 224 ]'
-     yellow_gold                      '[ 255, 215, 000 ]'
-     brown                            '[ 165, 042, 042 ]'
-     brown_sienna                     '[ 160, 082, 045 ]'
-     brown_beige                      '[ 245, 245, 220 ]'
-     brown_tan                        '[ 210, 180, 140 ]'
-     salmon                           '[ 250, 128, 114 ]'
-     salmon_light                     '[ 255, 160, 122 ]'
-     salmon_dark                      '[ 233, 150, 122 ]'
-     orange                           '[ 255, 165, 000 ]'
-     orange_dark                      '[ 255, 140, 000 ]'
-     red                              '[ 255, 000, 000 ]'
-     red_coral                        '[ 255, 127, 080 ]'
-     red_tomato                       '[ 255, 099, 071 ]'
-     red_orange                       '[ 255, 069, 000 ]'
-     red_violet                       '[ 219, 112, 147 ]'
-     red_maroon                       '[ 176, 048, 096 ]'
-     pink                             '[ 255, 192, 203 ]'
-     pink_light                       '[ 255, 182, 193 ]'
-     pink_deep                        '[ 255, 020, 147 ]'
-     pink_hot                         '[ 255, 105, 180 ]'
-     violet                           '[ 238, 130, 238 ]'
-     violet_red                       '[ 208, 032, 144 ]'
-     violet_magenta                   '[ 255, 000, 255 ]'
-     violet_dark                      '[ 148, 000, 211 ]'
-     violet_blue                      '[ 138, 043, 226 ]'
-     save_
+      _enumeration_set.state
+      _enumeration_set.detail
+         black                    '[ 000, 000, 000 ]'
+         white                    '[ 255, 255, 255 ]'
+         grey                     '[ 192, 192, 192 ]'
+         gray                     '[ 192, 192, 192 ]' #prefer 'grey'
+         grey_light               '[ 211, 211, 211 ]'
+         grey_slate               '[ 112, 128, 144 ]'
+         grey_steel               '[ 136, 139, 141 ]'
+         blue                     '[ 000, 000, 255 ]'
+         blue_light               '[ 176, 224, 230 ]'
+         blue_medium              '[ 000, 000, 205 ]'
+         blue_dark                '[ 025, 025, 112 ]'
+         blue_navy                '[ 000, 000, 128 ]'
+         blue_royal               '[ 065, 105, 225 ]'
+         blue_sky                 '[ 135, 206, 235 ]'
+         blue_steel               '[ 070, 130, 180 ]'
+         turquoise                '[ 064, 224, 208 ]'
+         colourless               '[   .,   .,   . ]'
+         cyan                     '[ 000, 255, 255 ]'
+         cyan_light               '[ 224, 255, 255 ]'
+         green                    '[ 000, 255, 000 ]'
+         green_light              '[ 152, 251, 152 ]'
+         green_dark               '[ 000, 100, 000 ]'
+         green_sea                '[ 046, 139, 087 ]'
+         green_lime               '[ 050, 205, 050 ]'
+         green_olive              '[ 107, 142, 035 ]'
+         green_khaki              '[ 240, 230, 140 ]'
+         yellow                   '[ 255, 255, 000 ]'
+         yellow_light             '[ 255, 255, 224 ]'
+         yellow_gold              '[ 255, 215, 000 ]'
+         brown                    '[ 165, 042, 042 ]'
+         brown_sienna             '[ 160, 082, 045 ]'
+         brown_beige              '[ 245, 245, 220 ]'
+         brown_tan                '[ 210, 180, 140 ]'
+         salmon                   '[ 250, 128, 114 ]'
+         salmon_light             '[ 255, 160, 122 ]'
+         salmon_dark              '[ 233, 150, 122 ]'
+         orange                   '[ 255, 165, 000 ]'
+         orange_dark              '[ 255, 140, 000 ]'
+         red                      '[ 255, 000, 000 ]'
+         red_coral                '[ 255, 127, 080 ]'
+         red_tomato               '[ 255, 099, 071 ]'
+         red_orange               '[ 255, 069, 000 ]'
+         red_violet               '[ 219, 112, 147 ]'
+         red_maroon               '[ 176, 048, 096 ]'
+         pink                     '[ 255, 192, 203 ]'
+         pink_light               '[ 255, 182, 193 ]'
+         pink_deep                '[ 255, 020, 147 ]'
+         pink_hot                 '[ 255, 105, 180 ]'
+         violet                   '[ 238, 130, 238 ]'
+         violet_red               '[ 208, 032, 144 ]'
+         violet_magenta           '[ 255, 000, 255 ]'
+         violet_dark              '[ 148, 000, 211 ]'
+         violet_blue              '[ 138, 043, 226 ]'
+
+save_
 
 save_database_list
 loop_
@@ -2320,7 +2322,7 @@ save_
    Updated the human-readable descriptions of the 'kelvins' and
    'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-      1.4.8   2021-03-18
+      1.4.8   2021-08-19
 ;
    Corrected a few typos in the 'units_code' save frame.
 


### PR DESCRIPTION
This PR resolves issue #238 as suggested in the related discussion. Main changes:
- Colour value 'unknown' was changed to CIF special value '?' in the 'colour_hue' save frame.
- Colour value 'magenta' was changed to 'violet_magenta' in the in the 'colour_hue' save frame.
- Colour value 'steel_grey' was changed to 'grey_steel' in the in the 'colour_hue' save frame to be similar to other colour names that are already used (i.e. 'blue_steel').
- Colour 'grey_steel' was added to the 'colour_RGB' save frame. I was not able to find a definitive definition of steel grey/grey steel colour so please change the RGB code if needed.

I also reformatted the 'colour_hue' and 'colour_RGB' save frames to follow the DDLm dictionary style guide [1] since it is much more readable.

[1] https://github.com/COMCIFS/comcifs.github.io/blob/master/accepted/ddlm_dictionary_style_guide.md