### PR TITLE
Add an upper limit to _space_group_symop.id

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.1.0
-    _dictionary.date              2021-11-14
+    _dictionary.date              2021-11-15
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -11407,7 +11407,7 @@ save_space_group_symop.id
          '_symmetry_equiv.pos_site_id'
          '_symmetry_equiv_pos_site_id'
 
-    _definition.update            2021-03-01
+    _definition.update            2021-11-15
     _description.text
 ;
     Index identifying each entry in the _space_group_symop.operation_xyz
@@ -11423,7 +11423,7 @@ save_space_group_symop.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
-    _enumeration.range            1:
+    _enumeration.range            1:192
     _units.code                   none
     _method.purpose               Evaluation
     _method.expression
@@ -25871,7 +25871,7 @@ save_
        Removed all instances of the _category.key_id attribute since it is no
        longer defined in the DDLm reference dictionary.
 ;
-         3.1.0                    2021-11-14
+         3.1.0                    2021-11-15
 ;
        Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
        and _model_site.adp_eigenvalues.
@@ -25934,4 +25934,7 @@ save_
 
        Homogenised the definitions of _citation.year, _journal.year,
        _citation.journal_issue, and _journal.issue data items.
+
+       Added an upper enumeration limit of 192 to the definition of
+       the _space_group_symop.id data item.
 ;


### PR DESCRIPTION
This PR resolves issue #277 by adding an upper enumeration limit of 192 to the definition of the _space_group_symop.id data item.