### PR TITLE
Fix dictionary audit loop in template files

### DIFF
--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -4,15 +4,15 @@
 #              TEMPLATE DEFINITION ATTRIBUTES DICTIONARY                     #
 #                                                                            #
 ##############################################################################
- 
+
 data_TEMPL_ATTR
- 
+
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.10
-    _dictionary.date             2021-07-21
+    _dictionary.date             2021-10-20
     _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
-    _dictionary.ddl_conformance  3.14.0
+    _dictionary.ddl_conformance  4.1.0
     _description.text
 ;
      This dictionary contains definition attribute sets that are common
@@ -837,152 +837,150 @@ save_display_colour
     _units.code                  none
      save_
 
-
-
 #=============================================================================
 #  The dictionary's attribute creation history.
 #============================================================================
- 
-     loop_
-    _dictionary_audit.version
-    _dictionary_audit.date
-    _dictionary_audit.revision
- 
-      1.0.0   2005-12-12
-;
-   Initial version of the TEMPLATES dictionary created from the 
-   definitions used in CORE_3 dictionary version 3.5.02
-;
-      1.0.1   2006-02-12
-;
-   Remove dictionary attributes from a save frame.
-   Change category core_templates to template
-;
-      1.2.01  2006-02-21
-;
-   File structure to conform with prototype version dictionaries.
-;
-      1.2.02  2006-03-07
-;
-   Added the template _template.relational_id for the ddl3 dictionary.
-;
-      1.2.03  2006-06-17
-;
-   Apply DDL 3.6.01 changes
-;
-      1.2.04  2006-06-29
-;
-   Remove "_template" from the definition names.
-   Apply DDL 3.6.05 changes.
-   Change file name from templates.dic to com_att.dic
-;
-      1.2.05  2006-09-07
-;
-   Apply DDL 3.6.08 changes
-;
-      1.2.06  2006-11-13
-;
-   Apply DDL 3.6.10 changes
-;
-      1.2.07  2006-12-14
-;
-   Apply DDL 3.7.01 changes
-;
-      1.2.08  2008-06-18
-;
-   Change _type.purpose for Miller_index from Observed to Identify
-;
-      1.3.01  2011-08-03
-;
-     Remove definition.id lines in keeping with nested imports.       
-;
-      1.3.02  2011-12-01
-;
-  Update the DDL version. No Matrix types present.
-;
-      1.3.03  2012-05-07
-;
-  Apply changes of 3.10.01 DDL version.
-;
-      1.3.04  2012-10-16
-;
-  Apply changes of 3.10.02 DDL version. "Label" becomes "Code".
-;
-      1.3.05  2012-11-29
-;
-  Add    "_enumeration.def_index_id  '_atom_type.symbol' "
-  to Cromer_Mann_coeff and hi_ang_Fox_coeffs.
-;
-      1.3.06  2012-12-11
-;
-  Add the templates Cartn_matrix and fract_matrix
-;
-      1.4.01  2013-03-08
-;
-  Changes arising from alerts issued by ALIGN.
-;
-      1.4.02  2013-04-15
-;
-   Removed desription.common from all defs; inconsistent invocations
-   Changed types for 'diffrn_angle'
-   Added new frame for 'orient_angle'
-;
-      1.4.03  2013-04-16
-;
-   Changed type.source 'Measured' to 'Recorded'
-   Changed type.source 'Assigned' to 'Recorded' in Miller_index
-;
-      1.4.04  2013-04-17
-;
-   Changed type.source 'Quantity' to 'Number' or 'Encode'
-;
-      1.4.05  2014-06-08
-;
-   Added aniso_BIJ_su and aniso_UIJ_su
-   Added atom_site_fract_su and atom_site_cartn_su
-;
-      1.4.06  2014-06-09
-;
-   dummy top line added to all frames; this is skipped on import.
-;
-      1.4.07  2014-06-12
-;
-   Added attribute save frame "aniso_BIJ2"
-   Added attribute save frame "rot_matrix_IJ"
-   Added attribute save frame "ncs_matrix_IJ"
-   Added attribute save frame "atom_site_id"
-   Added attribute save frame "label_comp"
-;
-      1.4.08  2014-06-27
-;
-   Added attribute save frame "ms_index"
-   Added attribute save frame "matrix_w"
-;
-      1.4.09  2019-09-25
-;
-   Changed the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
-   save frame.
 
-   Removed the '_name.linked_item_id' data item from the 'atom_site_label'
-   save frame.
-
-   Changed the data type in the 'diffr_counts' save frame from 'Count' to
-   'Integer'.
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.0.0                    2005-12-12
 ;
