### PR TITLE
Added missing SU data names.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3137,6 +3137,25 @@ save_diffrn_scale_group.i_net
 
 save_
 
+save_diffrn_scale_group.i_net_su
+
+    _definition.id                '_diffrn_scale_group.I_net_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _diffrn_scale_group.I_net
+;
+    _name.category_id             diffrn_scale_group
+    _name.object_id               I_net_su
+    _name.linked_item_id          '_diffrn_scale_group.I_net'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_DIFFRN_SOURCE
 
     _definition.id                DIFFRN_SOURCE
@@ -3486,6 +3505,25 @@ save_diffrn_standard.decay_percent
 
 save_
 
+save_diffrn_standard.decay_percent_su
+
+    _definition.id                '_diffrn_standard.decay_percent_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _diffrn_standard.decay_percent
+;
+    _name.category_id             diffrn_standard
+    _name.object_id               decay_percent_su
+    _name.linked_item_id          '_diffrn_standard.decay_percent'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_diffrn_standard.interval_count
 
     _definition.id                '_diffrn_standard.interval_count'
@@ -3585,6 +3623,25 @@ save_diffrn_standard.scale_su_average
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_standard.scale_su_average_su
+
+    _definition.id                '_diffrn_standard.scale_su_average_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _diffrn_standard.scale_su_average
+;
+    _name.category_id             diffrn_standard
+    _name.object_id               scale_su_average_su
+    _name.linked_item_id          '_diffrn_standard.scale_su_average'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -3752,6 +3809,24 @@ save_refln.a_calc
 
 save_
 
+save_refln.a_calc_su
+
+    _definition.id                '_refln.A_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.A_calc
+;
+    _name.category_id             refln
+    _name.object_id               A_calc_su
+    _name.linked_item_id          '_refln.A_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+save_
+
 save_refln.a_meas
 
     _definition.id                '_refln.A_meas'
@@ -3774,6 +3849,24 @@ save_refln.a_meas
     Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
     Else                                            _units.code =  "electrons"
 ;
+
+save_
+
+save_refln.a_meas_su
+
+    _definition.id                '_refln.A_meas_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.A_meas
+;
+    _name.category_id             refln
+    _name.object_id               A_meas_su
+    _name.linked_item_id          '_refln.A_meas'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
@@ -3810,6 +3903,24 @@ save_refln.b_calc
 
 save_
 
+save_refln.b_calc_su
+
+    _definition.id                '_refln.B_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.B_calc
+;
+    _name.category_id             refln
+    _name.object_id               B_calc_su
+    _name.linked_item_id          '_refln.B_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+save_
+
 save_refln.b_meas
 
     _definition.id                '_refln.B_meas'
@@ -3832,6 +3943,24 @@ save_refln.b_meas
     Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
     Else                                            _units.code =  "electrons"
 ;
+
+save_
+
+save_refln.b_meas_su
+
+    _definition.id                '_refln.B_meas_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.B_meas
+;
+    _name.category_id             refln
+    _name.object_id               B_meas_su
+    _name.linked_item_id          '_refln.B_meas'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
@@ -3921,6 +4050,24 @@ save_refln.f_calc
 
 save_
 
+save_refln.f_calc_su
+
+    _definition.id                '_refln.F_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.F_calc
+;
+    _name.category_id             refln
+    _name.object_id               F_calc_su
+    _name.linked_item_id          '_refln.F_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+save_
+
 save_refln.f_complex
 
     _definition.id                '_refln.F_complex'
@@ -3969,6 +4116,24 @@ save_refln.f_complex
          }  }
                 _refln.F_complex  =   fc / _space_group.multiplicity
 ;
+
+save_
+
+save_refln.f_complex_su
+
+    _definition.id                '_refln.F_complex_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.F_complex
+;
+    _name.category_id             refln
+    _name.object_id               F_complex_su
+    _name.linked_item_id          '_refln.F_complex'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
 
 save_
 
