### PR TITLE
Add ability to record elemental composition of specimens

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19363,7 +19363,8 @@ save_
 
 save_atom_analytical_source.equipment_manufacturer
 
-    _definition.id                '_atom_analytical_source.equipment_manufacturer'
+    _definition.id
+        '_atom_analytical_source.equipment_manufacturer'
     _definition.update            2022-11-18
     _description.text
 
@@ -19380,9 +19381,9 @@ save_atom_analytical_source.equipment_manufacturer
 
     loop_
       _description_example.case
-      "Bruker"
-      "ELEMISSION"
-      "Thermo Fisher Scientific"
+         'Bruker'
+         'ELEMISSION'
+         'Thermo Fisher Scientific'
 
 save_
 
@@ -19405,9 +19406,9 @@ save_atom_analytical_source.equipment_model
 
     loop_
       _description_example.case
-      "S2 Puma"
-      "COBRA"
-      "CAP PRO XPS ICP-OES"
+         'S2 Puma'
+         'COBRA'
+         'CAP PRO XPS ICP-OES'
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19638,7 +19638,8 @@ save_atom_analytical_extra.mass_loss_percent
 ;
     Mass lost by the specimen during specimen preparation expressed
     as a percentage. The temperature at which the mass loss was recorded
-    is given by _atom_analytical_extra.analysis_temperature.
+    is given by _atom_analytical_extra.analysis_temperature. A mass gain
+    can be represented as a negative value.
 
     This would be used to record mass loss on drying, or mass loss on
     ignitition, during, for example, fusion bead preparation for XRF
@@ -19650,7 +19651,6 @@ save_atom_analytical_extra.mass_loss_percent
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _enumeration.range            0.0:100.
     _units.code                   none
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2022-10-04
+    _dictionary.date              2022-11-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -19286,6 +19286,206 @@ save_ATOM
 
 save_
 
+save_ATOM_ANALYTICAL
+
+    _definition.id                ATOM_ANALYTICAL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe elemental
+    composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL
+    _category_key.name            '_atom_analytical.id'
+
+save_
+
+save_atom_analytical.id
+
+    _definition.id                '_atom_analytical.id'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Arbitrary label uniquely identifying a single elemental composition value.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_atom_analytical.meas_id
+
+    _definition.id                '_atom_analytical.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_ATOM_ANALYTICAL_SOURCE
+
+    _definition.id                ATOM_ANALYTICAL_SOURCE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe the source
+    of elemental composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM_ANALYTICAL
+    _name.object_id               ATOM_ANALYTICAL_SOURCE
+    _category_key.name            '_atom_analytical_source.id'
+
+save_
+
+save_atom_analytical_source.equipment_manufacturer
+
+    _definition.id                '_atom_analytical_source.equipment_manufacturer'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Text describing the manufacturer of the equipment used
+    to determine the elemental composition.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               equipment_manufacturer
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      "Bruker"
+      "ELEMISSION"
+      "Thermo Fisher Scientific"
+
+save_
+
+save_atom_analytical_source.equipment_model
+
+    _definition.id                '_atom_analytical_source.equipment_model'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Text describing the model of the equipment used
+    to determine the elemental composition.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               equipment_model
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      "S2 Puma"
+      "COBRA"
+      "CAP PRO XPS ICP-OES"
+
+save_
+
+save_atom_analytical_source.id
+
+    _definition.id                '_atom_analytical_source.id'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_atom_analytical_source.special_details
+
+    _definition.id                '_atom_analytical_source.special_details'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Text describing the equipment or conditions under which the
+    data were collected that are not able to be captured using
+    _atom_analytical_source.equipment_manufacturer,
+    _atom_analytical_source.equipment_model, or
+    _atom_analytical_source.technique.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_atom_analytical_source.technique
+
+    _definition.id                '_atom_analytical_source.technique'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Text describing the experimental technique used to find
+    the elemental composition.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               technique
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       XRF
+;
+;
+       LIBS
+;
+;
+       Inductively-coupled plasma
+       optical emission spectrometry
+;
+
+save_
+
 save_ATOM_SITE
 
     _definition.id                ATOM_SITE
@@ -26039,10 +26239,13 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2022-10-04
+         3.2.0                    2022-11-19
 ;
        Added data names to allow multi-data-block expression of data sets.
 
        Deprecated and replaced _diffrn_radiation.type and
        _diffrn_radiation.xray_symbol.