-
-      1.4.10  2021-07-21
+       Initial version of the TEMPLATES dictionary created from the
+       definitions used in CORE_3 dictionary version 3.5.02
 ;
-   Corrected a few typos in the descriptions of several save frames.
+         1.0.1                    2006-02-12
+;
+       Remove dictionary attributes from a save frame.
+       Change category core_templates to template
+;
+         1.2.1                    2006-02-21
+;
+       File structure to conform with prototype version dictionaries.
+;
+         1.2.2                    2006-03-07
+;
+       Added the template _template.relational_id for the ddl3 dictionary.
+;
+         1.2.3                    2006-06-17
+;
+       Apply DDL 3.6.01 changes
+;
+         1.2.4                    2006-06-29
+;
+       Remove "_template" from the definition names.
+       Apply DDL 3.6.05 changes.
+       Change file name from templates.dic to com_att.dic
+;
+         1.2.5                    2006-09-07
+;
+       Apply DDL 3.6.08 changes
+;
+         1.2.6                    2006-11-13
+;
+       Apply DDL 3.6.10 changes
+;
+         1.2.7                    2006-12-14
+;
+       Apply DDL 3.7.01 changes
+;
+         1.2.8                    2008-06-18
+;
+       Change _type.purpose for Miller_index from Observed to Identify
+;
+         1.3.1                    2011-08-03
+;
+       Remove definition.id lines in keeping with nested imports.
+;
+         1.3.2                    2011-12-01
+;
+       Update the DDL version. No Matrix types present.
+;
+         1.3.3                    2012-05-07
+;
+       Apply changes of 3.10.01 DDL version.
+;
+         1.3.4                    2012-10-16
+;
+       Apply changes of 3.10.02 DDL version. "Label" becomes "Code".
+;
+         1.3.5                    2012-11-29
+;
+       Add "_enumeration.def_index_id  '_atom_type.symbol' "
+       to Cromer_Mann_coeff and hi_ang_Fox_coeffs.
+;
+         1.3.6                    2012-12-11
+;
+       Add the templates Cartn_matrix and fract_matrix
+;
+         1.4.1                    2013-03-08
+;
+       Changes arising from alerts issued by ALIGN.
+;
+         1.4.2                    2013-04-15
+;
+       Removed description.common from all defs; inconsistent invocations
+       Changed types for 'diffrn_angle'
+       Added new frame for 'orient_angle'
+;
+         1.4.3                    2013-04-16
+;
+       Changed type.source 'Measured' to 'Recorded'
+       Changed type.source 'Assigned' to 'Recorded' in Miller_index
+;
+         1.4.4                    2013-04-17
+;
+       Changed type.source 'Quantity' to 'Number' or 'Encode'
+;
+         1.4.5                    2014-06-08
+;
+       Added aniso_BIJ_su and aniso_UIJ_su
+       Added atom_site_fract_su and atom_site_cartn_su
+;
+         1.4.6                    2014-06-09
+;
+       dummy top line added to all frames; this is skipped on import.
+;
+         1.4.7                    2014-06-12
+;
+       Added attribute save frame "aniso_BIJ2"
+       Added attribute save frame "rot_matrix_IJ"
+       Added attribute save frame "ncs_matrix_IJ"
+       Added attribute save frame "atom_site_id"
+       Added attribute save frame "label_comp"
+;
+         1.4.8                    2014-06-27
+;
+       Added attribute save frame "ms_index"
+       Added attribute save frame "matrix_w"
+;
+         1.4.9                    2019-09-25
+;
+       Changed the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
+       save frame.
 
-   Added the 'none' units of measurement to the 'rho_coeff', 'rho_kappa',
-   'rho_slater', 'matrix_pdb', 'matrix_w', 'index_limit_max', 'index_limit_min',
-   'ncs_matrix_IJ' and 'rot_matrix_IJ' save frames.
+       Removed the '_name.linked_item_id' data item from the 'atom_site_label'
+       save frame.
 
-   Changed the units of measurement in the 'Cartn_matrix' save frame
-   from 'reciprocal_angstroms' to 'angstroms'.
+       Changed the data type in the 'diffr_counts' save frame from 'Count' to
+       'Integer'.
+;
+         1.4.10                   2021-10-20
+;
+       Corrected a few typos in the descriptions of several save frames.
 
-   Changed the units of measurement in the 'fract_matrix' save frame
-   from 'none' to 'reciprocal_angstroms'.
+       Added the 'none' units of measurement to the 'rho_coeff',
+       'rho_kappa', 'rho_slater', 'matrix_pdb', 'matrix_w', 'index_limit_max',
+       'index_limit_min', 'ncs_matrix_IJ' and 'rot_matrix_IJ' save frames.
 
