### PR TITLE
Homogenise the definitions of publication year items

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-11-09
+    _dictionary.date              2021-11-14
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -15760,17 +15760,18 @@ save_citation.year
 
     _definition.id                '_citation.year'
     _alias.definition_id          '_citation_year'
-    _definition.update            2012-12-11
+    _definition.update            2021-11-14
     _description.text
 ;
     Year of citation; relevant for articles and book chapters.
 ;
     _name.category_id             citation
     _name.object_id               year
-    _type.purpose                 Encode
+    _type.purpose                 Number
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -17073,7 +17074,7 @@ save_journal.year
 
     _definition.id                '_journal.year'
     _alias.definition_id          '_journal_year'
-    _definition.update            2021-03-01
+    _definition.update            2021-11-14
     _description.text
 ;
     Year of the publication.
@@ -17084,7 +17085,6 @@ save_journal.year
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            1700:2100
     _units.code                   none
 
 save_
@@ -25866,7 +25866,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-11-09
+         3.1.0                    2021-11-14
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -25926,4 +25926,7 @@ save_
 
        Changed _gt/_lt data names to 'Number' type in accordance with DDL1
        behaviour. Removed associated SU data names.
+
+       Homogenised the definitions of _citation.year and _journal.year
+       data items.
 ;


### PR DESCRIPTION
This PR homogenises the definitions of `_citation.year` and `_journal.year` data items.

Note, that the `_enumeration.range` attribute with the value `1700:2100` was not copied to both of the items, but instead removed altogether. The lower limit of `1700` might make sense for crystallography related publications, but the citation category may potentially reference non-crystallography related books or papers that were published prior to 1700 (i.e. paper that the synthesis of the compound was first described in). The upper limit of `2100` could be used for validation for the next 80 years, however, semantically this limit looks quite strange and should probably be better implemented as a stand-alone subroutine, rather than hardcoded into the dictionary.

Please let me know if the `_enumeration.range` should be restored and propagated into other data items.