+
+       Added categories and data names to allow for the elemental composition
+       of speciments to be recorded
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19363,13 +19363,6 @@ save_atom_analytical.analyte_mass_percent
     _type.contents                Real
     _enumeration.range            0.0:100.
     _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_analytical.analyte_mass_percent = dREL to calculate wt% from:
-                                         _atom_analytical.chemical_species and
-                                _atom_analytical.chemical_species_mass_percent
-;
 
 save_
 
@@ -19416,7 +19409,6 @@ save_atom_analytical.chemical_species
        multiplier for the group must follow the closing parentheses.
        That is, all element and group multipliers are assumed to be
        printed as subscripted numbers.
-
 ;
     _name.category_id             atom_analytical
     _name.object_id               chemical_species
@@ -19430,12 +19422,7 @@ save_atom_analytical.chemical_species
          'Fe2 O3'
          'Li'
          'Si O2'
-
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_analytical.analyte = dREL to extract analyte symbol
-;
+         'Ca S O4 (H2 O)2'
 
 save_
 
@@ -19451,10 +19438,8 @@ save_atom_analytical.chemical_species_mass_percent
 
     This is most often used in elemental compositions determined by XRF,
     where elements are reported as equivalent mass percentages of their
-    relevant oxide.
-
-    eg: Al is reported as Al2O3, P is reported as P2O5.
-
+    relevant oxide. For example: Al is reported as Al2O3, P is reported
+    as P2O5.
 ;
     _name.category_id             atom_analytical
     _name.object_id               chemical_species_mass_percent
@@ -19491,7 +19476,6 @@ save_atom_analytical.id
     _definition.id                '_atom_analytical.id'
     _definition.update            2022-11-18
     _description.text
-
 ;
     Arbitrary label uniquely identifying a single composition value.
 ;
@@ -19500,7 +19484,7 @@ save_atom_analytical.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -19509,7 +19493,6 @@ save_atom_analytical.meas_id
     _definition.id                '_atom_analytical.meas_id'
     _definition.update            2022-11-18
     _description.text
-
 ;
     Arbitrary label identifying the source of an elemental composition.
     This code must match the _atom_analytical_source.id of the associated
@@ -19525,36 +19508,35 @@ save_atom_analytical.meas_id
 
 save_
 
-save_ATOM_ANALYTICAL_EXTRA
+save_ATOM_ANALYTICAL_MASS_LOSS
 
-    _definition.id                ATOM_ANALYTICAL_EXTRA
+    _definition.id                ATOM_ANALYTICAL_MASS_LOSS
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2022-11-21
     _description.text
 ;
     The CATEGORY of data items used to describe information
-    pertaining to mass loss during speciment preparation for
+    pertaining to mass loss during specimen preparation for
     the purposes of determining elemental composition
     information for use in crystallographic structure studies.
 ;
     _name.category_id             ATOM_ANALYTICAL
-    _name.object_id               ATOM_ANALYTICAL_EXTRA
-    _category_key.name            '_atom_analytical_extra.id'
+    _name.object_id               ATOM_ANALYTICAL_MASS_LOSS
+    _category_key.name            '_atom_analytical_mass_loss.id'
     _description_example.case
 ;
          loop_
-         _atom_analytical_extra.id
-         _atom_analytical_extra.meas_id
-         _atom_analytical_extra.mass_loss_percent
-         _atom_analytical_extra.analysis_temperature
+         _atom_analytical_mass_loss.id
+         _atom_analytical_mass_loss.meas_id
+         _atom_analytical_mass_loss.percent
+         _atom_analytical_mass_loss.temperature
          LOD1 a   2  328
          LOI1 a   5  623
          LOI2 a  10 1023
          LOI3 a  15 1373
          LOI4 b   5  673
          LOI5 b  10 1123
-
 ;
     _description_example.detail
 ;
@@ -19568,122 +19550,93 @@ save_ATOM_ANALYTICAL_EXTRA
 
 save_
 
-save_atom_analytical_extra.analysis_temperature
+save_atom_analytical_mass_loss.id
 
-    _definition.id                '_atom_analytical_extra.analysis_temperature'
+    _definition.id                '_atom_analytical_mass_loss.id'
     _definition.update            2022-11-21
     _description.text
