### PR TITLE
Moved CELL to DIFFRN category, deprecated some items.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2022-05-09
+    _dictionary.date              2022-05-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -494,6 +494,1627 @@ save_diffrn.symmetry_description
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_CELL
+
+    _definition.id                CELL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-25
+    _description.text
+;
+    The CATEGORY of data items used to describe the parameters of
+    the crystal unit cell.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               CELL
+    _category_key.name            '_cell.diffrn_id'
+
+save_
+
+save_cell.angle_alpha
+
+    _definition.id                '_cell.angle_alpha'
+    _alias.definition_id          '_cell_angle_alpha'
+    _name.category_id             cell
+    _name.object_id               angle_alpha
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_alpha_su
+
+    _definition.id                '_cell.angle_alpha_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle_alpha_su'
+         '_cell.angle_alpha_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_alpha_su
+    _name.linked_item_id          '_cell.angle_alpha'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.angle_beta
+
+    _definition.id                '_cell.angle_beta'
+    _alias.definition_id          '_cell_angle_beta'
+    _name.category_id             cell
+    _name.object_id               angle_beta
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_beta_su
+
+    _definition.id                '_cell.angle_beta_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle.beta_su'
+         '_cell_angle_beta_su'
+         '_cell.angle_beta_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_beta_su
+    _name.linked_item_id          '_cell.angle_beta'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.angle_gamma
+
+    _definition.id                '_cell.angle_gamma'
+    _alias.definition_id          '_cell_angle_gamma'
+    _name.category_id             cell
+    _name.object_id               angle_gamma
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_gamma_su
+
+    _definition.id                '_cell.angle_gamma_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle.gamma_su'
+         '_cell_angle_gamma_su'
+         '_cell.angle_gamma_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_gamma_su
+    _name.linked_item_id          '_cell.angle_gamma'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.atomic_mass
+
+    _definition.id                '_cell.atomic_mass'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Atomic mass of the contents of the unit cell. This calculated
+    from the atom sites present in the ATOM_TYPE list, rather than
+    the ATOM_SITE lists of atoms in the refined model.
+;
+    _name.category_id             cell
+    _name.object_id               atomic_mass
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:
+    _units.code                   dalton
+    _method.purpose               Evaluation
+    _method.expression
+;
+    mass = 0.
+
+    Loop t as atom_type  {
+
+                   mass += t.number_in_cell * t.atomic_mass
+    }
+      _cell.atomic_mass = mass
+;
+
+save_
+
+save_cell.convert_uij_to_betaij
+
+    _definition.id                '_cell.convert_Uij_to_betaij'
+    _definition.update            2021-09-24
+    _description.text
+;
+    The reciprocal space matrix for converting the U(ij) matrix of
+    atomic displacement parameters to a dimensionless beta(IJ) matrix.
+    The ADP factor in a structure factor expression:
+
+    t = exp -2pi**2 ( U11    h h a* a* + ...... 2 U23    k l b* c* )
+    t = exp - 0.25  ( B11    h h a* a* + ...... 2 B23    k l b* c* )
+      = exp -       ( beta11 h h + ............ 2 beta23 k l )
+
+    The conversion of the U or B matrices to the beta matrix
+
+        beta =   C U C   =    C B C /8pi**2
+
+    where C is conversion matrix defined here.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uij_to_betaij
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.convert_Uij_to_betaij =                              1.4142 * Pi *
+    Matrix([[ c.reciprocal_length_a, 0, 0 ],
+                [ 0, c.reciprocal_length_b, 0 ],
+                    [ 0, 0, c.reciprocal_length_c ]])
+;
+
+save_
+
+save_cell.convert_uij_to_betaij_su
+
+    _definition.id                '_cell.convert_Uij_to_betaij_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uij_to_betaij.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uij_to_betaij_su
+    _name.linked_item_id          '_cell.convert_Uij_to_betaij'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.convert_uiso_to_uij
+
+    _definition.id                '_cell.convert_Uiso_to_Uij'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The reciprocal space matrix for converting the isotropic Uiso
+    atomic displacement parameter to the anisotropic matrix Uij.
+
+                     | 1            cos(gamma*)   cos(beta*)  |
+    U[i,j]  = Uiso * | cos(gamma*)  1             cos(alpha*) |
+                     | cos(beta*)   cos(alpha*)   1           |
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uiso_to_Uij
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.convert_Uiso_to_Uij =                           [[ 1.,
+    Cosd(c.reciprocal_angle_gamma), Cosd(c.reciprocal_angle_beta)  ],
+                 [ Cosd(c.reciprocal_angle_gamma), 1.,
+    Cosd(c.reciprocal_angle_alpha) ],                        [
+    Cosd(c.reciprocal_angle_beta), Cosd(c.reciprocal_angle_alpha), 1.  ]]
+;
+
+save_
+
+save_cell.convert_uiso_to_uij_su
+
+    _definition.id                '_cell.convert_Uiso_to_Uij_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uiso_to_Uij.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uiso_to_Uij_su
+    _name.linked_item_id          '_cell.convert_Uiso_to_Uij'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_cell.diffrn_id
+
+    _definition.id                '_cell.diffrn_id'
+    _definition.update            2022-05-25
+    _description.text
+;
+    A pointer to the diffraction conditions used for cell measurement.
+;
+    _name.category_id             cell
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell.formula_units_z
+
+    _definition.id                '_cell.formula_units_Z'
+    _alias.definition_id          '_cell_formula_units_Z'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of the formula units in the unit cell as specified
+    by _chemical_formula.structural, _chemical_formula.moiety or
+    _chemical_formula.sum.
+;
+    _name.category_id             cell
+    _name.object_id               formula_units_Z
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_cell.length_a
+
+    _definition.id                '_cell.length_a'
+    _alias.definition_id          '_cell_length_a'
+    _name.category_id             cell
+    _name.object_id               length_a
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_a_su
+
+    _definition.id                '_cell.length_a_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_a_su'
+         '_cell.length_a_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_a_su
+    _name.linked_item_id          '_cell.length_a'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.length_b
+
+    _definition.id                '_cell.length_b'
+    _alias.definition_id          '_cell_length_b'
+    _name.category_id             cell
+    _name.object_id               length_b
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_b_su
+
+    _definition.id                '_cell.length_b_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_b_su'
+         '_cell.length_b_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_b_su
+    _name.linked_item_id          '_cell.length_b'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.length_c
+
+    _definition.id                '_cell.length_c'
+    _alias.definition_id          '_cell_length_c'
+    _name.category_id             cell
+    _name.object_id               length_c
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_c_su
+
+    _definition.id                '_cell.length_c_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_c_su'
+         '_cell.length_c_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_c_su
+    _name.linked_item_id          '_cell.length_c'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.metric_tensor
+
+    _definition.id                '_cell.metric_tensor'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The direct space (covariant) metric tensor used to transform
+    vectors and coordinates from real (direct) to reciprocal space.
+;
+    _name.category_id             cell
+    _name.object_id               metric_tensor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with c  as  cell
+
+          _cell.metric_tensor = [[ c.vector_a*c.vector_a,
+    c.vector_a*c.vector_b, c.vector_a*c.vector_c ],
+     [ c.vector_b*c.vector_a, c.vector_b*c.vector_b, c.vector_b*c.vector_c ],
+                               [ c.vector_c*c.vector_a, c.vector_c*c.vector_b,
+    c.vector_c*c.vector_c ]]
+;
+
+save_
+
+save_cell.orthogonal_matrix
+
+    _definition.id                '_cell.orthogonal_matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Orthogonal matrix of the crystal unit cell. Definition uses
+    Rollet's axial assignments with cell vectors a,b,c aligned
+    with orthogonal axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             cell
+    _name.object_id               orthogonal_matrix
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+    _cell.orthogonal_matrix =   [
+          [  c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma), 0,
+                                 0 ],       [
+    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma),
+    c.length_b*Sind(c.angle_alpha),   0 ],       [
+    c.length_a*Cosd(c.angle_beta),
+    c.length_b*Cosd(c.angle_alpha), c.length_c ]]
+;
+
+save_
+
+save_cell.reciprocal_angle_alpha
+
+    _definition.id                '_cell.reciprocal_angle_alpha'
+    _alias.definition_id          '_cell_reciprocal_angle_alpha'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_b and _cell.length_c.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_alpha
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:180.
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_alpha =
+    Acosd((Cosd(c.angle_beta)*Cosd(c.angle_gamma)-Cosd(c.angle_alpha))/
+    (Sind(c.angle_beta)*Sind(c.angle_gamma)))
+;
+
+save_
+
+save_cell.reciprocal_angle_alpha_su
+
+    _definition.id                '_cell.reciprocal_angle_alpha_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_alpha_su'
+         '_cell.reciprocal_angle_alpha_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the angle
+    between _cell.length_b and _cell.length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_alpha_su
+    _name.linked_item_id          '_cell.reciprocal_angle_alpha'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
+
+save_
+
+save_cell.reciprocal_angle_beta
+
+    _definition.id                '_cell.reciprocal_angle_beta'
+    _alias.definition_id          '_cell_reciprocal_angle_beta'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_a and _cell.length_c.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_beta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:180.
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_beta =
+    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_gamma)-Cosd(c.angle_beta))/
+    (Sind(c.angle_alpha)*Sind(c.angle_gamma)))
+;
+
+save_
+
+save_cell.reciprocal_angle_beta_su
+
+    _definition.id                '_cell.reciprocal_angle_beta_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_beta_su'
+         '_cell.reciprocal_angle_beta_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the angle
+    between _cell.length_a and _cell.length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_beta_su
+    _name.linked_item_id          '_cell.reciprocal_angle_beta'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
+
+save_
+
+save_cell.reciprocal_angle_gamma
+
+    _definition.id                '_cell.reciprocal_angle_gamma'
+    _alias.definition_id          '_cell_reciprocal_angle_gamma'
+    _definition.update            2016-09-09
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_a and _cell.length_b.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_gamma
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:180.
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_gamma =
+    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_beta)-Cosd(c.angle_gamma))/
+    (Sind(c.angle_alpha)*Sind(c.angle_beta)))
+;
+
+save_
+
+save_cell.reciprocal_angle_gamma_su
+
+    _definition.id                '_cell.reciprocal_angle_gamma_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_gamma_su'
+         '_cell.reciprocal_angle_gamma_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the angle
+    between _cell.length_a and _cell.length_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_gamma_su
+    _name.linked_item_id          '_cell.reciprocal_angle_gamma'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
+
+save_
+
+save_cell.reciprocal_length_a
+
+    _definition.id                '_cell.reciprocal_length_a'
+    _alias.definition_id          '_cell_reciprocal_length_a'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_a = Norm ( _cell.reciprocal_vector_a )
+;
+
+save_
+
+save_cell.reciprocal_length_a_su
+
+    _definition.id                '_cell.reciprocal_length_a_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_a_su'
+         '_cell.reciprocal_length_a_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the _cell.length_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_a_su
+    _name.linked_item_id          '_cell.reciprocal_length_a'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_length_b
+
+    _definition.id                '_cell.reciprocal_length_b'
+    _alias.definition_id          '_cell_reciprocal_length_b'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_b = Norm ( _cell.reciprocal_vector_b )
+;
+
+save_
+
+save_cell.reciprocal_length_b_su
+
+    _definition.id                '_cell.reciprocal_length_b_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_b_su'
+         '_cell.reciprocal_length_b_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the _cell.length_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_b_su
+    _name.linked_item_id          '_cell.reciprocal_length_b'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_length_c
+
+    _definition.id                '_cell.reciprocal_length_c'
+    _alias.definition_id          '_cell_reciprocal_length_c'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_c = Norm ( _cell.reciprocal_vector_c )
+;
+
+save_
+
+save_cell.reciprocal_length_c_su
+
+    _definition.id                '_cell.reciprocal_length_c_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_c_su'
+         '_cell.reciprocal_length_c_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the reciprocal of the _cell.length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_c_su
+    _name.linked_item_id          '_cell.reciprocal_length_c'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_metric_tensor
+
+    _definition.id                '_cell.reciprocal_metric_tensor'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The reciprocal (contravariant) metric tensor used to transform
+    vectors and coordinates from reciprocal space to real (direct)
+    space.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_metric_tensor
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+     with c as cell
+    _cell.reciprocal_metric_tensor = [
+         [ c.reciprocal_vector_a*c.reciprocal_vector_a,
+    c.reciprocal_vector_a*c.reciprocal_vector_b,
+    c.reciprocal_vector_a*c.reciprocal_vector_c ],      [
+    c.reciprocal_vector_b*c.reciprocal_vector_a,
+    c.reciprocal_vector_b*c.reciprocal_vector_b,
+    c.reciprocal_vector_b*c.reciprocal_vector_c ],      [
+    c.reciprocal_vector_c*c.reciprocal_vector_a,
+    c.reciprocal_vector_c*c.reciprocal_vector_b,
+    c.reciprocal_vector_c*c.reciprocal_vector_c ]]
+;
+
+save_
+
+save_cell.reciprocal_metric_tensor_su
+
+    _definition.id                '_cell.reciprocal_metric_tensor_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_metric_tensor.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_metric_tensor_su
+    _name.linked_item_id          '_cell.reciprocal_metric_tensor'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstrom_squared
+
+save_
+
+save_cell.reciprocal_orthogonal_matrix
+
+    _definition.id                '_cell.reciprocal_orthogonal_matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Orthogonal matrix of the reciprocal space. The matrix may be
+    used to transform the non-orthogonal vector h = (h,k,l) into
+    the orthogonal indices p = (p,q,r)
+
+                    M h = p
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_orthogonal_matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_orthogonal_matrix  =  Inverse(
+
+                           Transpose( _cell.orthogonal_matrix ))
+;
+
+save_
+
+save_cell.reciprocal_orthogonal_matrix_su
+
+    _definition.id                '_cell.reciprocal_orthogonal_matrix_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_orthogonal_matrix.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_orthogonal_matrix_su
+    _name.linked_item_id          '_cell.reciprocal_orthogonal_matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_a
+
+    _definition.id                '_cell.reciprocal_vector_a'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_a = c.vector_b ^ c.vector_c / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_a_su
+
+    _definition.id                '_cell.reciprocal_vector_a_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_a_su
+    _name.linked_item_id          '_cell.reciprocal_vector_a'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_b
+
+    _definition.id                '_cell.reciprocal_vector_b'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_b = c.vector_c ^ c.vector_a / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_b_su
+
+    _definition.id                '_cell.reciprocal_vector_b_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_b_su
+    _name.linked_item_id          '_cell.reciprocal_vector_b'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_c
+
+    _definition.id                '_cell.reciprocal_vector_c'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_c = c.vector_a ^ c.vector_b / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_c_su
+
+    _definition.id                '_cell.reciprocal_vector_c_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_c_su
+    _name.linked_item_id          '_cell.reciprocal_vector_c'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.special_details
+
+    _definition.id                '_cell.special_details'
+
+    loop_
+      _alias.definition_id
+         '_cell_special_details'
+         '_cell.details'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Description of special aspects of the cell choice, noting
+    possible alternative settings.
+;
+    _name.category_id             cell
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_cell.vector_a
+
+    _definition.id                '_cell.vector_a'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the x axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_a = _cell.orthogonal_matrix * Matrix([1,0,0])
+;
+
+save_
+
+save_cell.vector_a_su
+
+    _definition.id                '_cell.vector_a_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               vector_a_su
+    _name.linked_item_id          '_cell.vector_a'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.vector_b
+
+    _definition.id                '_cell.vector_b'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the y axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_b = _cell.orthogonal_matrix * Matrix([0,1,0])
+;
+
+save_
+
+save_cell.vector_b_su
+
+    _definition.id                '_cell.vector_b_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               vector_b_su
+    _name.linked_item_id          '_cell.vector_b'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.vector_c
+
+    _definition.id                '_cell.vector_c'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the z axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_c = _cell.orthogonal_matrix * Matrix([0,0,1])
+;
+
+save_
+
+save_cell.vector_c_su
+
+    _definition.id                '_cell.vector_c_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell.vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               vector_c_su
+    _name.linked_item_id          '_cell.vector_c'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.volume
+
+    _definition.id                '_cell.volume'
+    _alias.definition_id          '_cell_volume'
+    _definition.update            2013-03-07
+    _description.text
+;
+    Volume of the crystal unit cell.
+;
+    _name.category_id             cell
+    _name.object_id               volume
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_cubed
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.volume =  c.vector_a * ( c.vector_b ^ c.vector_c )
+;
+
+save_
+
+save_cell.volume_su
+
+    _definition.id                '_cell.volume_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_volume_su'
+         '_cell.volume_esd'
+
+    _definition.update            2014-06-08
+    _description.text
+;
+    Standard uncertainty of the volume of the crystal unit cell.
+;
+    _name.category_id             cell
+    _name.object_id               volume_su
+    _name.linked_item_id          '_cell.volume'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_cubed
+
+save_
+
+save_CELL_MEASUREMENT
+
+    _definition.id                CELL_MEASUREMENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-25
+    _description.text
+;
+    The CATEGORY of data items used to describe the measurement of
+    the cell parameters.
+;
+    _name.category_id             CELL
+    _name.object_id               CELL_MEASUREMENT
+    _category_key.name            '_cell_measurement.diffrn_id'
+
+save_
+
+save_cell_measurement.diffrn_id
+
+    _definition.id                '_cell_measurement.diffrn_id'
+    _definition.update            2022-05-25
+    _description.text
+;
+    A pointer to the diffraction conditions used for cell measurement.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell_measurement.pressure
+
+    _definition.id                '_cell_measurement.pressure'
+    _definition_replaced.by       '_diffrn.ambient_pressure'
+    _alias.definition_id          '_cell_measurement_pressure'
+    _definition.update            2022-05-25
+    _description.text
+;
+    **DEPRECATED**
+
+    The pressure at which the unit-cell parameters were measured
+    (not the pressure used to synthesize the sample).
+    Replaced by '_diffrn.ambient_pressure'
+;
+    _name.category_id             cell_measurement
+    _name.object_id               pressure
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_cell_measurement.pressure_su
+
+    _definition.id                '_cell_measurement.pressure_su'
+    _definition_replaced.by       '_diffrn.ambient_pressure_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_pressure_su'
+         '_cell_measurement.pressure_esd'
+
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of the pressure at which
+    the unit-cell parameters were measured.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               pressure_su
+    _name.linked_item_id          '_cell_measurement.pressure'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kilopascals
+
+save_
+
+save_cell_measurement.radiation
+
+    _definition.id                '_cell_measurement.radiation'
+    _definition_replaced.by       .
+    _alias.definition_id          '_cell_measurement_radiation'
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Description of the radiation used to measure the unit-cell data.
+    Items from the DIFFRN_RADIATION category should be used instead
+    of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               radiation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'neutron'
+         'X-ray tube'
+         'synchrotron'
+
+save_
+
+save_cell_measurement.reflns_used
+
+    _definition.id                '_cell_measurement.reflns_used'
+    _alias.definition_id          '_cell_measurement_reflns_used'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of reflections used to determine the unit cell.
+    The reflections may be specified as cell_measurement_refln items.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               reflns_used
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            3:
+    _units.code                   none
+
+save_
+
+save_cell_measurement.temperature
+
+    _definition.id                '_cell_measurement.temperature'
+    _definition_replaced.by       '_diffrn.ambient_temperature'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_temperature'
+         '_cell_measurement_temp'
+         '_cell_measurement.temp'
+
+    _definition.update            2022-05-25
+    _description.text
+;
+    ** DEPRECATED **
+
+    The temperature at which the unit-cell parameters were measured
+    (not the temperature of synthesis).
+    _diffrn.ambient_temperature should be used instead of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_cell_measurement.temperature_su
+
+    _definition.id                '_cell_measurement.temperature_su'
+    _definition_replaced.by       '_diffrn.ambient_temperature_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_temp_su'
+         '_cell_measurement.temp_esd'
+
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of the temperature of at which
+    the unit-cell parameters were measured.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               temperature_su
+    _name.linked_item_id          '_cell_measurement.temperature'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   kelvins
+
+save_
+
+save_cell_measurement.theta_max
+
+    _definition.id                '_cell_measurement.theta_max'
+    _alias.definition_id          '_cell_measurement_theta_max'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Maximum theta scattering angle of reflections used to measure
+    the crystal unit cell.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               theta_max
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement.theta_min
+
+    _definition.id                '_cell_measurement.theta_min'
+    _alias.definition_id          '_cell_measurement_theta_min'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Minimum theta scattering angle of reflections used to measure
+    the crystal unit cell.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               theta_min
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement.wavelength
+
+    _definition.id                '_cell_measurement.wavelength'
+    _definition_replaced.by       '_diffrn_radiation_wavelength.value'
+    _alias.definition_id          '_cell_measurement_wavelength'
+    _definition.update            2022-05-25
+    _description.text
+;
+    ** DEPRECATED **
+
+    Wavelength of the radiation used to measure the unit cell.
+    Items from the _diffrn_radiation_wavelength category should
+    be used instead of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               wavelength
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_CELL_MEASUREMENT_REFLN
+
+    _definition.id                CELL_MEASUREMENT_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the measurement of the crystal unit cell.
+;
+    _name.category_id             CELL_MEASUREMENT
+    _name.object_id               CELL_MEASUREMENT_REFLN
+
+    loop_
+      _category_key.name
+         '_cell_measurement_refln.diffrn_id'
+         '_cell_measurement_refln.index_h'
+         '_cell_measurement_refln.index_k'
+         '_cell_measurement_refln.index_l'
+
+save_
+
+save_cell_measurement_refln.diffrn_id
+
+    _definition.id                '_cell_measurement_refln.diffrn_id'
+    _definition.update            2022-05-25
+    _description.text
+;
+    A pointer to the diffraction conditions used for cell measurement.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell_measurement_refln.hkl
+
+    _definition.id                '_cell_measurement_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of a reflection used to measure the unit cell.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell_measurement_refln
+
+    _cell_measurement_refln.hkl = [c.index_h, c.index_k, c.index_l]
+;
+
+save_
+
+save_cell_measurement_refln.index_h
+
+    _definition.id                '_cell_measurement_refln.index_h'
+    _alias.definition_id          '_cell_measurement_refln_index_h'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
+
+save_
+
+save_cell_measurement_refln.index_k
+
+    _definition.id                '_cell_measurement_refln.index_k'
+    _alias.definition_id          '_cell_measurement_refln_index_k'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
+
+save_
+
+save_cell_measurement_refln.index_l
+
+    _definition.id                '_cell_measurement_refln.index_l'
+    _alias.definition_id          '_cell_measurement_refln_index_l'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
+
+save_
+
+save_cell_measurement_refln.theta
+
+    _definition.id                '_cell_measurement_refln.theta'
+    _alias.definition_id          '_cell_measurement_refln_theta'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Theta angle of reflection used to measure the crystal unit cell.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               theta
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement_refln.theta_su
+
+    _definition.id                '_cell_measurement_refln.theta_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _cell_measurement_refln.theta.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               theta_su
+    _name.linked_item_id          '_cell_measurement_refln.theta'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -6632,1548 +8253,6 @@ save_exptl.transmission_factor_min_su
     _name.object_id               transmission_factor_min_su
     _name.linked_item_id          '_exptl.transmission_factor_min'
     _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_CELL