@@ -4055,6 +4220,24 @@ save_refln.f_squared_calc
                                          _units.code =  "volt_squared"
     Else                                 _units.code =  "electron_squared"
 ;
+
+save_
+
+save_refln.f_squared_calc_su
+
+    _definition.id                '_refln.F_squared_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.F_squared_calc
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_calc_su
+    _name.linked_item_id          '_refln.F_squared_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
@@ -4317,6 +4500,25 @@ save_refln.intensity_calc
 
 save_
 
+save_refln.intensity_calc_su
+
+    _definition.id                '_refln.intensity_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.intensity_calc
+;
+    _name.category_id             refln
+    _name.object_id               intensity_calc_su
+    _name.linked_item_id          '_refln.intensity_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_refln.intensity_meas
 
     _definition.id                '_refln.intensity_meas'
@@ -4432,6 +4634,25 @@ save_refln.phase_calc
 
 save_
 
+save_refln.phase_calc_su
+
+    _definition.id                '_refln.phase_calc_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.phase_calc
+;
+    _name.category_id             refln
+    _name.object_id               phase_calc_su
+    _name.linked_item_id          '_refln.phase_calc'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
+
+save_
+
 save_refln.phase_meas
 
     _definition.id                '_refln.phase_meas'
@@ -4450,6 +4671,25 @@ save_refln.phase_meas
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.:360.
+    _units.code                   degrees
+
+save_
+
+save_refln.phase_meas_su
+
+    _definition.id                '_refln.phase_meas_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refln.phase_meas
+;
+    _name.category_id             refln
+    _name.object_id               phase_meas_su
+    _name.linked_item_id          '_refln.phase_meas'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   degrees
 
 save_
@@ -5412,6 +5652,25 @@ save_reflns_scale.meas_f
 
 save_
 
+save_reflns_scale.meas_f_su
+
+    _definition.id                '_reflns_scale.meas_F_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_F
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F_su
+    _name.linked_item_id          '_reflns_scale.meas_F'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_reflns_scale.meas_f_squared
 
     _definition.id                '_reflns_scale.meas_F_squared'
@@ -5432,6 +5691,25 @@ save_reflns_scale.meas_f_squared
 
 save_
 
+save_reflns_scale.meas_f_squared_su
+
+    _definition.id                '_reflns_scale.meas_F_squared_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_F_squared
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F_squared_su
+    _name.linked_item_id          '_reflns_scale.meas_F_squared'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_reflns_scale.meas_intensity
 
     _definition.id                '_reflns_scale.meas_intensity'
@@ -5448,6 +5726,25 @@ save_reflns_scale.meas_intensity
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_scale.meas_intensity_su
+
+    _definition.id                '_reflns_scale.meas_intensity_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_intensity
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_intensity_su
+    _name.linked_item_id          '_reflns_scale.meas_intensity'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -6026,6 +6323,25 @@ save_exptl.transmission_factor_max
 
 save_
 
+save_exptl.transmission_factor_max_su
+
+    _definition.id                '_exptl.transmission_factor_max_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl.transmission_factor_max
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_max_su
+    _name.linked_item_id          '_exptl.transmission_factor_max'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_exptl.transmission_factor_min
 
     _definition.id                '_exptl.transmission_factor_min'
@@ -6047,6 +6363,25 @@ save_exptl.transmission_factor_min
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_exptl.transmission_factor_min_su
+
+    _definition.id                '_exptl.transmission_factor_min_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl.transmission_factor_min
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_min_su
+    _name.linked_item_id          '_exptl.transmission_factor_min'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -6229,6 +6564,26 @@ save_cell.convert_uij_to_betaij
 
 save_
 
+save_cell.convert_uij_to_betaij_su
+
+    _definition.id                '_cell.convert_Uij_to_betaij_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uij_to_betaij
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uij_to_betaij_su
+    _name.linked_item_id          '_cell.convert_Uij_to_betaij'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
 save_cell.convert_uiso_to_uij
 
     _definition.id                '_cell.convert_Uiso_to_Uij'