-;
-    The temperature, in kelvin, at which the mass loss was recorded
-    as given by _atom_analytical_extra.mass_loss_percent.
-
-    This would be used to record the temperature of drying or ignitition,
-    during, for example, fusion bead preparation for XRF analysis.
-;
-    _name.category_id             atom_analytical_extra
-    _name.object_id               analysis_temperature
-    _type.purpose                 Measurand
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   kelvins
-
-save_
-
-save_atom_analytical_extra.analysis_temperature_su
-
-    _definition.id
-        '_atom_analytical_extra.analysis_temperature_su'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Standard uncertainty of _atom_analytical_extra.analysis_temperature.
-;
-    _name.category_id             atom_analytical_extra
-    _name.object_id               analysis_temperature_su
-    _name.linked_item_id          '_atom_analytical_extra.analysis_temperature'
-    _units.code                   kelvins
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_analytical_extra.id
-
-    _definition.id                '_atom_analytical_extra.id'
-    _definition.update            2022-11-21
-    _description.text
-
 ;
     Arbitrary label uniquely identifying the source of an elemental
     composition value. This value is used by _atom_analytical.meas_id
     to link individual composition values to their corresponding
     technique of determination.
 ;
-    _name.category_id             atom_analytical_extra
+    _name.category_id             atom_analytical_mass_loss
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
-save_atom_analytical_extra.mass_loss_percent
+save_atom_analytical_mass_loss.percent
 
-    _definition.id                '_atom_analytical_extra.mass_loss_percent'
+    _definition.id                '_atom_analytical_mass_loss.percent'
     _definition.update            2022-11-21
     _description.text
 ;
     Mass lost by the specimen during specimen preparation expressed
     as a percentage. The temperature at which the mass loss was recorded
-    is given by _atom_analytical_extra.analysis_temperature. A mass gain
-    can be represented as a negative value.
+    is given by _atom_analytical_mass_loss.temperature. A mass gain
+    is represented by a negative value.
 
-    This would be used to record mass loss on drying, or mass loss on
-    ignitition, during, for example, fusion bead preparation for XRF
-    analysis.
+    This data name would be used to record mass loss on drying, or mass
+    loss on ignitition, during, for example, fusion bead preparation for
+    XRF analysis.
 ;
-    _name.category_id             atom_analytical_extra
-    _name.object_id               mass_loss_percent
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none
 
+    loop_
+      _description_example.case
+      _description_example.detail
+         12.5
+;
+         Represents a mass loss of 12.5 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+         -7.2
+;
+         Represents a mass gain of 7.2 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+
 save_
 
-save_atom_analytical_extra.mass_loss_percent_su
+save_atom_analytical_mass_loss.percent_su
 
-    _definition.id                '_atom_analytical_extra.mass_loss_percent_su'
+    _definition.id                '_atom_analytical_mass_loss.percent_su'
     _definition.update            2022-11-21
     _description.text
 ;
-    Standard uncertainty of _atom_analytical_extra.mass_loss_percent.
+    Standard uncertainty of _atom_analytical_mass_loss.percent.
 ;
-    _name.category_id             atom_analytical_extra
-    _name.object_id               mass_loss_percent_su
-    _name.linked_item_id          '_atom_analytical_extra.mass_loss_percent'
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.percent'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
-save_atom_analytical_extra.meas_id
+save_atom_analytical_mass_loss.meas_id
 
-    _definition.id                '_atom_analytical_extra.meas_id'
+    _definition.id                '_atom_analytical_mass_loss.meas_id'
     _definition.update            2022-11-18
     _description.text
-
 ;
     Arbitrary label identifying the source of an elemental composition.
     This code must match the _atom_analytical_source.id of the associated
     technique in the analytical source list.
 ;
-    _name.category_id             atom_analytical_extra
+    _name.category_id             atom_analytical_mass_loss
     _name.object_id               meas_id
     _name.linked_item_id          '_atom_analytical_source.id'
     _type.purpose                 Link
@@ -19693,23 +19646,63 @@ save_atom_analytical_extra.meas_id
 
 save_
 
-save_atom_analytical_extra.special_details
+save_atom_analytical_mass_loss.special_details
 
-    _definition.id                '_atom_analytical_extra.special_details'
+    _definition.id                '_atom_analytical_mass_loss.special_details'
     _definition.update            2022-11-21
     _description.text
-
 ;
-    Text describing the conditions under which the
-    data were collected that are not able to be captured using
-
+    Text describing the conditions under which the data were collected
+    that are not able to be captured using other data names
+    within the ATOM_ANALYTICAL_MASS_LOSS category.
 ;
