### PR TITLE
Homogenise definitions of journal issue items.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-11-09
+    _dictionary.date              2021-11-12
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -15599,20 +15599,21 @@ save_citation.journal_issue
 
     _definition.id                '_citation.journal_issue'
     _alias.definition_id          '_citation_journal_issue'
-    _definition.update            2021-03-01
+    _definition.update            2021-11-12
     _description.text
 ;
-    Issue number of the journal cited;  relevant for articles.
+    Issue identifier of the journal cited;  relevant for articles.
 ;
     _name.category_id             citation
     _name.object_id               journal_issue
-    _type.purpose                 Number
+    _type.purpose                 Encode
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _units.code                   none
-    _description_example.case     2
+    _type.contents                Text
+    loop_
+      _description_example.case
+         '2'
+         'Special Issue'
 
 save_
 
@@ -16872,7 +16873,7 @@ save_journal.issue
 
     _definition.id                '_journal.issue'
     _alias.definition_id          '_journal_issue'
-    _definition.update            2021-11-04
+    _definition.update            2021-11-12
     _description.text
 ;
     Issue identifier within the journal.
@@ -16883,6 +16884,10 @@ save_journal.issue
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Text
+    loop_
+      _description_example.case
+         '2'
+         'Special Issue'
 
 save_
 
@@ -25866,7 +25871,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-11-09
+         3.1.0                    2021-11-12
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -25926,4 +25931,7 @@ save_
 
        Changed _gt/_lt data names to 'Number' type in accordance with DDL1
        behaviour. Removed associated SU data names.
+
+       Homogenised the definitions of _citation_journal_issue and
+       _journal.issue data items.
 ;


### PR DESCRIPTION
This PR homogenises the definitions of `_journal.issue` and `_citation_journal_issue` data items. Note the example case, that was added to justify the 'Text' content type.