-   Added the 'Cartn_vector' and 'fract_vector' save frames.
+       Changed the units of measurement in the 'Cartn_matrix' save frame
+       from 'reciprocal_angstroms' to 'angstroms'.
+
+       Changed the units of measurement in the 'fract_matrix' save frame
+       from 'none' to 'reciprocal_angstroms'.
+
+       Added the 'Cartn_vector' and 'fract_vector' save frames.
+
+       Changed the DDL conformance version number from 3.14.0 to 4.1.0.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -2261,7 +2261,7 @@ save_
        Initial version of the TEMPLATES dictionary created from the
        definitions used in CORE_3 dictionary version 3.5.02
 ;
-         1.0.1                    2006-02-12
+         1.1.0                    2006-02-12
 ;
        Remove dictionary attributes from a save frame.
        Change category core_templates to template
@@ -2355,7 +2355,7 @@ save_
        Updated the human-readable descriptions of the 'kelvins' and
        'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-         1.4.8                    2021-09-23
+         1.4.8                    2021-10-20
 ;
        Corrected a few typos in the 'units_code' save frame.
 
@@ -2371,4 +2371,7 @@ save_
        Added the 'Wyckoff_letter' save frame.
 
        Changed the DDL conformance version number from 3.11.04 to 4.1.0.
+
+       Changed a duplicate version number in the DICTIONARY_AUDIT loop
+       from 1.0.1 to 1.1.0.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -6,13 +6,13 @@
 ##############################################################################
 
 data_COM_VAL
- 
+
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.8
-    _dictionary.date             2021-09-23
+    _dictionary.date             2021-10-20
     _dictionary.uri              www.iucr.org/cif/dic/com_val.dic
-    _dictionary.ddl_conformance  3.11.04
+    _dictionary.ddl_conformance  4.1.0
     _description.text
 ;
      This dictionary contains commonly used enumeration value sets that
@@ -2252,122 +2252,123 @@ save_
 #  The dictionary's creation history.
 #============================================================================
  
-     loop_
-    _dictionary_audit.version
-    _dictionary_audit.date
-    _dictionary_audit.revision
- 
-      1.0.01   2005-12-12
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.0.1                    2005-12-12
 ;
-   Initial version of the TEMPLATES dictionary created from the 
-   definitions used in CORE_3 dictionary version 3.5.02
+       Initial version of the TEMPLATES dictionary created from the
+       definitions used in CORE_3 dictionary version 3.5.02
 ;
-      1.0.1   2006-02-12
+         1.0.1                    2006-02-12
 ;
-   Remove dictionary attributes from a save frame.
-   Change category core_templates to template
+       Remove dictionary attributes from a save frame.
+       Change category core_templates to template
 ;
-      1.2.01  2006-02-21
+         1.2.1                    2006-02-21
 ;
-   File structure to conform with prototype version dictionaries.
+       File structure to conform with prototype version dictionaries.
 ;
-      1.2.02  2006-03-07
+         1.2.2                    2006-03-07
 ;
-   Added the template _template.relational_id for the ddl3 dictionary.
+       Added the template _template.relational_id for the ddl3 dictionary.
 ;
-      1.2.03  2006-06-20
+         1.2.3                    2006-06-20
 ;
-   Apply DDL 3.6.04 attributes.
+       Apply DDL 3.6.04 attributes.
 ;
-      1.2.04  2006-06-27
+         1.2.4                    2006-06-27
 ;
-   Change filename to com_val.dic.
-   apply DDL 3.6.05 changes.
-   add 'context' and 'method' enumerated lists
-   add 'enumeration_default' blocks to this file
+       Change filename to com_val.dic.
+       apply DDL 3.6.05 changes.
+       add 'context' and 'method' enumerated lists
+       add 'enumeration_default' blocks to this file
 ;
-      1.2.05  2006-08-30
+         1.2.5                    2006-08-30
 ;
-   In type.contents change constrction of Otag to 'ANchar [_]'
+       In type.contents change constrction of Otag to 'ANchar [_]'
 ;
-      1.2.06  2006-11-13
+         1.2.6                    2006-11-13
 ;
-   Remove method and context frames
+       Remove method and context frames
 ;
-      1.2.07  2006-12-14
+         1.2.7                    2006-12-14
 ;
-     Apply DDL3 3.7.01 attributes.
+       Apply DDL3 3.7.01 attributes.
 ;
-      1.2.08  2007-10-11
+         1.2.8                    2007-10-11
 ;
-     Correct definitions of Ctag and Otag in _type.contents
+       Correct definitions of Ctag and Otag in _type.contents
 ;