-    _name.category_id             atom_analytical_extra
+    _name.category_id             atom_analytical_mass_loss
     _name.object_id               special_details
     _type.purpose                 Describe
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_atom_analytical_mass_loss.temperature
+
+    _definition.id                '_atom_analytical_mass_loss.temperature'
+    _definition.update            2022-11-21
+    _description.text
+;
+    The temperature, in kelvin, at which the mass loss was recorded
+    as given by _atom_analytical_mass_loss.percent.
+
+    This would be used to record the temperature of drying or ignitition,
+    during, for example, fusion bead preparation for XRF analysis.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_atom_analytical_mass_loss.temperature_su
+
+    _definition.id
+        '_atom_analytical_mass_loss.temperature_su'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_mass_loss.temperature.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               analysis_temperature_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -19733,12 +19726,11 @@ save_ATOM_ANALYTICAL_SOURCE
          loop_
          _atom_analytical_source.id
          _atom_analytical_source.technique
-         _atom_analytical_source.equipment_manufacturer
-         _atom_analytical_source.equipment_model
-         a  XRF Hitachi Lab-X5000
-         b  'X-ray fluorescence EDS' Hitachi Lab-X5000
-         c  ICP . .
-         d  EDS . .
+         _atom_analytical_source.equipment_make
+         a  XRF 'Hitachi Lab-X5000'
+         b  'X-ray fluorescence EDS' 'Hitachi Lab-X5000'
+         c  ICP .
+         d  EDS .
 ;
     _description_example.detail
 ;
@@ -19747,19 +19739,18 @@ save_ATOM_ANALYTICAL_SOURCE
 
 save_
 
-save_atom_analytical_source.equipment_manufacturer
+save_atom_analytical_source.equipment_make
 
     _definition.id
-        '_atom_analytical_source.equipment_manufacturer'
+        '_atom_analytical_source.equipment_make'
     _definition.update            2022-11-18
     _description.text
-
 ;
-    Text describing the manufacturer of the equipment used
-    to determine the elemental composition.
+    The make, model or name of the equipment used to determine the
+    elemental composition.
 ;
     _name.category_id             atom_analytical_source
-    _name.object_id               equipment_manufacturer
+    _name.object_id               equipment_make
     _type.purpose                 Describe
     _type.source                  Recorded
     _type.container               Single
@@ -19773,37 +19764,11 @@ save_atom_analytical_source.equipment_manufacturer
 
 save_
 
-save_atom_analytical_source.equipment_model
-
-    _definition.id                '_atom_analytical_source.equipment_model'
-    _definition.update            2022-11-18
-    _description.text
-
-;
-    Text describing the model of the equipment used
-    to determine the elemental composition.
-;
-    _name.category_id             atom_analytical_source
-    _name.object_id               equipment_model
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'S2 Puma'
-         'COBRA'
-         'CAP PRO XPS ICP-OES'
-
-save_
-
 save_atom_analytical_source.id
 
     _definition.id                '_atom_analytical_source.id'
     _definition.update            2022-11-18
     _description.text
-
 ;
     Arbitrary label uniquely identifying the source of an elemental
     composition value. This value is used by _atom_analytical.meas_id
@@ -19815,7 +19780,7 @@ save_atom_analytical_source.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -19824,12 +19789,10 @@ save_atom_analytical_source.special_details
     _definition.id                '_atom_analytical_source.special_details'
     _definition.update            2022-11-18
     _description.text
-
 ;
     Text describing the equipment or conditions under which the
     data were collected that are not able to be captured using
-    _atom_analytical_source.equipment_manufacturer,
-    _atom_analytical_source.equipment_model, or
+    _atom_analytical_source.equipment_make or
     _atom_analytical_source.technique.
 ;
     _name.category_id             atom_analytical_source
@@ -19839,6 +19802,20 @@ save_atom_analytical_source.special_details
     _type.container               Single
     _type.contents                Text
 
+    loop_
+      _description_example.case
+;
+         XRF utilising a WDS detector system calibrated for the analysis
+         of iron ores.
+;
+;
+         Laser Induced Breakdown Spectroscopy. Measurements carried out
+         by commercial laboratory, report #P90.
+;
+;
+         Detector calibrated following Smith (2018).
+;
+
 save_
 
 save_atom_analytical_source.technique
@@ -19846,10 +19823,13 @@ save_atom_analytical_source.technique
     _definition.id                '_atom_analytical_source.technique'
     _definition.update            2022-11-18
     _description.text
-
 ;
-    Text describing the experimental technique used to find
-    the elemental composition.
+    Succinct text or acronym describing the experimental technique used
+    to find the elemental composition.
+
+    If further details are required to properly describe the experimental
+    technique, or the given acronym is not in common use, use
+    _atom_analytical_source.special_details.
 ;
     _name.category_id             atom_analytical_source
     _name.object_id               technique
@@ -19860,16 +19840,9 @@ save_atom_analytical_source.technique
 
     loop_
       _description_example.case
