### PR TITLE
rename DIFFRN_STANDARD and data names to DIFFRN_STANDARDS

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-06
+    _dictionary.date              2023-01-10
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -3911,25 +3911,25 @@ save_diffrn_source.voltage
 
 save_
 
-save_DIFFRN_STANDARD
+save_DIFFRN_STANDARDS
 
-    _definition.id                DIFFRN_STANDARD
+    _definition.id                DIFFRN_STANDARDS
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2012-11-26
+    _definition.update            2023-01-10
     _description.text
 ;
     The CATEGORY of data items which specify information about the
     standard reflections used in the diffraction measurement process.
 ;
     _name.category_id             DIFFRN
-    _name.object_id               DIFFRN_STANDARD
+    _name.object_id               DIFFRN_STANDARDS
 
 save_
 
-save_diffrn_standard.decay_percent
+save_diffrn_standards.decay_percent
 
-    _definition.id                '_diffrn_standard.decay_percent'
+    _definition.id                '_diffrn_standards.decay_percent'
 
     loop_
       _alias.definition_id
@@ -3937,7 +3937,7 @@ save_diffrn_standard.decay_percent
          '_diffrn_standards.decay_%'
          '_diffrn_standards_decay_percent'
 
-    _definition.update            2013-03-07
+    _definition.update            2023-01-10
     _description.text
 ;
     The percentage decrease in the mean of the intensities for the
@@ -3951,7 +3951,7 @@ save_diffrn_standard.decay_percent
     uncertainties is considered possible.  Thus 0.0(1) would indicate
     a decay of less than 0.3% or an enhancement of less than 0.3%.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               decay_percent
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -3969,38 +3969,38 @@ save_diffrn_standard.decay_percent
 
 save_
 
-save_diffrn_standard.decay_percent_su
+save_diffrn_standards.decay_percent_su
 
-    _definition.id                '_diffrn_standard.decay_percent_su'
-    _definition.update            2021-09-23
+    _definition.id                '_diffrn_standards.decay_percent_su'
+    _definition.update            2023-01-10
     _description.text
 ;
-    Standard uncertainty of _diffrn_standard.decay_percent.
+    Standard uncertainty of _diffrn_standards.decay_percent.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               decay_percent_su
-    _name.linked_item_id          '_diffrn_standard.decay_percent'
+    _name.linked_item_id          '_diffrn_standards.decay_percent'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
-save_diffrn_standard.interval_count
+save_diffrn_standards.interval_count
 
-    _definition.id                '_diffrn_standard.interval_count'
+    _definition.id                '_diffrn_standards.interval_count'
 
     loop_
       _alias.definition_id
          '_diffrn_standards_interval_count'
          '_diffrn_standards.interval_count'
 
-    _definition.update            2021-03-01
+    _definition.update            2023-01-10
     _description.text
 ;
     Reflection count between the standard reflection measurements.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               interval_count
     _type.purpose                 Number
     _type.source                  Assigned
@@ -4011,21 +4011,21 @@ save_diffrn_standard.interval_count
 
 save_
 
-save_diffrn_standard.interval_time
+save_diffrn_standards.interval_time
 
-    _definition.id                '_diffrn_standard.interval_time'
+    _definition.id                '_diffrn_standards.interval_time'
 
     loop_
       _alias.definition_id
          '_diffrn_standards_interval_time'
          '_diffrn_standards.interval_time'
 
-    _definition.update            2012-11-26
+    _definition.update            2023-01-10
     _description.text
 ;
     Time between the standard reflection measurements.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               interval_time
     _type.purpose                 Number
     _type.source                  Assigned
@@ -4036,21 +4036,21 @@ save_diffrn_standard.interval_time
 
 save_
 
-save_diffrn_standard.number
+save_diffrn_standards.number
 
-    _definition.id                '_diffrn_standard.number'
+    _definition.id                '_diffrn_standards.number'
 
     loop_
       _alias.definition_id
          '_diffrn_standards_number'
          '_diffrn_standards.number'
 
-    _definition.update            2021-03-01
+    _definition.update            2023-01-10
     _description.text
 ;
     Number of unique standard reflections used in measurements.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               number
     _type.purpose                 Number
     _type.source                  Assigned
@@ -4061,9 +4061,9 @@ save_diffrn_standard.number
 
 save_
 