@@ -6261,6 +6616,26 @@ save_cell.convert_uiso_to_uij
     Cosd(c.reciprocal_angle_alpha) ],                        [
     Cosd(c.reciprocal_angle_beta), Cosd(c.reciprocal_angle_alpha), 1.  ]]
 ;
+
+save_
+
+save_cell.convert_uiso_to_uij_su
+
+    _definition.id                '_cell.convert_Uiso_to_Uij_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uiso_to_Uij
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uiso_to_Uij_su
+    _name.linked_item_id          '_cell.convert_Uiso_to_Uij'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -6794,6 +7169,26 @@ save_cell.reciprocal_metric_tensor
 
 save_
 
+save_cell.reciprocal_metric_tensor_su
+
+    _definition.id                '_cell.reciprocal_metric_tensor_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_metric_tensor
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_metric_tensor_su
+    _name.linked_item_id          '_cell.reciprocal_metric_tensor'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstrom_squared
+
+save_
+
 save_cell.reciprocal_orthogonal_matrix
 
     _definition.id                '_cell.reciprocal_orthogonal_matrix'
@@ -6824,6 +7219,26 @@ save_cell.reciprocal_orthogonal_matrix
 
 save_
 
+save_cell.reciprocal_orthogonal_matrix_su
+
+    _definition.id                '_cell.reciprocal_orthogonal_matrix_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_orthogonal_matrix
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_orthogonal_matrix_su
+    _name.linked_item_id          '_cell.reciprocal_orthogonal_matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
 save_cell.reciprocal_vector_a
 
     _definition.id                '_cell.reciprocal_vector_a'
@@ -6847,6 +7262,26 @@ save_cell.reciprocal_vector_a
 
     _cell.reciprocal_vector_a = c.vector_b ^ c.vector_c / _cell.volume
 ;
+
+save_
+
+save_cell.reciprocal_vector_a_su
+
+    _definition.id                '_cell.reciprocal_vector_a_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_a
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_a_su
+    _name.linked_item_id          '_cell.reciprocal_vector_a'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
 
 save_
 
@@ -6876,6 +7311,26 @@ save_cell.reciprocal_vector_b
 
 save_
 
+save_cell.reciprocal_vector_b_su
+
+    _definition.id                '_cell.reciprocal_vector_b_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_b
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_b_su
+    _name.linked_item_id          '_cell.reciprocal_vector_b'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
 save_cell.reciprocal_vector_c
 
     _definition.id                '_cell.reciprocal_vector_c'
@@ -6899,6 +7354,26 @@ save_cell.reciprocal_vector_c
 
     _cell.reciprocal_vector_c = c.vector_a ^ c.vector_b / _cell.volume
 ;
+
+save_
+
+save_cell.reciprocal_vector_c_su
+
+    _definition.id                '_cell.reciprocal_vector_c_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_c
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_c_su
+    _name.linked_item_id          '_cell.reciprocal_vector_c'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
 
 save_
 
@@ -6950,6 +7425,26 @@ save_cell.vector_a
 
 save_
 
+save_cell.vector_a_su
+
+    _definition.id                '_cell.vector_a_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.vector_a
+;
+    _name.category_id             cell
+    _name.object_id               vector_a_su
+    _name.linked_item_id          '_cell.vector_a'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_cell.vector_b
 
     _definition.id                '_cell.vector_b'
@@ -6974,6 +7469,26 @@ save_cell.vector_b
 
 save_
 
+save_cell.vector_b_su
+
+    _definition.id                '_cell.vector_b_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.vector_b
+;
+    _name.category_id             cell
+    _name.object_id               vector_b_su
+    _name.linked_item_id          '_cell.vector_b'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_cell.vector_c
 
     _definition.id                '_cell.vector_c'
@@ -6995,6 +7510,26 @@ save_cell.vector_c
 ;
     _cell.vector_c = _cell.orthogonal_matrix * Matrix([0,0,1])
 ;
