### PR TITLE
Fix the _exptl_crystal.colour data item example case.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-09-27
+    _dictionary.date              2021-10-20
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.0.1
@@ -9784,7 +9784,7 @@ save_exptl_crystal.colour
 
     _definition.id                '_exptl_crystal.colour'
     _alias.definition_id          '_exptl_crystal_colour'
-    _definition.update            2021-03-03
+    _definition.update            2021-10-20
     _description.text
 ;
     Colour description of a crystal as a list of the allowed
@@ -9797,7 +9797,7 @@ save_exptl_crystal.colour
     _type.container               List
     _type.dimension               '[3]'
     _type.contents                Code
-    _description_example.case     '[translucent, pale, green]'
+    _description_example.case     [translucent  pale  green]
     _method.purpose               Evaluation
     _method.expression
 ;
@@ -26039,7 +26039,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-09-27
+         3.1.0                    2021-10-20
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -26087,4 +26087,6 @@ save_
        Updated the capitalisation of multiple data items.
 
        Updated the AUDIT_SUPPORT category example case.
+
+       Fixed the _exptl_crystal.colour data item example case.
 ;


### PR DESCRIPTION
This PR fixes the `_exptl_crystal.colour` data item example case by changing it from a string to a proper CIF2 list. 

The `_exptl_crystal.colour` data item might get further modified in the future (see issue #189), however, this fix will at least allow the dictionary to properly validate for now.