### PR TITLE
update author.name-type data items to specify single-name author formatting

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-06
+    _dictionary.date              2023-01-10
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -14897,13 +14897,15 @@ save_audit_author.name
 
     _definition.id                '_audit_author.name'
     _alias.definition_id          '_audit_author_name'
-    _definition.update            2012-11-29
+    _definition.update            2023-01-10
     _description.text
 ;
     The name of an author of this data block. If there are multiple
     authors, _audit_author.name is looped with _audit_author.address.
     The family name(s), followed by a comma and including any
     dynastic components, precedes the first name(s) or initial(s).
+    For authors with only one name, provide the full name without
+    abbreviation.
 ;
     _name.category_id             audit_author
     _name.object_id               name
@@ -14921,6 +14923,7 @@ save_audit_author.name
          '''Simonov, Yu.A.'''
          '''M\"uller, H.A.'''
          '''Ross II, C.R.'''
+         '''Chandra'''
 
 save_
 
@@ -15245,13 +15248,14 @@ save_audit_contact_author.name
          '_audit_contact_author_name'
          '_audit_contact_author'
 
-    _definition.update            2012-11-29
+    _definition.update            2023-01-10
     _description.text
 ;
     The name of the author of the data block to whom correspondence
     should be addressed. The family name(s), followed by a comma and
     including any dynastic components, precedes the first name(s) or
-    initial(s).
+    initial(s). For authors with only one name, provide the full name
+    without abbreviation.
 ;
     _name.category_id             audit_contact_author
     _name.object_id               name
@@ -15265,6 +15269,7 @@ save_audit_contact_author.name
          "Bleary, Percival R."
          "O'Neil, F.K."
          "Van den Bossche, G."
+         "Chandra"
 
 save_
 
@@ -16175,12 +16180,14 @@ save_citation_author.name
 
     _definition.id                '_citation_author.name'
     _alias.definition_id          '_citation_author_name'
-    _definition.update            2012-12-11
+    _definition.update            2023-01-10
     _description.text
 ;
     Name of citation author; relevant for articles and book chapters.
     The family name(s), followed by a comma and including any
     dynastic components, precedes the first name(s) or initial(s).
+    For authors with only one name, provide the full name without
+    abbreviation.
 ;
     _name.category_id             citation_author
     _name.object_id               name
@@ -16198,6 +16205,7 @@ save_citation_author.name
          '''Simonov, Yu.A'''
          '''M\"uller, H.A.'''
          '''Ross II, C.R.'''
+         '''Chandra'''
 
 save_
 
@@ -18333,13 +18341,14 @@ save_publ_author.name
 
     _definition.id                '_publ_author.name'
     _alias.definition_id          '_publ_author_name'
-    _definition.update            2012-12-13
+    _definition.update            2023-01-10
     _description.text
 ;
     The name of a publication author. If there are multiple authors,
     this will be looped with _publ_author.address. The family
     name(s), followed by a comma and including any dynastic
-    components, precedes the first names or initials.
+    components, precedes the first names or initials. For authors
+    with only one name, provide the full name without abbreviation.
 ;
     _name.category_id             publ_author
     _name.object_id               name
@@ -18357,6 +18366,7 @@ save_publ_author.name
          '''Simonov, Yu.A'''
          '''M\"uller, H.A.'''
          '''Ross II, C.R.'''
+         '''Chandra'''
 
 save_
 
@@ -26832,7 +26842,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-06
+         3.2.0                    2023-01-10
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26848,4 +26858,8 @@ save_
 
        Changed the content type of the _diffrn_reflns.limit_min and
        _diffrn_reflns.limit_max data items from Real to Integer.
+
+       Updated _audit_author.name, _audit_contact_author.name,
+       _citation_author.name, and _publ_author.name to specify how authors with
+       single names should be handled.
 ;


### PR DESCRIPTION
will close #240 

Wording guided by https://blog.apastyle.org/apastyle/2017/05/whats-in-a-name-authors-with-only-one-name.html