-
-    _definition.id                CELL
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2012-11-22
-    _description.text
-;
-    The CATEGORY of data items used to describe the parameters of
-    the crystal unit cell and their measurement.
-;
-    _name.category_id             EXPTL
-    _name.object_id               CELL
-
-save_
-
-save_cell.angle_alpha
-
-    _definition.id                '_cell.angle_alpha'
-    _alias.definition_id          '_cell_angle_alpha'
-    _name.category_id             cell
-    _name.object_id               angle_alpha
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
-
-save_
-
-save_cell.angle_alpha_su
-
-    _definition.id                '_cell.angle_alpha_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_angle_alpha_su'
-         '_cell.angle_alpha_esd'
-
-    _name.category_id             cell
-    _name.object_id               angle_alpha_su
-    _name.linked_item_id          '_cell.angle_alpha'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_angle_su}]
-
-save_
-
-save_cell.angle_beta
-
-    _definition.id                '_cell.angle_beta'
-    _alias.definition_id          '_cell_angle_beta'
-    _name.category_id             cell
-    _name.object_id               angle_beta
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
-
-save_
-
-save_cell.angle_beta_su
-
-    _definition.id                '_cell.angle_beta_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_angle.beta_su'
-         '_cell_angle_beta_su'
-         '_cell.angle_beta_esd'
-
-    _name.category_id             cell
-    _name.object_id               angle_beta_su
-    _name.linked_item_id          '_cell.angle_beta'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_angle_su}]
-
-save_
-
-save_cell.angle_gamma
-
-    _definition.id                '_cell.angle_gamma'
-    _alias.definition_id          '_cell_angle_gamma'
-    _name.category_id             cell
-    _name.object_id               angle_gamma
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
-
-save_
-
-save_cell.angle_gamma_su
-
-    _definition.id                '_cell.angle_gamma_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_angle.gamma_su'
-         '_cell_angle_gamma_su'
-         '_cell.angle_gamma_esd'
-
-    _name.category_id             cell
-    _name.object_id               angle_gamma_su
-    _name.linked_item_id          '_cell.angle_gamma'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_angle_su}]
-
-save_
-
-save_cell.atomic_mass
-
-    _definition.id                '_cell.atomic_mass'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Atomic mass of the contents of the unit cell. This calculated
-    from the atom sites present in the ATOM_TYPE list, rather than
-    the ATOM_SITE lists of atoms in the refined model.
-;
-    _name.category_id             cell
-    _name.object_id               atomic_mass
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:
-    _units.code                   dalton
-    _method.purpose               Evaluation
-    _method.expression
-;
-    mass = 0.
-
-    Loop t as atom_type  {
-
-                   mass += t.number_in_cell * t.atomic_mass
-    }
-      _cell.atomic_mass = mass
-;
-
-save_
-
-save_cell.convert_uij_to_betaij
-
-    _definition.id                '_cell.convert_Uij_to_betaij'
-    _definition.update            2021-09-24
-    _description.text
-;
-    The reciprocal space matrix for converting the U(ij) matrix of
-    atomic displacement parameters to a dimensionless beta(IJ) matrix.
-    The ADP factor in a structure factor expression:
-
-    t = exp -2pi**2 ( U11    h h a* a* + ...... 2 U23    k l b* c* )
-    t = exp - 0.25  ( B11    h h a* a* + ...... 2 B23    k l b* c* )
-      = exp -       ( beta11 h h + ............ 2 beta23 k l )
-
-    The conversion of the U or B matrices to the beta matrix
-
-        beta =   C U C   =    C B C /8pi**2
-
-    where C is conversion matrix defined here.
-;
-    _name.category_id             cell
-    _name.object_id               convert_Uij_to_betaij
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With c  as  cell
-
-    _cell.convert_Uij_to_betaij =                              1.4142 * Pi *
-    Matrix([[ c.reciprocal_length_a, 0, 0 ],
-                [ 0, c.reciprocal_length_b, 0 ],
-                    [ 0, 0, c.reciprocal_length_c ]])
-;
-
-save_
-
-save_cell.convert_uij_to_betaij_su
-
-    _definition.id                '_cell.convert_Uij_to_betaij_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.convert_Uij_to_betaij.
-;
-    _name.category_id             cell
-    _name.object_id               convert_Uij_to_betaij_su
-    _name.linked_item_id          '_cell.convert_Uij_to_betaij'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.convert_uiso_to_uij
-
-    _definition.id                '_cell.convert_Uiso_to_Uij'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The reciprocal space matrix for converting the isotropic Uiso
-    atomic displacement parameter to the anisotropic matrix Uij.
-
-                     | 1            cos(gamma*)   cos(beta*)  |
-    U[i,j]  = Uiso * | cos(gamma*)  1             cos(alpha*) |
-                     | cos(beta*)   cos(alpha*)   1           |
-;
-    _name.category_id             cell
-    _name.object_id               convert_Uiso_to_Uij
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With c  as  cell
-
-    _cell.convert_Uiso_to_Uij =                           [[ 1.,
-    Cosd(c.reciprocal_angle_gamma), Cosd(c.reciprocal_angle_beta)  ],
-                 [ Cosd(c.reciprocal_angle_gamma), 1.,
-    Cosd(c.reciprocal_angle_alpha) ],                        [
-    Cosd(c.reciprocal_angle_beta), Cosd(c.reciprocal_angle_alpha), 1.  ]]
-;
-
-save_
-
-save_cell.convert_uiso_to_uij_su
-
-    _definition.id                '_cell.convert_Uiso_to_Uij_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.convert_Uiso_to_Uij.
-;
-    _name.category_id             cell
-    _name.object_id               convert_Uiso_to_Uij_su
-    _name.linked_item_id          '_cell.convert_Uiso_to_Uij'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_cell.formula_units_z
-
-    _definition.id                '_cell.formula_units_Z'
-    _alias.definition_id          '_cell_formula_units_Z'
-    _definition.update            2021-03-01
-    _description.text
-;
-    The number of the formula units in the unit cell as specified
-    by _chemical_formula.structural, _chemical_formula.moiety or
-    _chemical_formula.sum.
-;
-    _name.category_id             cell
-    _name.object_id               formula_units_Z
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _units.code                   none
-
-save_
-
-save_cell.length_a
-
-    _definition.id                '_cell.length_a'
-    _alias.definition_id          '_cell_length_a'
-    _name.category_id             cell
-    _name.object_id               length_a
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
-
-save_
-
-save_cell.length_a_su
-
-    _definition.id                '_cell.length_a_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_length_a_su'
-         '_cell.length_a_esd'
-
-    _name.category_id             cell
-    _name.object_id               length_a_su
-    _name.linked_item_id          '_cell.length_a'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_length_su}]
-
-save_
-
-save_cell.length_b
-
-    _definition.id                '_cell.length_b'
-    _alias.definition_id          '_cell_length_b'
-    _name.category_id             cell
-    _name.object_id               length_b
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
-
-save_
-
-save_cell.length_b_su
-
-    _definition.id                '_cell.length_b_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_length_b_su'
-         '_cell.length_b_esd'
-
-    _name.category_id             cell
-    _name.object_id               length_b_su
-    _name.linked_item_id          '_cell.length_b'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_length_su}]
-
-save_
-
-save_cell.length_c
-
-    _definition.id                '_cell.length_c'
-    _alias.definition_id          '_cell_length_c'
-    _name.category_id             cell
-    _name.object_id               length_c
-
-    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
-
-save_
-
-save_cell.length_c_su
-
-    _definition.id                '_cell.length_c_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_length_c_su'
-         '_cell.length_c_esd'
-
-    _name.category_id             cell
-    _name.object_id               length_c_su
-    _name.linked_item_id          '_cell.length_c'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cell_length_su}]
-
-save_
-
-save_cell.metric_tensor
-
-    _definition.id                '_cell.metric_tensor'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The direct space (covariant) metric tensor used to transform
-    vectors and coordinates from real (direct) to reciprocal space.
-;
-    _name.category_id             cell
-    _name.object_id               metric_tensor
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstrom_squared
-    _method.purpose               Evaluation
-    _method.expression
-;
-    with c  as  cell
-
-          _cell.metric_tensor = [[ c.vector_a*c.vector_a,
-    c.vector_a*c.vector_b, c.vector_a*c.vector_c ],
-     [ c.vector_b*c.vector_a, c.vector_b*c.vector_b, c.vector_b*c.vector_c ],
-                               [ c.vector_c*c.vector_a, c.vector_c*c.vector_b,
-    c.vector_c*c.vector_c ]]
-;
-
-save_
-
-save_cell.orthogonal_matrix
-
-    _definition.id                '_cell.orthogonal_matrix'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Orthogonal matrix of the crystal unit cell. Definition uses
-    Rollet's axial assignments with cell vectors a,b,c aligned
-    with orthogonal axes X,Y,Z so that c||Z and b in plane YZ.
-;
-    _name.category_id             cell
-    _name.object_id               orthogonal_matrix
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c as cell
-    _cell.orthogonal_matrix =   [
-          [  c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma), 0,
-                                 0 ],       [
-    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma),
-    c.length_b*Sind(c.angle_alpha),   0 ],       [
-    c.length_a*Cosd(c.angle_beta),
-    c.length_b*Cosd(c.angle_alpha), c.length_c ]]
-;
-
-save_
-
-save_cell.reciprocal_angle_alpha
-
-    _definition.id                '_cell.reciprocal_angle_alpha'
-    _alias.definition_id          '_cell_reciprocal_angle_alpha'
-    _definition.update            2013-01-18
-    _description.text
-;
-    Reciprocal of the angle between _cell.length_b and _cell.length_c.
-    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
-         New York: John Wiley & Sons Inc.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_alpha
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:180.
-    _units.code                   degrees
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c as cell
-
-    _cell.reciprocal_angle_alpha =
-    Acosd((Cosd(c.angle_beta)*Cosd(c.angle_gamma)-Cosd(c.angle_alpha))/
-    (Sind(c.angle_beta)*Sind(c.angle_gamma)))
-;
-
-save_
-
-save_cell.reciprocal_angle_alpha_su
-
-    _definition.id                '_cell.reciprocal_angle_alpha_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_angle_alpha_su'
-         '_cell.reciprocal_angle_alpha_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the angle
-    between _cell.length_b and _cell.length_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_alpha_su
-    _name.linked_item_id          '_cell.reciprocal_angle_alpha'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   degrees
-
-save_
-
-save_cell.reciprocal_angle_beta
-
-    _definition.id                '_cell.reciprocal_angle_beta'
-    _alias.definition_id          '_cell_reciprocal_angle_beta'
-    _definition.update            2013-01-18
-    _description.text
-;
-    Reciprocal of the angle between _cell.length_a and _cell.length_c.
-    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
-         New York: John Wiley & Sons Inc.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_beta
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:180.
-    _units.code                   degrees
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c as cell
-
-    _cell.reciprocal_angle_beta =
-    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_gamma)-Cosd(c.angle_beta))/
-    (Sind(c.angle_alpha)*Sind(c.angle_gamma)))
-;
-
-save_
-
-save_cell.reciprocal_angle_beta_su
-
-    _definition.id                '_cell.reciprocal_angle_beta_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_angle_beta_su'
-         '_cell.reciprocal_angle_beta_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the angle
-    between _cell.length_a and _cell.length_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_beta_su
-    _name.linked_item_id          '_cell.reciprocal_angle_beta'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   degrees
-
-save_
-
-save_cell.reciprocal_angle_gamma
-
-    _definition.id                '_cell.reciprocal_angle_gamma'
-    _alias.definition_id          '_cell_reciprocal_angle_gamma'
-    _definition.update            2016-09-09
-    _description.text
-;
-    Reciprocal of the angle between _cell.length_a and _cell.length_b.
-    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
-         New York: John Wiley & Sons Inc.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_gamma
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:180.
-    _units.code                   degrees
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c as cell
-
-    _cell.reciprocal_angle_gamma =
-    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_beta)-Cosd(c.angle_gamma))/
-    (Sind(c.angle_alpha)*Sind(c.angle_beta)))
-;
-
-save_
-
-save_cell.reciprocal_angle_gamma_su
-
-    _definition.id                '_cell.reciprocal_angle_gamma_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_angle_gamma_su'
-         '_cell.reciprocal_angle_gamma_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the angle
-    between _cell.length_a and _cell.length_b.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_angle_gamma_su
-    _name.linked_item_id          '_cell.reciprocal_angle_gamma'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   degrees
-
-save_
-
-save_cell.reciprocal_length_a
-
-    _definition.id                '_cell.reciprocal_length_a'
-    _alias.definition_id          '_cell_reciprocal_length_a'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Reciprocal of the _cell.length_a.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_a
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.reciprocal_length_a = Norm ( _cell.reciprocal_vector_a )
-;
-
-save_
-
-save_cell.reciprocal_length_a_su
-
-    _definition.id                '_cell.reciprocal_length_a_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_length_a_su'
-         '_cell.reciprocal_length_a_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the _cell.length_a.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_a_su
-    _name.linked_item_id          '_cell.reciprocal_length_a'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_length_b
-
-    _definition.id                '_cell.reciprocal_length_b'
-    _alias.definition_id          '_cell_reciprocal_length_b'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Reciprocal of the _cell.length_b.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_b
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.reciprocal_length_b = Norm ( _cell.reciprocal_vector_b )
-;
-
-save_
-
-save_cell.reciprocal_length_b_su
-
-    _definition.id                '_cell.reciprocal_length_b_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_length_b_su'
-         '_cell.reciprocal_length_b_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the _cell.length_b.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_b_su
-    _name.linked_item_id          '_cell.reciprocal_length_b'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_length_c
-
-    _definition.id                '_cell.reciprocal_length_c'
-    _alias.definition_id          '_cell_reciprocal_length_c'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Reciprocal of the _cell.length_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_c
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.:
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.reciprocal_length_c = Norm ( _cell.reciprocal_vector_c )
-;
-
-save_
-
-save_cell.reciprocal_length_c_su
-
-    _definition.id                '_cell.reciprocal_length_c_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_reciprocal_length_c_su'
-         '_cell.reciprocal_length_c_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the reciprocal of the _cell.length_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_length_c_su
-    _name.linked_item_id          '_cell.reciprocal_length_c'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_metric_tensor
-
-    _definition.id                '_cell.reciprocal_metric_tensor'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The reciprocal (contravariant) metric tensor used to transform
-    vectors and coordinates from reciprocal space to real (direct)
-    space.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_metric_tensor
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstrom_squared
-    _method.purpose               Evaluation
-    _method.expression
-;
-     with c as cell
-    _cell.reciprocal_metric_tensor = [
-         [ c.reciprocal_vector_a*c.reciprocal_vector_a,
-    c.reciprocal_vector_a*c.reciprocal_vector_b,
-    c.reciprocal_vector_a*c.reciprocal_vector_c ],      [
-    c.reciprocal_vector_b*c.reciprocal_vector_a,
-    c.reciprocal_vector_b*c.reciprocal_vector_b,
-    c.reciprocal_vector_b*c.reciprocal_vector_c ],      [
-    c.reciprocal_vector_c*c.reciprocal_vector_a,
-    c.reciprocal_vector_c*c.reciprocal_vector_b,
-    c.reciprocal_vector_c*c.reciprocal_vector_c ]]
-;
-
-save_
-
-save_cell.reciprocal_metric_tensor_su
-
-    _definition.id                '_cell.reciprocal_metric_tensor_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.reciprocal_metric_tensor.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_metric_tensor_su
-    _name.linked_item_id          '_cell.reciprocal_metric_tensor'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstrom_squared
-
-save_
-
-save_cell.reciprocal_orthogonal_matrix
-
-    _definition.id                '_cell.reciprocal_orthogonal_matrix'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Orthogonal matrix of the reciprocal space. The matrix may be
-    used to transform the non-orthogonal vector h = (h,k,l) into
-    the orthogonal indices p = (p,q,r)
-
-                    M h = p
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_orthogonal_matrix
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.reciprocal_orthogonal_matrix  =  Inverse(
-
-                           Transpose( _cell.orthogonal_matrix ))
-;
-
-save_
-
-save_cell.reciprocal_orthogonal_matrix_su
-
-    _definition.id                '_cell.reciprocal_orthogonal_matrix_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.reciprocal_orthogonal_matrix.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_orthogonal_matrix_su
-    _name.linked_item_id          '_cell.reciprocal_orthogonal_matrix'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_vector_a
-
-    _definition.id                '_cell.reciprocal_vector_a'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Reciprocal of the _cell.vector_a.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_a
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c  as  cell
-
-    _cell.reciprocal_vector_a = c.vector_b ^ c.vector_c / _cell.volume
-;
-
-save_
-
-save_cell.reciprocal_vector_a_su
-
-    _definition.id                '_cell.reciprocal_vector_a_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.reciprocal_vector_a.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_a_su
-    _name.linked_item_id          '_cell.reciprocal_vector_a'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_vector_b
-
-    _definition.id                '_cell.reciprocal_vector_b'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Reciprocal of the _cell.vector_b.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_b
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c  as  cell
-
-    _cell.reciprocal_vector_b = c.vector_c ^ c.vector_a / _cell.volume
-;
-
-save_
-
-save_cell.reciprocal_vector_b_su
-
-    _definition.id                '_cell.reciprocal_vector_b_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.reciprocal_vector_b.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_b_su
-    _name.linked_item_id          '_cell.reciprocal_vector_b'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.reciprocal_vector_c
-
-    _definition.id                '_cell.reciprocal_vector_c'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Reciprocal of the _cell.vector_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_c
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With c  as  cell
-
-    _cell.reciprocal_vector_c = c.vector_a ^ c.vector_b / _cell.volume
-;
-
-save_
-
-save_cell.reciprocal_vector_c_su
-
-    _definition.id                '_cell.reciprocal_vector_c_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.reciprocal_vector_c.
-;
-    _name.category_id             cell
-    _name.object_id               reciprocal_vector_c_su
-    _name.linked_item_id          '_cell.reciprocal_vector_c'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_cell.special_details
-
-    _definition.id                '_cell.special_details'
-
-    loop_
-      _alias.definition_id
-         '_cell_special_details'
-         '_cell.details'
-
-    _definition.update            2012-11-22
-    _description.text
-;
-    Description of special aspects of the cell choice, noting
-    possible alternative settings.
-;
-    _name.category_id             cell
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_cell.vector_a
-
-    _definition.id                '_cell.vector_a'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The cell vector along the x axis.
-;
-    _name.category_id             cell
-    _name.object_id               vector_a
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.vector_a = _cell.orthogonal_matrix * Matrix([1,0,0])
-;
-
-save_
-
-save_cell.vector_a_su
-
-    _definition.id                '_cell.vector_a_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.vector_a.
-;
-    _name.category_id             cell
-    _name.object_id               vector_a_su
-    _name.linked_item_id          '_cell.vector_a'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_cell.vector_b
-
-    _definition.id                '_cell.vector_b'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The cell vector along the y axis.
-;
-    _name.category_id             cell
-    _name.object_id               vector_b
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.vector_b = _cell.orthogonal_matrix * Matrix([0,1,0])
-;
-
-save_
-
-save_cell.vector_b_su
-
-    _definition.id                '_cell.vector_b_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.vector_b.
-;
-    _name.category_id             cell
-    _name.object_id               vector_b_su
-    _name.linked_item_id          '_cell.vector_b'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_cell.vector_c
-
-    _definition.id                '_cell.vector_c'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The cell vector along the z axis.
-;
-    _name.category_id             cell
-    _name.object_id               vector_c
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _cell.vector_c = _cell.orthogonal_matrix * Matrix([0,0,1])
-;
-
-save_
-
-save_cell.vector_c_su
-
-    _definition.id                '_cell.vector_c_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell.vector_c.
-;
-    _name.category_id             cell
-    _name.object_id               vector_c_su
-    _name.linked_item_id          '_cell.vector_c'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_cell.volume
-
-    _definition.id                '_cell.volume'
-    _alias.definition_id          '_cell_volume'
-    _definition.update            2013-03-07
-    _description.text
-;
-    Volume of the crystal unit cell.
-;
-    _name.category_id             cell
-    _name.object_id               volume
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstrom_cubed
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With c  as  cell
-
-    _cell.volume =  c.vector_a * ( c.vector_b ^ c.vector_c )
-;
-
-save_
-
-save_cell.volume_su
-
-    _definition.id                '_cell.volume_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_volume_su'
-         '_cell.volume_esd'
-
-    _definition.update            2014-06-08
-    _description.text
-;
-    Standard uncertainty of the volume of the crystal unit cell.
-;
-    _name.category_id             cell
-    _name.object_id               volume_su
-    _name.linked_item_id          '_cell.volume'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   angstrom_cubed
-
-save_
-
-save_CELL_MEASUREMENT
-
-    _definition.id                CELL_MEASUREMENT
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2012-11-22
-    _description.text
-;
-    The CATEGORY of data items used to describe the angles between
-    the axes in the crystal unit cell.
-;
-    _name.category_id             CELL
-    _name.object_id               CELL_MEASUREMENT
-
-save_
-
-save_cell_measurement.pressure
-
-    _definition.id                '_cell_measurement.pressure'
-    _alias.definition_id          '_cell_measurement_pressure'
-    _definition.update            2012-11-22
-    _description.text
-;
-    The pressure at which the unit-cell parameters were measured
-    (not the pressure used to synthesize the sample).
-;
-    _name.category_id             cell_measurement
-    _name.object_id               pressure
-    _type.purpose                 Measurand
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   kilopascals
-
-save_
-
-save_cell_measurement.pressure_su
-
-    _definition.id                '_cell_measurement.pressure_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_measurement_pressure_su'
-         '_cell_measurement.pressure_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the pressure at which
-    the unit-cell parameters were measured.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               pressure_su
-    _name.linked_item_id          '_cell_measurement.pressure'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   kilopascals
-
-save_
-
-save_cell_measurement.radiation
-
-    _definition.id                '_cell_measurement.radiation'
-    _alias.definition_id          '_cell_measurement_radiation'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Description of the radiation used to measure the unit-cell data.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               radiation
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'neutron'
-         'X-ray tube'
-         'synchrotron'
-
-save_
-
-save_cell_measurement.reflns_used
-
-    _definition.id                '_cell_measurement.reflns_used'
-    _alias.definition_id          '_cell_measurement_reflns_used'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Total number of reflections used to determine the unit cell.
-    The reflections may be specified as cell_measurement_refln items.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               reflns_used
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            3:
-    _units.code                   none
-
-save_
-
-save_cell_measurement.temperature
-
-    _definition.id                '_cell_measurement.temperature'
-
-    loop_
-      _alias.definition_id
-         '_cell_measurement_temperature'
-         '_cell_measurement_temp'
-         '_cell_measurement.temp'
-
-    _definition.update            2012-11-22
-    _description.text
-;
-    The temperature at which the unit-cell parameters were measured
-    (not the temperature of synthesis).
-;
-    _name.category_id             cell_measurement
-    _name.object_id               temperature
-    _type.purpose                 Measurand
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   kelvins
-
-save_
-
-save_cell_measurement.temperature_su
-
-    _definition.id                '_cell_measurement.temperature_su'
-
-    loop_
-      _alias.definition_id
-         '_cell_measurement_temp_su'
-         '_cell_measurement.temp_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the temperature of at which
-    the unit-cell parameters were measured.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               temperature_su
-    _name.linked_item_id          '_cell_measurement.temperature'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   kelvins
-
-save_
-
-save_cell_measurement.theta_max
-
-    _definition.id                '_cell_measurement.theta_max'
-    _alias.definition_id          '_cell_measurement_theta_max'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Maximum theta scattering angle of reflections used to measure
-    the crystal unit cell.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               theta_max
-    _type.purpose                 Number
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:90.0
-    _units.code                   degrees
-
-save_
-
-save_cell_measurement.theta_min
-
-    _definition.id                '_cell_measurement.theta_min'
-    _alias.definition_id          '_cell_measurement_theta_min'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Minimum theta scattering angle of reflections used to measure
-    the crystal unit cell.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               theta_min
-    _type.purpose                 Number
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:90.0
-    _units.code                   degrees
-
-save_
-
-save_cell_measurement.wavelength
-
-    _definition.id                '_cell_measurement.wavelength'
-    _alias.definition_id          '_cell_measurement_wavelength'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Wavelength of the radiation used to measure the unit cell.
-    If this is not specified, the wavelength is assumed to be the
-    same as that given in _diffrn_radiation_wavelength.value
-;
-    _name.category_id             cell_measurement
-    _name.object_id               wavelength
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstroms
-
-save_
-
-save_CELL_MEASUREMENT_REFLN
-
-    _definition.id                CELL_MEASUREMENT_REFLN
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2021-06-29
-    _description.text
-;
-    The CATEGORY of data items used to describe the reflection data
-    used in the measurement of the crystal unit cell.
-;
-    _name.category_id             CELL_MEASUREMENT
-    _name.object_id               CELL_MEASUREMENT_REFLN
-
-    loop_
-      _category_key.name
-         '_cell_measurement_refln.index_h'
-         '_cell_measurement_refln.index_k'
-         '_cell_measurement_refln.index_l'
-
-save_
-
-save_cell_measurement_refln.hkl
-
-    _definition.id                '_cell_measurement_refln.hkl'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Miller indices of a reflection used to measure the unit cell.
-;
-    _name.category_id             cell_measurement_refln
-    _name.object_id               hkl
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Integer
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With c  as  cell_measurement_refln
-
-    _cell_measurement_refln.hkl = [c.index_h, c.index_k, c.index_l]
-;
-
-save_
-
-save_cell_measurement_refln.index_h
-
-    _definition.id                '_cell_measurement_refln.index_h'
-    _alias.definition_id          '_cell_measurement_refln_index_h'
-    _name.category_id             cell_measurement_refln
-    _name.object_id               index_h
-
-    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
-
-save_
-
-save_cell_measurement_refln.index_k
-
-    _definition.id                '_cell_measurement_refln.index_k'
-    _alias.definition_id          '_cell_measurement_refln_index_k'
-    _name.category_id             cell_measurement_refln
-    _name.object_id               index_k
-
-    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
-
-save_
-
-save_cell_measurement_refln.index_l
-
-    _definition.id                '_cell_measurement_refln.index_l'
-    _alias.definition_id          '_cell_measurement_refln_index_l'
-    _name.category_id             cell_measurement_refln
-    _name.object_id               index_l
-
-    _import.get                   [{'file':templ_attr.cif  'save':Miller_index}]
-
-save_
-
-save_cell_measurement_refln.theta
-
-    _definition.id                '_cell_measurement_refln.theta'
-    _alias.definition_id          '_cell_measurement_refln_theta'
-    _definition.update            2012-11-22
-    _description.text
-;
-    Theta angle of reflection used to measure the crystal unit cell.
-;
-    _name.category_id             cell_measurement_refln
-    _name.object_id               theta
-    _type.purpose                 Measurand
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:90.0
-    _units.code                   degrees
-
-save_
-
-save_cell_measurement_refln.theta_su
-
-    _definition.id                '_cell_measurement_refln.theta_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _cell_measurement_refln.theta.
-;
-    _name.category_id             cell_measurement_refln
-    _name.object_id               theta_su
-    _name.linked_item_id          '_cell_measurement_refln.theta'
-    _units.code                   degrees
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
@@ -25986,4 +26065,8 @@ save_
          3.2.0                    2022-05-09
 ;
        Added data names to allow multi-data-block expression of data sets.