-;
-       XRF
-;
-;
-       LIBS
-;
-;
-       Inductively-coupled plasma
-       optical emission spectrometry
-;
+         'XRF'
+         'LIBS'
+         'ICP OES'
 
 save_
 
@@ -26634,5 +26607,5 @@ save_
        _diffrn_radiation.xray_symbol.
 
        Added categories and data names to allow for the elemental composition
-       of specimens to be recorded
+       of specimens to be recorded.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19504,7 +19504,7 @@ save_atom_analytical.meas_id
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -19570,6 +19570,26 @@ save_atom_analytical_mass_loss.id
 
 save_
 
+save_atom_analytical_mass_loss.meas_id
+
+    _definition.id                '_atom_analytical_mass_loss.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_atom_analytical_mass_loss.percent
 
     _definition.id                '_atom_analytical_mass_loss.percent'
@@ -19626,26 +19646,6 @@ save_atom_analytical_mass_loss.percent_su
 
 save_
 
-save_atom_analytical_mass_loss.meas_id
-
-    _definition.id                '_atom_analytical_mass_loss.meas_id'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Arbitrary label identifying the source of an elemental composition.
-    This code must match the _atom_analytical_source.id of the associated
-    technique in the analytical source list.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               meas_id
-    _name.linked_item_id          '_atom_analytical_source.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Code
-
-save_
-
 save_atom_analytical_mass_loss.special_details
 
     _definition.id                '_atom_analytical_mass_loss.special_details'
@@ -19690,8 +19690,7 @@ save_
 
 save_atom_analytical_mass_loss.temperature_su
 
-    _definition.id
-        '_atom_analytical_mass_loss.temperature_su'
+    _definition.id                '_atom_analytical_mass_loss.temperature_su'
     _definition.update            2022-11-21
     _description.text
 ;
@@ -19741,8 +19740,7 @@ save_
 
 save_atom_analytical_source.equipment_make
 
-    _definition.id
-        '_atom_analytical_source.equipment_make'
+    _definition.id                '_atom_analytical_source.equipment_make'
     _definition.update            2022-11-18
     _description.text
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19441,7 +19441,7 @@ save_
 save_atom_analytical.chemical_species_mass_percent
 
     _definition.id
-         '_atom_analytical.chemical_species_mass_percent'
+        '_atom_analytical.chemical_species_mass_percent'
     _definition.update            2022-11-19
     _description.text
 ;
@@ -19469,7 +19469,7 @@ save_
 save_atom_analytical.chemical_species_mass_percent_su
 
     _definition.id
-         '_atom_analytical.chemical_species_mass_percent_su'
+        '_atom_analytical.chemical_species_mass_percent_su'
     _definition.update            2022-11-19
     _description.text
 ;
@@ -19478,7 +19478,7 @@ save_atom_analytical.chemical_species_mass_percent_su
     _name.category_id             atom_analytical
     _name.object_id               chemical_species_mass_percent_su
     _name.linked_item_id
-         '_atom_analytical.chemical_species_mass_percent'
+        '_atom_analytical.chemical_species_mass_percent'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19302,6 +19302,93 @@ save_ATOM_ANALYTICAL
     _name.object_id               ATOM_ANALYTICAL
     _category_key.name            '_atom_analytical.id'
 
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _atom_analytical.analyte
+         _atom_analytical.meas_id
+         _atom_analytical.chemical_species
+         _atom_analytical.analyte_mass_percent
+         _atom_analytical.chemical_species_mass_percent
+         Si  a 'Si O2'   ?     22.7
+         Al  a 'Al2 O3'  ?     27.4
+         Ti  b 'Ti O2'   ?      2.7
+         Si  c .         10.5  .
+         Si  d Si        11.7  11.7
+;
+;
+         There are three separate determinations of Si content, and one each of Al and Ti.
+         The amount of Al is reported as the mass percent of Al2O3. The equivalent
+         amount of Al is not given. There are four different measurements presented in
+         this table.
+;
+
+save_
+
+save_atom_analytical.analyte
+
+    _definition.id                '_atom_analytical.analyte'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Symbol of the element for which a particular composition
+    refers to, as given by _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol}]
+
+save_
+
+save_atom_analytical.analyte_mass_percent
+
+    _definition.id                '_atom_analytical.analyte_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the analyte element derived from elemental analysis.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_analytical.analyte_mass_percent = dREL to calculate wt% from:
+                                            _atom_analytical.chemical_species and
+                                            _atom_analytical.chemical_species_mass_percent
+;
+
+save_
+
+save_atom_analytical.analyte_mass_percent_su
+
+    _definition.id                '_atom_analytical.analyte_mass_percent_su'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent_su
+    _name.linked_item_id          '_atom_analytical.analyte_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
 save_
 
 save_atom_analytical.id
