### PR TITLE
Add journal article number and page count

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-16
+    _dictionary.date              2023-01-26
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -17347,6 +17347,30 @@ save_journal.paper_doi
 
 save_
 
+save_journal.paper_number
+
+    _definition.id                '_journal.paper_number'
+    _definition.update            2023-01-26
+    _description.text
+;
+    Article number that is used by some journals instead of a page range.
+    Usually applies to electronic-only journals.
+;
+    _name.category_id             journal
+    _name.object_id               paper_number
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         e0222394
+         L041303
+         044501
+
+save_
+
 save_journal.suppl_publ_number
 
     _definition.id                '_journal.suppl_publ_number'
@@ -26864,7 +26888,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-16
+         3.2.0                    2023-01-26
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26901,4 +26925,6 @@ save_
 
        Changed the _exptl_crystal.colour data item from a list to a text string
        to restore compatibility with the DDL1 version of the dictionary.
+
+       Added the journal.paper_number data item.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -17388,6 +17388,12 @@ save_journal.paper_pages
     _enumeration.range            1:
     _units.code                   none
 
+    loop_
+      _description_example.case
+         1
+         4
+         13
+
 save_
 
 save_journal.suppl_publ_number

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -17371,6 +17371,25 @@ save_journal.paper_number
 
 save_
 
+save_journal.paper_pages
+
+    _definition.id                '_journal.paper_pages'
+    _definition.update            2023-01-26
+    _description.text
+;
+    Number of pages in the journal article.
+;
+    _name.category_id             journal
+    _name.object_id               paper_pages
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
 save_journal.suppl_publ_number
 
     _definition.id                '_journal.suppl_publ_number'
@@ -26926,5 +26945,5 @@ save_
        Changed the _exptl_crystal.colour data item from a list to a text string
        to restore compatibility with the DDL1 version of the dictionary.
 
-       Added the journal.paper_number data item.
+       Added the _journal.paper_number and _journal.paper_pages data items.
 ;


### PR DESCRIPTION
This PR introduces two bibliography-related data items addition of which were requested at the IUCr website:
* `_journal_article_number` (https://www.iucr.org/resources/cif/dictionaries/new-item/cif_core/_journal_article_number).
* `_journal_article_page_count` (https://www.iucr.org/resources/cif/dictionaries/new-item/cif_core/_journal_article_page_count).

I slightly renamed the data items to follow the naming conventions of other data items:
* `_journal_article_number` to `_journal.paper_number` to match `_journal.paper_DOI`.
* `_journal_article_page_count` to `_journal.paper_pages` to match `_journal.suppl_publ_pages`.

Of course, the original names could be used if preferred.