+
+save_
+
+save_cell.vector_c_su
+
+    _definition.id                '_cell.vector_c_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell.vector_c
+;
+    _name.category_id             cell
+    _name.object_id               vector_c_su
+    _name.linked_item_id          '_cell.vector_c'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
 
 save_
 
@@ -7376,6 +7911,25 @@ save_cell_measurement_refln.theta
 
 save_
 
+save_cell_measurement_refln.theta_su
+
+    _definition.id                '_cell_measurement_refln.theta_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _cell_measurement_refln.theta
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               theta_su
+    _name.linked_item_id          '_cell_measurement_refln.theta'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
+
+save_
+
 save_CHEMICAL
 
     _definition.id                CHEMICAL
@@ -7502,6 +8056,25 @@ save_chemical.enantioexcess_bulk
 
 save_
 
+save_chemical.enantioexcess_bulk_su
+
+    _definition.id                '_chemical.enantioexcess_bulk_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.enantioexcess_bulk
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_bulk_su
+    _name.linked_item_id          '_chemical.enantioexcess_bulk'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_chemical.enantioexcess_bulk_technique
 
     _definition.id                '_chemical.enantioexcess_bulk_technique'
@@ -7566,6 +8139,25 @@ save_chemical.enantioexcess_crystal
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_chemical.enantioexcess_crystal_su
+
+    _definition.id                '_chemical.enantioexcess_crystal_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.enantioexcess_crystal
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_crystal_su
+    _name.linked_item_id          '_chemical.enantioexcess_crystal'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -7696,6 +8288,25 @@ save_chemical.melting_point
 
 save_
 
+save_chemical.melting_point_su
+
+    _definition.id                '_chemical.melting_point_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.melting_point
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_su
+    _name.linked_item_id          '_chemical.melting_point'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
 save_chemical.melting_point_gt
 
     _definition.id                '_chemical.melting_point_gt'
@@ -7717,6 +8328,25 @@ save_chemical.melting_point_gt
 
 save_
 
+save_chemical.melting_point_gt_su
+
+    _definition.id                '_chemical.melting_point_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.melting_point_gt
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_gt_su
+    _name.linked_item_id          '_chemical.melting_point_gt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
 save_chemical.melting_point_lt
 
     _definition.id                '_chemical.melting_point_lt'
@@ -7734,6 +8364,25 @@ save_chemical.melting_point_lt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.melting_point_lt_su
+
+    _definition.id                '_chemical.melting_point_lt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.melting_point_lt
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_lt_su
+    _name.linked_item_id          '_chemical.melting_point_lt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   kelvins
 
 save_
@@ -7983,6 +8632,25 @@ save_chemical.temperature_decomposition_gt
 
 save_
 
+save_chemical.temperature_decomposition_gt_su
+
+    _definition.id                '_chemical.temperature_decomposition_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_decomposition_gt
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition_gt_su
+    _name.linked_item_id          '_chemical.temperature_decomposition_gt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
 save_chemical.temperature_decomposition_lt
 
     _definition.id                '_chemical.temperature_decomposition_lt'
@@ -8000,6 +8668,25 @@ save_chemical.temperature_decomposition_lt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_decomposition_lt_su
+
+    _definition.id                '_chemical.temperature_decomposition_lt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_decomposition_lt
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition_lt_su
+    _name.linked_item_id          '_chemical.temperature_decomposition_lt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   kelvins
 
 save_
@@ -8071,6 +8758,25 @@ save_chemical.temperature_sublimation_gt
 
 save_
 
+save_chemical.temperature_sublimation_gt_su
+
+    _definition.id                '_chemical.temperature_sublimation_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_sublimation_gt
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation_gt_su
+    _name.linked_item_id          '_chemical.temperature_sublimation_gt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
 save_chemical.temperature_sublimation_lt
 
     _definition.id                '_chemical.temperature_sublimation_lt'