@@ -19311,7 +19398,7 @@ save_atom_analytical.id
     _description.text
 
 ;
-    Arbitrary label uniquely identifying a single elemental composition value.
+    Arbitrary label uniquely identifying a single composition value.
 ;
     _name.category_id             atom_analytical
     _name.object_id               id
@@ -19319,6 +19406,97 @@ save_atom_analytical.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Code
+
+save_
+
+save_atom_analytical.chemical_species
+
+    _definition.id                '_atom_analytical.chemical_species'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Chemical formula of the species for which the corresponding
+    _atom_analytical.chemical_species_mass_percent refers.
+
+    The following rules apply in the construction of the formula:
+
+    1. Only recognized element symbols may be used.
+
+    2. The first element corresponds to the analyte. The remaining
+       elements should be given in alphabetic order by symbol.
+
+    3. Each element symbol is followed by a 'count' number. A count of
+       '1' may be omitted.
+
+    4. A space or parenthesis must separate each cluster of (element
+       symbol + count). A formula cannot begin with a paranthesis.
+
+    5. Where a group of elements is enclosed in parentheses, the
+       multiplier for the group must follow the closing parentheses.
+       That is, all element and group multipliers are assumed to be
+       printed as subscripted numbers.
+
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_analytical.analyte = dREL to extract analyte symbol
+;
+
+    loop_
+      _description_example.case
+         'Fe2 O3'
+         'Li'
+         'Si O2'
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent
+
+    _definition.id                '_atom_analytical.chemical_species_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the chemical species given in
+    _atom_analytical.chemical_species as derived from elemental analysis.
+
+    This is most often used in elemental compositions determined by XRF, where
+    elements are reported as equivalent mass percentages of their relevant oxide.
+
+    eg: Al is reported as Al2O3, P is reported as P2O5.
+
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.
+    _units.code                   none
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent_su
+
+    _definition.id                '_atom_analytical.chemical_species_mass_percent_su'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.chemical_species_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent_su
+    _name.linked_item_id          '_atom_analytical.chemical_species_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -19358,6 +19536,24 @@ save_ATOM_ANALYTICAL_SOURCE
     _name.category_id             ATOM_ANALYTICAL
     _name.object_id               ATOM_ANALYTICAL_SOURCE
     _category_key.name            '_atom_analytical_source.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _atom_analytical_source.id
+         _atom_analytical_source.technique
+         _atom_analytical_source.equipment_manufacturer
+         _atom_analytical_source.equipment_model
+         a  XRF Hitachi Lab-X5000
+         b  'X-ray fluorescence WDS' Hitachi Lab-X5000
+         c  ICP . .
+         d  EDS . .
+;
+;
+         Four different measurements of elemental composition are enumerated.
+;
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19301,10 +19301,7 @@ save_ATOM_ANALYTICAL
     _name.category_id             ATOM
     _name.object_id               ATOM_ANALYTICAL
     _category_key.name            '_atom_analytical.id'
-
-    loop_
-      _description_example.case
-      _description_example.detail
+    _description_example.case
 ;
          loop_
          _atom_analytical.analyte
@@ -19318,11 +19315,12 @@ save_ATOM_ANALYTICAL
          Si  c .         10.5  .
          Si  d Si        11.7  11.7
 ;
+    _description_example.detail
 ;
-         There are three separate determinations of Si content, and one each of Al and Ti.
-         The amount of Al is reported as the mass percent of Al2O3. The equivalent
-         amount of Al is not given. There are four different measurements presented in
-         this table.
+         There are three separate determinations of Si content, and one each
+         of Al and Ti. The amount of Al is reported as the mass percent of
+         Al2O3. The equivalent amount of Al is not given. There are four
+         different measurements presented in this table.
 ;
 
 save_
@@ -19368,8 +19366,8 @@ save_atom_analytical.analyte_mass_percent
     _method.expression
 ;
     _atom_analytical.analyte_mass_percent = dREL to calculate wt% from:
-                                            _atom_analytical.chemical_species and
-                                            _atom_analytical.chemical_species_mass_percent
+                                         _atom_analytical.chemical_species and
+                                _atom_analytical.chemical_species_mass_percent
 ;
 
 save_