-save_diffrn_standard.scale_su_average
+save_diffrn_standards.scale_su_average
 
-    _definition.id                '_diffrn_standard.scale_su_average'
+    _definition.id                '_diffrn_standards.scale_su_average'
 
     loop_
       _alias.definition_id
@@ -4072,13 +4072,13 @@ save_diffrn_standard.scale_su_average
          '_diffrn_standards.scale_u'
          '_diffrn_standards_scale_u'
 
-    _definition.update            2013-01-20
+    _definition.update            2023-01-10
     _description.text
 ;
     The average standard uncertainty of the individual standard scales
     applied to the intensity data.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               scale_su_average
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -4089,17 +4089,17 @@ save_diffrn_standard.scale_su_average
 
 save_
 
-save_diffrn_standard.scale_su_average_su
+save_diffrn_standards.scale_su_average_su
 
-    _definition.id                '_diffrn_standard.scale_su_average_su'
+    _definition.id                '_diffrn_standards.scale_su_average_su'
     _definition.update            2021-09-23
     _description.text
 ;
-    Standard uncertainty of _diffrn_standard.scale_su_average.
+    Standard uncertainty of _diffrn_standards.scale_su_average.
 ;
-    _name.category_id             diffrn_standard
+    _name.category_id             diffrn_standards
     _name.object_id               scale_su_average_su
-    _name.linked_item_id          '_diffrn_standard.scale_su_average'
+    _name.linked_item_id          '_diffrn_standards.scale_su_average'
     _units.code                   none
 
     _import.get                   [{'file':templ_attr.cif  'save':general_su}]
@@ -4118,7 +4118,7 @@ save_DIFFRN_STANDARD_REFLN
     measured repeatedly to monitor variations in intensity due to source
     flux, environment conditions or crystal quality.
 ;
-    _name.category_id             DIFFRN_STANDARD
+    _name.category_id             DIFFRN_STANDARDS
     _name.object_id               DIFFRN_STANDARD_REFLN
 
     loop_
@@ -26832,7 +26832,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-06
+         3.2.0                    2023-01-10
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26848,4 +26848,7 @@ save_
 
        Changed the content type of the _diffrn_reflns.limit_min and
        _diffrn_reflns.limit_max data items from Real to Integer.
+
+       Renamed DIFFRN_STANDARD to DIFFRN_STANDARDS, as well as all data names,
+       to retain consistency with the DDL1 dictionary.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3989,12 +3989,7 @@ save_
 save_diffrn_standards.interval_count
 
     _definition.id                '_diffrn_standards.interval_count'
-
-    loop_
-      _alias.definition_id
-         '_diffrn_standards_interval_count'
-         '_diffrn_standards.interval_count'
-
+    _alias.definition_id          '_diffrn_standards_interval_count'
     _definition.update            2023-01-10
     _description.text
 ;
@@ -4014,12 +4009,7 @@ save_
 save_diffrn_standards.interval_time
 
     _definition.id                '_diffrn_standards.interval_time'
-
-    loop_
-      _alias.definition_id
-         '_diffrn_standards_interval_time'
-         '_diffrn_standards.interval_time'
-
+    _alias.definition_id          '_diffrn_standards_interval_time'
     _definition.update            2023-01-10
     _description.text
 ;
@@ -4039,12 +4029,7 @@ save_
 save_diffrn_standards.number
 
     _definition.id                '_diffrn_standards.number'
-
-    loop_
-      _alias.definition_id
-         '_diffrn_standards_number'
-         '_diffrn_standards.number'
-
+    _alias.definition_id          '_diffrn_standards_number'
     _definition.update            2023-01-10
     _description.text
 ;


### PR DESCRIPTION
Will close #291 

As noted above:
>the `_diffrn_standards_*` data names in DDL1 have been transformed into `_diffrn_standard.*` data names in DDLm, i.e. the `s` has been dropped. This breaks the convenient heuristic that valid DDL1 data names can be created by simply replacing the `.` with `_` in DDLm. ... I can see no useful reason for this change.

The DDL1 dictionary is [here](https://github.com/COMCIFS/DDL1-legacy-dictionaries/blob/28e20dc928790dceb889716d2bed435fc10c4c79/dictionaries/cif_core.dic#L6285).