-      1.2.09  2011-03-25
+         1.2.9                    2011-03-25
 ;
-     Change the syntax of "Filename" in type_contents enumeration set.
+       Change the syntax of "Filename" in type_contents enumeration set.
 ;
-      1.3.01  2011-08-03
+         1.3.1                    2011-08-03
 ;
-     Remove definition.id lines in keeping with nested imports.       
+       Remove definition.id lines in keeping with nested imports.
 ;
-      1.3.02  2011-12-01
+         1.3.2                    2011-12-01
 ;
-  Update the DDL version. No Matrix types present.
+       Update the DDL version. No Matrix types present.
 ;
-      1.3.03  2012-05-07
+         1.3.3                    2012-05-07
 ;
-  Update the DDL version. Change dictionary class to Template
+       Update the DDL version. Change dictionary class to Template
 ;
-      1.3.04  2012-07-08
+         1.3.4                    2012-07-08
 ;
-  Remove type.contents enumeration list
+       Remove type.contents enumeration list
 ;
-      1.3.05  2012-10-16
+         1.3.5                    2012-10-16
 ;
-  Change all element symbols in the ion-to-elemnt default list to Upper
-  and lower case characters (from all upper).
+       Change all element symbols in the ion-to-elemnt default list to Upper
+       and lower case characters (from all upper).
 ;
-      1.4.01  2013-03-08
+         1.4.1                    2013-03-08
 ;
-  Changes arising from alerts issued by ALIGN.
+       Changes arising from alerts issued by ALIGN.
 ;
-      1.4.02  2013-04-16
+         1.4.2                    2013-04-16
 ;
-   Changed type.source 'Measured' to 'Recorded'
+       Changed type.source 'Measured' to 'Recorded'
 ;
-      1.4.03  2014-06-09
+         1.4.3                    2014-06-09
 ;
-   Inserted dummy line at top of each frame; this is skipped on import
+       Inserted dummy line at top of each frame; this is skipped on import
 ;
-      1.4.04  2016-04-01
+         1.4.4                    2016-04-01
 ;
-   Added Bohr magnetons and radians to the units list (James Hester)
+       Added Bohr magnetons and radians to the units list (James Hester)
 ;
-      1.4.05  2016-05-13
-;  
-   Added Schoenflies group list (James Hester)
+         1.4.5                    2016-05-13
 ;
-      1.4.06  2017-12-12
+       Added Schoenflies group list (James Hester)
 ;
-   Updated atom symbol list for newly-named elements (James Hester)
+         1.4.6                    2017-12-12
 ;
-      1.4.07  2019-12-09
+       Updated atom symbol list for newly-named elements (James Hester)
 ;
-   Updated the human-readable descriptions of the 'kelvins' and
-   'kelvins_per_minute' enumeration states in the _units_code save frame.
+         1.4.7                    2019-12-09
 ;
-      1.4.8   2021-09-23
+       Updated the human-readable descriptions of the 'kelvins' and
+       'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-   Corrected a few typos in the 'units_code' save frame.
+         1.4.8                    2021-09-23
+;
+       Corrected a few typos in the 'units_code' save frame.
 
-   Added deuterium (D) to the 'element_symbol' save frame.
+       Added deuterium (D) to the 'element_symbol' save frame.
 
-   Corrected several discrepancies in the 'colour_hue' save frame:
-   replaced colour value 'unknown' with CIF special value '?',
-   renamed colour 'steel_grey' to 'grey_steel', renamed colour
-   'violet' to 'violet_magenta'.
+       Corrected several discrepancies in the 'colour_hue' save frame:
+       replaced colour value 'unknown' with CIF special value '?',
+       renamed colour 'steel_grey' to 'grey_steel', renamed colour
+       'violet' to 'violet_magenta'.
 
-   Added the 'grey_steel' colour to the 'colour_RGB' save frame.
+       Added the 'grey_steel' colour to the 'colour_RGB' save frame.
 
-   Added the 'Wyckoff_letter' save frame.
+       Added the 'Wyckoff_letter' save frame.
+
+       Changed the DDL conformance version number from 3.11.04 to 4.1.0.
 ;


### PR DESCRIPTION
This PR:
- Updates the version number string in template files to conform to format used in other dictionaries.
- Updates the formatting of the `DICTIONARY_AUDIT` loop to follow the DDLm dictionary style guide.
- Changes the DDLm dictionary conformance version to 4.1.0 (latest available at the time).

Also note, that one version number in the `DICTIONARY_AUDIT` loop of the `temp_enum.cif` file had to be changed from 1.0.1 to 1.1.0 in order to avoid duplicate loop key values.