@@ -19425,11 +19423,6 @@ save_atom_analytical.chemical_species
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_analytical.analyte = dREL to extract analyte symbol
-;
 
     loop_
       _description_example.case
@@ -19437,19 +19430,27 @@ save_atom_analytical.chemical_species
          'Li'
          'Si O2'
 
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_analytical.analyte = dREL to extract analyte symbol
+;
+
 save_
 
 save_atom_analytical.chemical_species_mass_percent
 
-    _definition.id                '_atom_analytical.chemical_species_mass_percent'
+    _definition.id
+         '_atom_analytical.chemical_species_mass_percent'
     _definition.update            2022-11-19
     _description.text
 ;
     Mass percentage of the chemical species given in
     _atom_analytical.chemical_species as derived from elemental analysis.
 
-    This is most often used in elemental compositions determined by XRF, where
-    elements are reported as equivalent mass percentages of their relevant oxide.
+    This is most often used in elemental compositions determined by XRF,
+    where elements are reported as equivalent mass percentages of their
+    relevant oxide.
 
     eg: Al is reported as Al2O3, P is reported as P2O5.
 
@@ -19467,7 +19468,8 @@ save_
 
 save_atom_analytical.chemical_species_mass_percent_su
 
-    _definition.id                '_atom_analytical.chemical_species_mass_percent_su'
+    _definition.id
+         '_atom_analytical.chemical_species_mass_percent_su'
     _definition.update            2022-11-19
     _description.text
 ;
@@ -19475,7 +19477,8 @@ save_atom_analytical.chemical_species_mass_percent_su
 ;
     _name.category_id             atom_analytical
     _name.object_id               chemical_species_mass_percent_su
-    _name.linked_item_id          '_atom_analytical.chemical_species_mass_percent'
+    _name.linked_item_id
+         '_atom_analytical.chemical_species_mass_percent'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
@@ -19536,10 +19539,7 @@ save_ATOM_ANALYTICAL_SOURCE
     _name.category_id             ATOM_ANALYTICAL
     _name.object_id               ATOM_ANALYTICAL_SOURCE
     _category_key.name            '_atom_analytical_source.id'
-
-    loop_
-      _description_example.case
-      _description_example.detail
+    _description_example.case
 ;
          loop_
          _atom_analytical_source.id
@@ -19551,6 +19551,7 @@ save_ATOM_ANALYTICAL_SOURCE
          c  ICP . .
          d  EDS . .
 ;
+    _description_example.detail
 ;
          Four different measurements of elemental composition are enumerated.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19304,16 +19304,17 @@ save_ATOM_ANALYTICAL
     _description_example.case
 ;
          loop_
+         _atom_analytical.id
          _atom_analytical.analyte
          _atom_analytical.meas_id
          _atom_analytical.chemical_species
          _atom_analytical.analyte_mass_percent
          _atom_analytical.chemical_species_mass_percent
-         Si  a 'Si O2'   ?     22.7
-         Al  a 'Al2 O3'  ?     27.4
-         Ti  b 'Ti O2'   ?      2.7
-         Si  c .         10.5  .
-         Si  d Si        11.7  11.7
+         1 Si  a 'Si O2'   ?     22.7
+         2 Al  a 'Al2 O3'  ?     27.4
+         3 Ti  b 'Ti O2'   ?      2.7
+         4 Si  c .         10.5  .
+         5 Si  d Si        11.7  11.7
 ;
     _description_example.detail
 ;
@@ -19547,7 +19548,7 @@ save_ATOM_ANALYTICAL_SOURCE
          _atom_analytical_source.equipment_manufacturer
          _atom_analytical_source.equipment_model
          a  XRF Hitachi Lab-X5000
-         b  'X-ray fluorescence WDS' Hitachi Lab-X5000
+         b  'X-ray fluorescence EDS' Hitachi Lab-X5000
          c  ICP . .
          d  EDS . .
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19525,6 +19525,194 @@ save_atom_analytical.meas_id
 
 save_
 
