### PR TITLE
Add units for time-of-flight calibration equation.

### DIFF
--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -10,7 +10,7 @@ data_COM_VAL
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.8
-    _dictionary.date             2022-04-11
+    _dictionary.date             2022-10-11
     _dictionary.uri              www.iucr.org/cif/dic/com_val.dic
     _dictionary.ddl_conformance  4.1.0
     _description.text
@@ -2365,7 +2365,7 @@ save_
        Updated the human-readable descriptions of the 'kelvins' and
        'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-         1.4.8                    2022-04-11
+         1.4.8                    2022-10-11
 ;
        Corrected a few typos in the 'units_code' save frame.
 
@@ -2387,4 +2387,6 @@ save_
 
        Added the 'micrometres', 'counts' and 'photons per second' enumeration
        states to the 'units_code' save frame.
+
+       Added units for TOF coefficients.
 ;

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -846,6 +846,10 @@ save_units_code
    'counts'            "counts from a detector"
    'photons per second'  "photons registered in one second"
 
+   'microseconds_per_angstrom' "seconds * 10^(-6)/metres * 10^(-10)"
+   'microseconds_per_angstrom_squared' "(seconds * 10^(-6)/(metres * 10^(-10))^2"
+   'microseconds_per_angstrom_cubed' "(seconds * 10^(-6)/(metres * 10^(-10))^3"
+   'angstroms_per_microsecond'       "metres * 10^(-10)/seconds * 10^(-6)"
     save_
 
 

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -846,10 +846,10 @@ save_units_code
    'counts'            "counts from a detector"
    'photons per second'  "photons registered in one second"
 
-   'microseconds_per_angstrom' "seconds * 10^(-6)/metres * 10^(-10)"
-   'microseconds_per_angstrom_squared' "(seconds * 10^(-6)/(metres * 10^(-10))^2"
-   'microseconds_per_angstrom_cubed' "(seconds * 10^(-6)/(metres * 10^(-10))^3"
-   'angstroms_per_microsecond'       "metres * 10^(-10)/seconds * 10^(-6)"
+   'microseconds_per_angstrom' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-1))'"
+   'microseconds_per_angstrom_squared' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-2))'"
+   'microseconds_per_angstrom_cubed' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-3))'"
+   'angstroms_per_microsecond'       "TOF coefficient '(metres * 10^(-10)) * (seconds * 10^(-6)^(-1))'"
     save_
 
 


### PR DESCRIPTION
See [here](https://github.com/COMCIFS/Powder_Dictionary/blob/master/cif_pow.dic#L452) for usage of these units in the TOF calibration equation.