@@ -8088,6 +8794,25 @@ save_chemical.temperature_sublimation_lt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_sublimation_lt_su
+
+    _definition.id                '_chemical.temperature_sublimation_lt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_sublimation_lt
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation_lt_su
+    _name.linked_item_id          '_chemical.temperature_sublimation_lt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   kelvins
 
 save_
@@ -8651,6 +9376,25 @@ save_chemical_formula.weight_meas
 
 save_
 
+save_chemical_formula.weight_meas_su
+
+    _definition.id                '_chemical_formula.weight_meas_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _chemical_formula.weight_meas
+;
+    _name.category_id             chemical_formula
+    _name.object_id               weight_meas_su
+    _name.linked_item_id          '_chemical_formula.weight_meas'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   dalton
+
+save_
+
 save_EXPTL_ABSORPT
 
     _definition.id                EXPTL_ABSORPT
@@ -8898,6 +9642,25 @@ save_exptl_crystal.density_diffrn
 
 save_
 
+save_exptl_crystal.density_diffrn_su
+
+    _definition.id                '_exptl_crystal.density_diffrn_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_diffrn
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_diffrn_su
+    _name.linked_item_id          '_exptl_crystal.density_diffrn'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
 save_exptl_crystal.density_meas
 
     _definition.id                '_exptl_crystal.density_meas'
@@ -8968,6 +9731,25 @@ save_exptl_crystal.density_meas_gt
 
 save_
 
+save_exptl_crystal.density_meas_gt_su
+
+    _definition.id                '_exptl_crystal.density_meas_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas_gt
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_gt_su
+    _name.linked_item_id          '_exptl_crystal.density_meas_gt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
 save_exptl_crystal.density_meas_lt
 
     _definition.id                '_exptl_crystal.density_meas_lt'
@@ -8988,6 +9770,25 @@ save_exptl_crystal.density_meas_lt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
+save_exptl_crystal.density_meas_lt_su
+
+    _definition.id                '_exptl_crystal.density_meas_lt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas_lt
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_lt_su
+    _name.linked_item_id          '_exptl_crystal.density_meas_lt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   megagrams_per_metre_cubed
 
 save_
@@ -9061,6 +9862,25 @@ save_exptl_crystal.density_meas_temp_gt
 
 save_
 
+save_exptl_crystal.density_meas_temp_gt_su
+
+    _definition.id                '_exptl_crystal.density_meas_temp_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas_temp_gt
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp_gt_su
+    _name.linked_item_id          '_exptl_crystal.density_meas_temp_gt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
 save_exptl_crystal.density_meas_temp_lt
 
     _definition.id                '_exptl_crystal.density_meas_temp_lt'
@@ -9080,6 +9900,25 @@ save_exptl_crystal.density_meas_temp_lt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_exptl_crystal.density_meas_temp_lt_su
+
+    _definition.id                '_exptl_crystal.density_meas_temp_lt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas_temp_lt
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp_lt_su
+    _name.linked_item_id          '_exptl_crystal.density_meas_temp_lt'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   kelvins
 
 save_
@@ -9258,6 +10097,25 @@ save_exptl_crystal.size_length
 
 save_
 
+save_exptl_crystal.size_length_su
+
+    _definition.id                '_exptl_crystal.size_length_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_length
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_length_su
+    _name.linked_item_id          '_exptl_crystal.size_length'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
 save_exptl_crystal.size_max
 
     _definition.id                '_exptl_crystal.size_max'
@@ -9274,6 +10132,25 @@ save_exptl_crystal.size_max
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_max_su
+
+    _definition.id                '_exptl_crystal.size_max_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_max
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_max_su
+    _name.linked_item_id          '_exptl_crystal.size_max'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   millimetres
 
 save_
@@ -9298,6 +10175,25 @@ save_exptl_crystal.size_mid
 
 save_
 
+save_exptl_crystal.size_mid_su
+
+    _definition.id                '_exptl_crystal.size_mid_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_mid
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_mid_su
+    _name.linked_item_id          '_exptl_crystal.size_mid'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
 save_exptl_crystal.size_min
 
     _definition.id                '_exptl_crystal.size_min'