+
+       Reparented CELL to DIFFRN category and added key data names to allow
+       multiple cells for different diffraction conditions. Deprecated
+       _cell_measurement.temperature,pressure data names.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.1.0
-    _dictionary.date              2021-12-08
+    _dictionary.date              2021-12-16
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.1.0
@@ -1505,12 +1505,12 @@ save_name.linked_item_id
 
     _definition.id                '_name.linked_item_id'
     _definition.class             Attribute
-    _definition.update            2021-08-18
+    _definition.update            2021-12-16
     _description.text
 ;
     Data name of an equivalent item which has a
     common set of values, or, in the definition of a type SU
-    item is the name of the associated Measurement item to
+    item is the name of the associated measurand item to
     which the standard uncertainty applies.
 ;
     _name.category_id             name
@@ -2580,7 +2580,7 @@ save_
 
        Unified the spelling of certain words.
 ;
-         4.1.0                    2021-12-08
+         4.1.0                    2021-12-16
 ;
        Added new 'Word' content type.
 
@@ -2594,4 +2594,6 @@ save_
        all the constraints that they inherit from the defining item.
 
        Improved wording of "Implied" value descriptors.
+
+       Updated the description of the _name.linked_item_id data item.
 ;


### PR DESCRIPTION
This addresses items discussed in issue #294.
 
The CELL category parent is now DIFFRN.
Pressure, temperature items in CELL_MEASUREMENT deprecated
in favour of identical items in DIFFRN.

Pointers to `_diffrn.id` added to CELL etc. to allow multiple
cells to be presented where multiple diffraction
conditions are used.

Note that in the now unusual case that cell measurement conditions are different to diffraction conditions, a separate data block with different `_diffrn.id` can be created to describe those measurement conditions, and a pointer to that `_diffrn.id` used. Therefore the `_cell_measurement.pressure,temperature` items are now completely unnecessary.

The diff looks quite large because the CELL category and all children have been moved around.