### PR TITLE
Redefine the _atom_site.Wyckoff_symbol data item as an enumerator

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11855,7 +11855,7 @@ save_
 save_space_group_wyckoff.letter
 
     _definition.id                '_space_group_Wyckoff.letter'
-    _definition.update            2014-06-12
+    _definition.update            2021-09-23
     _description.text
 ;
     The Wyckoff letter associated with this position, as given in
@@ -11874,35 +11874,8 @@ save_space_group_wyckoff.letter
     _type.container               Single
     _type.contents                Text
 
-    loop_
-      _enumeration_set.state
-         a
-         b
-         c
-         d
-         e
-         f
-         g
-         h
-         i
-         j
-         k
-         l
-         m
-         n
-         o
-         p
-         q
-         r
-         s
-         t
-         u
-         v
-         w
-         x
-         y
-         z
-         \a
+    _import.get
+        [{'file':templ_enum.cif  'save':Wyckoff_letter}]
 
 save_
 
@@ -20632,7 +20605,7 @@ save_atom_site.wyckoff_symbol
 
     _definition.id                '_atom_site.Wyckoff_symbol'
     _alias.definition_id          '_atom_site_Wyckoff_symbol'
-    _definition.update            2012-11-20
+    _definition.update            2021-09-23
     _description.text
 ;
     The Wyckoff symbol (letter) as listed in the space-group section
@@ -20640,10 +20613,13 @@ save_atom_site.wyckoff_symbol
 ;
     _name.category_id             atom_site
     _name.object_id               Wyckoff_symbol
-    _type.purpose                 Encode
+    _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
+
+    _import.get
+        [{'file':templ_enum.cif  'save':Wyckoff_letter}]
 
 save_
 
@@ -26112,4 +26088,7 @@ save_
        Fixed text description of _atom_site.U,B_iso_or_equiv.
 
        Added multiple standard uncertainty (SU) data items.
+
+       Restricted the _atom_site.Wyckoff_symbol data item values
+       to a set of case-sensitive enumeration values.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -10,7 +10,7 @@ data_COM_VAL
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.8
-    _dictionary.date             2021-08-19
+    _dictionary.date             2021-09-23
     _dictionary.uri              www.iucr.org/cif/dic/com_val.dic
     _dictionary.ddl_conformance  3.11.04
     _description.text
@@ -2214,6 +2214,40 @@ save_colour_hue
 
 save_
 
+save_Wyckoff_letter
+
+    loop_
+      _enumeration_set.state
+         a
+         b
+         c
+         d
+         e
+         f
+         g
+         h
+         i
+         j
+         k
+         l
+         m
+         n
+         o
+         p
+         q
+         r
+         s
+         t
+         u
+         v
+         w
+         x
+         y
+         z
+         \a
+
+save_
+
 #=============================================================================
 #  The dictionary's creation history.
 #============================================================================
@@ -2322,7 +2356,7 @@ save_
    Updated the human-readable descriptions of the 'kelvins' and
    'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-      1.4.8   2021-08-19
+      1.4.8   2021-09-23
 ;
    Corrected a few typos in the 'units_code' save frame.
 
@@ -2334,4 +2368,6 @@ save_
    'violet' to 'violet_magenta'.
 
    Added the 'grey_steel' colour to the 'colour_RGB' save frame.
+
+   Added the 'Wyckoff_letter' save frame.
 ;


### PR DESCRIPTION
This PR resolves issue #71. Please note, that I also changed the data type of the `_atom_site.Wyckoff_symbol` data item from `Code` to `Text` to make it case sensitive (and match the definition of the `_space_group_Wyckoff.letter` data item). I guess for most "custom" enumeration values the distinction between lower/upper letters is not important (i.e. Uijo), however, in this instance the enumeration values are taken from an external source and thus it might be better to restrict them to the original (lower) case.