+save_ATOM_ANALYTICAL_EXTRA
+
+    _definition.id                ATOM_ANALYTICAL_EXTRA
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-21
+    _description.text
+;
+    The CATEGORY of data items used to describe information
+    pertaining to mass loss during speciment preparation for
+    the purposes of determining elemental composition
+    information for use in crystallographic structure studies.
+;
+    _name.category_id             ATOM_ANALYTICAL
+    _name.object_id               ATOM_ANALYTICAL_EXTRA
+    _category_key.name            '_atom_analytical_extra.id'
+    _description_example.case
+;
+         loop_
+         _atom_analytical_extra.id
+         _atom_analytical_extra.meas_id
+         _atom_analytical_extra.mass_loss_percent
+         _atom_analytical_extra.analysis_temperature
+         LOD1 a   2  328
+         LOI1 a   5  623
+         LOI2 a  10 1023
+         LOI3 a  15 1373
+         LOI4 b   5  673
+         LOI5 b  10 1123
+
+;
+    _description_example.detail
+;
+         Four mass-loss percentages are given for measurement 'a', and two
+         for measurement 'b'. The mass losses were recorded after exposing
+         the specimen to the listed temperatures. The mass lost at a lower
+         temperature for the same measurement should be included in the
+         higher temperatures; that is, for measurement 'a', the total mass
+         loss after four measurements is 15 wt%, not (2+5+10+15) wt%.
+;
+
+save_
+
+save_atom_analytical_extra.analysis_temperature
+
+    _definition.id                '_atom_analytical_extra.analysis_temperature'
+    _definition.update            2022-11-21
+    _description.text
+;
+    The temperature, in kelvin, at which the mass loss was recorded
+    as given by _atom_analytical_extra.mass_loss_percent.
+
+    This would be used to record the temperature of drying or ignitition,
+    during, for example, fusion bead preparation for XRF analysis.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               analysis_temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_atom_analytical_extra.analysis_temperature_su
+
+    _definition.id
+        '_atom_analytical_extra.analysis_temperature_su'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_extra.analysis_temperature.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               analysis_temperature_su
+    _name.linked_item_id          '_atom_analytical_extra.analysis_temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical_extra.id
+
+    _definition.id                '_atom_analytical_extra.id'
+    _definition.update            2022-11-21
+    _description.text
+
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_atom_analytical_extra.mass_loss_percent
+
+    _definition.id                '_atom_analytical_extra.mass_loss_percent'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Mass lost by the specimen during specimen preparation expressed
+    as a percentage. The temperature at which the mass loss was recorded
+    is given by _atom_analytical_extra.analysis_temperature.
+
+    This would be used to record mass loss on drying, or mass loss on
+    ignitition, during, for example, fusion bead preparation for XRF
+    analysis.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               mass_loss_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.
+    _units.code                   none
+
+save_
+
+save_atom_analytical_extra.mass_loss_percent_su
+
+    _definition.id                '_atom_analytical_extra.mass_loss_percent_su'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_extra.mass_loss_percent.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               mass_loss_percent_su
+    _name.linked_item_id          '_atom_analytical_extra.mass_loss_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical_extra.meas_id
+
+    _definition.id                '_atom_analytical_extra.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_atom_analytical_extra.special_details
+
+    _definition.id                '_atom_analytical_extra.special_details'
+    _definition.update            2022-11-21
+    _description.text
+
+;
+    Text describing the conditions under which the
+    data were collected that are not able to be captured using
+
+;
+    _name.category_id             atom_analytical_extra
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
 save_ATOM_ANALYTICAL_SOURCE
 
     _definition.id                ATOM_ANALYTICAL_SOURCE

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2022-11-19
+    _dictionary.date              2022-11-21
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -26626,7 +26626,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2022-11-19
+         3.2.0                    2022-11-21
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26634,5 +26634,5 @@ save_
        _diffrn_radiation.xray_symbol.
 
        Added categories and data names to allow for the elemental composition
-       of speciments to be recorded
+       of specimens to be recorded
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19391,24 +19391,6 @@ save_atom_analytical.analyte_mass_percent_su
 
 save_
 
-save_atom_analytical.id
-
-    _definition.id                '_atom_analytical.id'
-    _definition.update            2022-11-18
-    _description.text
-
-;
-    Arbitrary label uniquely identifying a single composition value.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Code
-
-save_
-
 save_atom_analytical.chemical_species
 
     _definition.id                '_atom_analytical.chemical_species'
@@ -19497,6 +19479,24 @@ save_atom_analytical.chemical_species_mass_percent_su
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical.id
+
+    _definition.id                '_atom_analytical.id'
+    _definition.update            2022-11-18
+    _description.text
+
+;
+    Arbitrary label uniquely identifying a single composition value.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
 
 save_
 


### PR DESCRIPTION
Begins to address #304 

I've added `ATOM_ANALYTICAL_SOURCE` and associated data names. Also added the beginnings of `ATOM_ANALYTICAL` so I could properly nest everything.

`ATOM_ANALYTICAL_SOURCE` should contain all the necessary data names. More to come for `ATOM_ANALYTICAL`.

I think I've done it correctly.