### PR TITLE
Fix scattering density units in dREL

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-10
+    _dictionary.date              2023-01-12
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -24450,7 +24450,7 @@ save_refine_diff.density_max
          '_refine_diff_density_max'
          '_refine.diff_density_max'
 
-    _definition.update            2012-11-20
+    _definition.update            2023-01-12
     _description.text
 ;
     Maximum density value in a difference Fourier map.
@@ -24465,9 +24465,11 @@ save_refine_diff.density_max
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -24481,7 +24483,7 @@ save_refine_diff.density_max_su
          '_refine_diff_density_max_su'
          '_refine.diff_density_max_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-01-12
     _description.text
 ;
     Standard uncertainty of the maximum density value
@@ -24497,9 +24499,11 @@ save_refine_diff.density_max_su
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -24513,7 +24517,7 @@ save_refine_diff.density_min
          '_refine_diff_density_min'
          '_refine.diff_density_min'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-01-12
     _description.text
 ;
     Minimum density value in a difference Fourier map.
@@ -24528,9 +24532,11 @@ save_refine_diff.density_min
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -24544,7 +24550,7 @@ save_refine_diff.density_min_su
          '_refine_diff_density_min_su'
          '_refine.diff_density_min_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-01-12
     _description.text
 ;
     Standard uncertainty of the minimum density value
@@ -24560,9 +24566,11 @@ save_refine_diff.density_min_su
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -24576,7 +24584,7 @@ save_refine_diff.density_rms
          '_refine_diff_density_RMS'
          '_refine.diff_density_RMS'
 
-    _definition.update            2012-11-20
+    _definition.update            2023-01-12
     _description.text
 ;
     Root mean square density value in a difference Fourier map.
@@ -24596,9 +24604,11 @@ save_refine_diff.density_rms
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -24612,7 +24622,7 @@ save_refine_diff.density_rms_su
          '_refine_diff_density_RMS_su'
          '_refine.diff_density_RMS_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-01-12
     _description.text
 ;
     Standard uncertainty of the root mean square density value
@@ -24628,9 +24638,11 @@ save_refine_diff.density_rms_su
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
-    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
-    Else                                            _units.code =  "electrons"
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
 ;
 
 save_
@@ -26827,7 +26839,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-10
+         3.2.0                    2023-01-12
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26850,4 +26862,9 @@ save_
 
        Renamed DIFFRN_STANDARD to DIFFRN_STANDARDS, as well as all data names,
        to retain consistency with the DDL1 dictionary.
+
+       Corrected the dREL methods responsible for the assignment of units of
+       measurement to the _refine_diff.density_min, _refine_diff.density_min_su,
+       _refine_diff.density_max, _refine_diff.density_max_su,
+       _refine_diff.density_rms and _refine_diff.density_rms_su data items.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24428,10 +24428,10 @@ save_REFINE_DIFF
     _definition.id                REFINE_DIFF
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2021-09-24
+    _definition.update            2023-01-12
     _description.text
 ;
-    The CATEGORY of data items which specify the electron density limits
+    The CATEGORY of data items which specify the scattering density limits
     in a difference Fourier map after the structure has been refined. The
     RMS value is with respect to the arithmetic mean density, and is derived
     from summations over each grid point in the asymmetric unit of the cell.

--- a/ddl.dic
+++ b/ddl.dic
@@ -2601,7 +2601,7 @@ save_
 
        Unified the spelling of certain words.
 ;
-         4.1.0                    2023-01-11
+         4.1.0                    2023-01-12
 ;
        Added new 'Word' content type.
 

--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.1.0
-    _dictionary.date              2023-01-11
+    _dictionary.date              2023-01-12
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.1.0

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -10,7 +10,7 @@ data_COM_VAL
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.8
-    _dictionary.date             2022-10-11
+    _dictionary.date             2023-01-12
     _dictionary.uri              www.iucr.org/cif/dic/com_val.dic
     _dictionary.ddl_conformance  4.1.0
     _description.text
@@ -827,6 +827,9 @@ save_units_code
    "electron-density 'electrons per angstroms  cubed (electrons * (metres * 10^(-10))^(-3))'"
    'electrons_per_picometre_cubed'     
    "electron-density 'electrons per picometres cubed (electrons * (metres * 10^(-12))^(-3))'"
+
+   'femtometres_per_angstrom_cubed'
+   "scattering-length-density 'femtometres per angstroms cubed (10^-6 * (metres * 10^(-10))^(-2))'"
 
    'dalton'      "standard atomic mass unit"
  
@@ -2365,7 +2368,7 @@ save_
        Updated the human-readable descriptions of the 'kelvins' and
        'kelvins_per_minute' enumeration states in the _units_code save frame.
 ;
-         1.4.8                    2022-10-11
+         1.4.8                    2023-01-12
 ;
        Corrected a few typos in the 'units_code' save frame.
 
@@ -2385,8 +2388,9 @@ save_
        Changed a duplicate version number in the DICTIONARY_AUDIT loop
        from 1.0.1 to 1.1.0.
 
-       Added the 'micrometres', 'counts' and 'photons per second' enumeration
-       states to the 'units_code' save frame.
+       Added the 'micrometres', 'counts', 'photons per second' and
+       'femtometres_per_angstrom_cubed' enumeration states to the
+       'units_code' save frame.
 
        Added units for TOF coefficients.
 


### PR DESCRIPTION
This PR resolves issue  #205.

Note that I also slightly changed the phrasing in the description of the `REFINE_DIFF` category. Specifically, I changed the phrase "electron density limits" to "scattering density limits" since the data items in the category can describe both electron densities and scattering length density. @jamesrhester , @rowlesmr  is the term `scattering density limits` appropriate or is there a better one?