@@ -9318,6 +10214,25 @@ save_exptl_crystal.size_min
 
 save_
 
+save_exptl_crystal.size_min_su
+
+    _definition.id                '_exptl_crystal.size_min_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_min
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_min_su
+    _name.linked_item_id          '_exptl_crystal.size_min'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
 save_exptl_crystal.size_rad
 
     _definition.id                '_exptl_crystal.size_rad'
@@ -9334,6 +10249,25 @@ save_exptl_crystal.size_rad
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_rad_su
+
+    _definition.id                '_exptl_crystal.size_rad_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_rad
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_rad_su
+    _name.linked_item_id          '_exptl_crystal.size_rad'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   millimetres
 
 save_
@@ -9615,6 +10549,25 @@ save_exptl_crystal_face.perp_dist
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal_face.perp_dist_su
+
+    _definition.id                '_exptl_crystal_face.perp_dist_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.perp_dist
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               perp_dist_su
+    _name.linked_item_id          '_exptl_crystal_face.perp_dist'
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
     _units.code                   millimetres
 
 save_
@@ -11072,6 +12025,26 @@ save_geom_angle.distances
 
 save_
 
+save_geom_angle.distances_su
+
+    _definition.id                '_geom_angle.distances_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _geom_angle.distances
+;
+    _name.category_id             geom_angle
+    _name.object_id               distances_su
+    _name.linked_item_id          '_geom_angle.distances'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_geom_angle.id
 
     _definition.id                '_geom_angle.id'
@@ -11476,6 +12449,25 @@ save_geom_bond.valence
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.:
+    _units.code                   electrons
+
+save_
+
+save_geom_bond.valence_su
+
+    _definition.id                '_geom_bond.valence_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _geom_bond.valence
+;
+    _name.category_id             geom_bond
+    _name.object_id               valence_su
+    _name.linked_item_id          '_geom_bond.valence'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   electrons
 
 save_
@@ -12348,6 +13340,26 @@ save_geom_torsion.distances
 
 save_
 
+save_geom_torsion.distances_su
+
+    _definition.id                '_geom_torsion.distances_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _geom_torsion.distances
+;
+    _name.category_id             geom_torsion
+    _name.object_id               distances_su
+    _name.linked_item_id          '_geom_torsion.distances'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_geom_torsion.id
 
     _definition.id                '_geom_torsion.id'
@@ -12557,6 +13569,26 @@ save_model_site.adp_eigenvalues
 
 save_
 
+save_model_site.adp_eigenvalues_su
+
+    _definition.id                '_model_site.adp_eigenvalues_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _model_site.adp_eigenvalues
+;
+    _name.category_id             model_site
+    _name.object_id               adp_eigenvalues_su
+    _name.linked_item_id          '_model_site.adp_eigenvalues'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Array
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_model_site.adp_eigenvectors
 
     _definition.id                '_model_site.adp_eigenvectors'
@@ -12588,6 +13620,26 @@ save_model_site.adp_eigenvectors
 
 save_
 
+save_model_site.adp_eigenvectors_su
+
+    _definition.id                '_model_site.adp_eigenvectors_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _model_site.adp_eigenvectors
+;
+    _name.category_id             model_site
+    _name.object_id               adp_eigenvectors_su
+    _name.linked_item_id          '_model_site.adp_eigenvectors'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Array
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
 save_model_site.adp_matrix_beta
 
     _definition.id                '_model_site.adp_matrix_beta'
@@ -12616,6 +13668,26 @@ save_model_site.adp_matrix_beta
 
 save_
 
+save_model_site.adp_matrix_beta_su
+
+    _definition.id                '_model_site.adp_matrix_beta_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _model_site.adp_matrix_beta
+;
+    _name.category_id             model_site
+    _name.object_id               adp_matrix_beta_su
+    _name.linked_item_id          '_model_site.adp_matrix_beta'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_model_site.cartn_xyz
 
     _definition.id                '_model_site.Cartn_xyz'
