### PR TITLE
Change the _exptl_crystal.colour data item from a list to a text string

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10038,12 +10038,12 @@ save_exptl_crystal.colour
          'red'
          'colourless'
 
-    _method.purpose               Evaluation
+    _method.purpose               Definition
     _method.expression
 ;
     With c as exptl_crystal_appearance
 
-     _exptl_crystal.colour = c.general + " " + c.intensity + " " + c.hue
+     _enumeration.default = c.general + " " + c.intensity + " " + c.hue
 ;
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10000,10 +10000,7 @@ save_exptl_crystal.colour
     _definition.update            2023-01-12
     _description.text
 ;
-    Colour description of the crystal expressed as a combination of
-    the _exptl_crystal_appearance.general,
-    _exptl_crystal_appearance.intensity and _exptl_crystal_appearance.hue
-    data item values separated by sequences of a single space symbol.
+    Colour description of the crystal.
 
     Data items from EXPTL_CRYSTAL_APPEARANCE category should be used in
     preference to this item when possible.
@@ -10022,6 +10019,7 @@ save_exptl_crystal.colour
          'metallic blue'
          'red'
          'colourless'
+         'dichroic dark purple/pale blue'
 
     _method.purpose               Definition
     _method.expression

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-10
+    _dictionary.date              2023-01-12
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -10012,26 +10012,38 @@ save_exptl_crystal.colour
 
     _definition.id                '_exptl_crystal.colour'
     _alias.definition_id          '_exptl_crystal_colour'
-    _definition.update            2021-11-04
+    _definition.update            2023-01-12
     _description.text
 ;
-    Colour description of a crystal as a list of the allowed
-    exptl_crystal_appearance states for general, intensity and hue.
+    Colour description of the crystal expressed as a combination of
+    the _exptl_crystal_appearance.general,
+    _exptl_crystal_appearance.intensity and _exptl_crystal_appearance.hue
+    data item values separated by sequences of a single space symbol.
+
+    Data items from EXPTL_CRYSTAL_APPEARANCE category should be used in
+    preference to this item when possible.
 ;
     _name.category_id             exptl_crystal
     _name.object_id               colour
     _type.purpose                 Composite
     _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[3]'
-    _type.contents                Word
-    _description_example.case     [translucent  pale  green]
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'translucent pale green'
+         'dark yellow'
+         'metallic blue'
+         'red'
+         'colourless'
+
     _method.purpose               Evaluation
     _method.expression
 ;
-    With  c  as  exptl_crystal_appearance
+    With c as exptl_crystal_appearance
 
-     _exptl_crystal.colour = [ c.general, c.intensity, c.hue ]
+     _exptl_crystal.colour = c.general + " " + c.intensity + " " + c.hue
 ;
 
 save_
@@ -26832,7 +26844,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-10
+         3.2.0                    2023-01-12
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26848,4 +26860,7 @@ save_
 
        Changed the content type of the _diffrn_reflns.limit_min and
        _diffrn_reflns.limit_max data items from Real to Integer.
+
+       Changed the _exptl_crystal.colour data item from a list to a text string
+       to restore compatibility with the DDL1 version of the dictionary.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10041,9 +10041,22 @@ save_exptl_crystal.colour
     _method.purpose               Definition
     _method.expression
 ;
-    With c as exptl_crystal_appearance
+    default_value = ""
+    With c as exptl_crystal_appearance {
+        if (not Is_missing(c.general))
+            default_value = c.general
+        if (not Is_missing(c.intensity)) {
+            if (len(default_value) > 0) default_value = default_value + " "
+            default_value = default_value + c.intensity
+        }
+        if (not Is_missing(c.hue)) {
+            if (len(default_value) > 0) default_value = default_value + " "
+            default_value = default_value + c.hue
+        }
+    }
 
-     _enumeration.default = c.general + " " + c.intensity + " " + c.hue
+    if (len(default_value) > 0)
+        _enumeration.default = default_value
 ;
 
 save_


### PR DESCRIPTION
This PR addresses issue #189.

While drafting this PR I made a few assumptions that should be addressed before merging:
- I introduced quite a strict format for the color text string based on the values of items from the `EXPTL_CRYSTAL_APPEARANCE` category to mimic the format of the removed list data structure. However, alternatively we might want to remove any formatting requirements on the field so it could also be used as a catch-all field (read `special_details`) for crystal colour data. There are a few instances in the COD of entries which seemingly cannot be described by the items from the `EXPTL_CRYSTAL_APPPEARANCE` category (e.g. `dichroic dark purple/pale blue`), but they are not very numerous. Should I remove the formatting requirements (the dREL part can still remain as a fallback mechanism)? 
- I added a statement about `EXPTL_CRYSTAL_APPEARANCE` items being preferred since modular structured data is usually a better choice.
- The dREL code that I added should work well in the most general case when all items from the `EXPTL_CRYSTAL_APPEARANCE` category are provided, but would most likely produce a strangely formatted string when at least one of the items is missing/undefined (string would contain leading, trailing or double spaces). This could be rewritten to check if the item actually has a value and only then concatenate it to the string, however, I am not sure if there is an operator for such a check in dREL. Any suggestions? 