@@ -12639,6 +13711,26 @@ save_model_site.cartn_xyz
 
     _model_site.Cartn_xyz =  _atom_sites_Cartn_transform.matrix * m.fract_xyz
 ;
+
+save_
+
+save_model_site.cartn_xyz_su
+
+    _definition.id                '_model_site.Cartn_xyz_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _model_site.Cartn_xyz
+;
+    _name.category_id             model_site
+    _name.object_id               Cartn_xyz_su
+    _name.linked_item_id          '_model_site.Cartn_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
 
 save_
 
@@ -12692,6 +13784,26 @@ save_model_site.fract_xyz
 
     _model_site.fract_xyz =  SymEquiv(m.symop, xyz)
 ;
+
+save_
+
+save_model_site.fract_xyz_su
+
+    _definition.id                '_model_site.fract_xyz_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _model_site.fract_xyz
+;
+    _name.category_id             model_site
+    _name.object_id               fract_xyz_su
+    _name.linked_item_id          '_model_site.fract_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -13298,8 +14410,8 @@ save_audit.schema
 ;
          'Entry'
 ;
-         entry category is defined and looped: information from multiple
-         data blocks in one block
+         entry category is defined and looped: information from multiple data
+         blocks in one block
 ;
          'Custom'
 ;
@@ -18346,6 +19458,26 @@ save_atom_site.cartn_xyz
 
 save_
 
+save_atom_site.cartn_xyz_su
+
+    _definition.id                '_atom_site.Cartn_xyz_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_site.Cartn_xyz
+;
+    _name.category_id             atom_site
+    _name.object_id               Cartn_xyz_su
+    _name.linked_item_id          '_atom_site.Cartn_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_atom_site.cartn_y
 
     _definition.id                '_atom_site.Cartn_y'
@@ -18587,6 +19719,26 @@ save_atom_site.fract_xyz
 
     _atom_site.fract_xyz =  [a.fract_x, a.fract_y, a.fract_z]
 ;
+
+save_
+
+save_atom_site.fract_xyz_su
+
+    _definition.id                '_atom_site.fract_xyz_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_site.fract_xyz
+;
+    _name.category_id             atom_site
+    _name.object_id               fract_xyz_su
+    _name.linked_item_id          '_atom_site.fract_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -19082,6 +20234,26 @@ save_atom_site.tensor_beta
 
 save_
 
+save_atom_site.tensor_beta_su
+
+    _definition.id                '_atom_site.tensor_beta_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_site.tensor_beta
+;
+    _name.category_id             atom_site
+    _name.object_id               tensor_beta_su
+    _name.linked_item_id          '_atom_site.tensor_beta'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_atom_site.type_symbol
 
     _definition.id                '_atom_site.type_symbol'
@@ -19522,6 +20694,26 @@ save_atom_site_aniso.matrix_b
 
 save_
 
+save_atom_site_aniso.matrix_b_su
+
+    _definition.id                '_atom_site_aniso.matrix_B_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_B
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_B_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_B'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
 save_atom_site_aniso.matrix_u
 
     _definition.id                '_atom_site_aniso.matrix_U'
@@ -19547,6 +20739,26 @@ save_atom_site_aniso.matrix_u
                       [ a.U_12, a.U_22, a.U_23 ],
                       [ a.U_13, a.U_23, a.U_33 ]]
 ;
+
+save_
+
+save_atom_site_aniso.matrix_u_su
+
+    _definition.id                '_atom_site_aniso.matrix_U_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_U
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_U_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_U'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
 
 save_
 
@@ -20382,6 +21594,26 @@ save_atom_sites_cartn_transform.matrix
 
 save_
 
+save_atom_sites_cartn_transform.matrix_su
+
+    _definition.id                '_atom_sites_Cartn_transform.matrix_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.matrix
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
 save_atom_sites_cartn_transform.vec_1
 
     _definition.id                '_atom_sites_Cartn_transform.vec_1'
@@ -20456,6 +21688,26 @@ save_atom_sites_cartn_transform.vector
 
     _atom_sites_Cartn_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
 ;
+
+save_
+
+save_atom_sites_cartn_transform.vector_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vector_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vector
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
 
 save_
 
@@ -20685,6 +21937,26 @@ save_atom_sites_fract_transform.matrix
 
 save_
 
+save_atom_sites_fract_transform.matrix_su
+
+    _definition.id                '_atom_sites_fract_transform.matrix_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.matrix
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_fract_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
 save_atom_sites_fract_transform.vec_1
 
     _definition.id                '_atom_sites_fract_transform.vec_1'
@@ -20762,6 +22034,26 @@ save_atom_sites_fract_transform.vector
 
 save_
 
+save_atom_sites_fract_transform.vector_su
+
+    _definition.id                '_atom_sites_fract_transform.vector_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vector
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_ATOM_TYPE
 
     _definition.id                ATOM_TYPE
@@ -20814,6 +22106,25 @@ save_atom_type.analytical_mass_percent
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:100.
+    _units.code                   none
+
+save_
+
+save_atom_type.analytical_mass_percent_su
+
+    _definition.id                '_atom_type.analytical_mass_percent_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _atom_type.analytical_mass_percent
+;
+    _name.category_id             atom_type
+    _name.object_id               analytical_mass_percent_su
+    _name.linked_item_id          '_atom_type.analytical_mass_percent'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -22424,6 +23735,24 @@ save_refine_ls.f_calc_precision
 
 save_
 
+save_refine_ls.f_calc_precision_su
+
+    _definition.id                '_refine_ls.F_calc_precision_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refine_ls.F_calc_precision
+;
+    _name.category_id             refine_ls
+    _name.object_id               F_calc_precision_su
+    _name.linked_item_id          '_refine_ls.F_calc_precision'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+save_
+
 save_refine_ls.goodness_of_fit_all
 
     _definition.id                '_refine_ls.goodness_of_fit_all'
@@ -22603,6 +23932,25 @@ save_refine_ls.goodness_of_fit_ref
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.goodness_of_fit_ref_su
+
+    _definition.id                '_refine_ls.goodness_of_fit_ref_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refine_ls.goodness_of_fit_ref
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_ref_su
+    _name.linked_item_id          '_refine_ls.goodness_of_fit_ref'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_
@@ -23089,6 +24437,25 @@ save_refine_ls.restrained_s_all
 
 save_
 
+save_refine_ls.restrained_s_all_su
+
+    _definition.id                '_refine_ls.restrained_S_all_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refine_ls.restrained_S_all
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_all_su
+    _name.linked_item_id          '_refine_ls.restrained_S_all'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_refine_ls.restrained_s_gt
 
     _definition.id                '_refine_ls.restrained_S_gt'
@@ -23139,6 +24506,25 @@ save_refine_ls.restrained_s_gt
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.restrained_s_gt_su
+
+    _definition.id                '_refine_ls.restrained_S_gt_su'
+    _definition.update            2021-09-22
+    _description.text
+;
+    Standard uncertainty of _refine_ls.restrained_S_gt
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_gt_su
+    _name.linked_item_id          '_refine_ls.restrained_S_gt'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
     _units.code                   none
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-08-19
+    _dictionary.date              2021-09-22
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.0.1
@@ -25430,7 +25430,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-08-19
+         3.1.0                    2021-09-22
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -25469,4 +25469,6 @@ save_
        the _space_group_Wyckoff.multiplicity data item.
 
        Fixed text description of _atom_site.U,B_iso_or_equiv.
+
+       Added multiple standard uncertainty (SU) data items.
 ;


### PR DESCRIPTION
A recent update to DDL stipulated that all "Measurand" data names
should have SU data names defined for them. This update adds
missing SU data names for those Measurand data names that did
not previously have them.