### PR TITLE
Change identifiers to word

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -8677,7 +8677,7 @@ save_chemical.identifier_inchi
 
     _definition.id                '_chemical.identifier_InChI'
     _alias.definition_id          '_chemical_identifier_InChI'
-    _definition.update            2021-09-24
+    _definition.update            2023-02-02
     _description.text
 ;
     The IUPAC International Chemical Identifier (InChI) is a
@@ -8693,7 +8693,7 @@ save_chemical.identifier_inchi
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _description_example.case
         InChI=1/C10H8/c1-2-6-10-8-4-3-7-9(10)5-1/h1-8H'
     _description_example.detail   naphthalene
@@ -8704,7 +8704,7 @@ save_chemical.identifier_inchi_key
 
     _definition.id                '_chemical.identifier_InChI_key'
     _alias.definition_id          '_chemical_identifier_InChI_key'
-    _definition.update            2021-09-24
+    _definition.update            2023-02-02
     _description.text
 ;
     The InChIKey is a compact hashed version of the full InChI
@@ -8717,7 +8717,7 @@ save_chemical.identifier_inchi_key
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
     _description_example.case     InChIKey=OROGSEYTTFOCAN-DNJOTXNNBG
     _description_example.detail   codeine
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-29
+    _dictionary.date              2023-02-02
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -9449,7 +9449,7 @@ save_
 save_chemical_conn_bond.id
 
     _definition.id                '_chemical_conn_bond.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     Unique identifier for the bond.
@@ -9459,7 +9459,7 @@ save_chemical_conn_bond.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -12006,7 +12006,7 @@ save_
 save_space_group_wyckoff.id
 
     _definition.id                '_space_group_Wyckoff.id'
-    _definition.update            2014-06-12
+    _definition.update            2023-02-02
     _description.text
 ;
     An arbitrary code that is unique to a particular Wyckoff position.
@@ -12016,7 +12016,7 @@ save_space_group_wyckoff.id
     _type.purpose                 Encode
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -12426,18 +12426,17 @@ save_
 save_geom_angle.id
 
     _definition.id                '_geom_angle.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
-    An arbitrary, unique identifier for the angle formed by the
-    three atoms.
+    An arbitrary, unique identifier for the angle formed by the three atoms.
 ;
     _name.category_id             geom_angle
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -12720,7 +12719,7 @@ save_
 save_geom_bond.id
 
     _definition.id                '_geom_bond.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     Unique identifier for the bond.
@@ -12730,7 +12729,7 @@ save_geom_bond.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -13010,7 +13009,7 @@ save_
 save_geom_contact.id
 
     _definition.id                '_geom_contact.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     An identifier for the contact that is unique within the loop.
@@ -13020,7 +13019,7 @@ save_geom_contact.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -13413,7 +13412,7 @@ save_
 save_geom_hbond.id
 
     _definition.id                '_geom_hbond.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     An identifier for the hydrogen bond that is unique within the loop.
@@ -13423,7 +13422,7 @@ save_geom_hbond.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -13739,7 +13738,7 @@ save_
 save_geom_torsion.id
 
     _definition.id                '_geom_torsion.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     An identifier for the torsion angle that is unique within its loop.
@@ -13749,7 +13748,7 @@ save_geom_torsion.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -14186,7 +14185,7 @@ save_
 save_model_site.id
 
     _definition.id                '_model_site.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
     An identifier for the model site that is unique within its loop.
@@ -14196,7 +14195,7 @@ save_model_site.id
     _type.purpose                 Key
     _type.source                  Derived
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -14868,17 +14867,17 @@ save_
 save_audit_author.id
 
     _definition.id                '_audit_author.id'
-    _definition.update            2020-08-13
+    _definition.update            2023-02-02
     _description.text
 ;
-    Arbitrary identifier for this author
+    Arbitrary identifier for this author.
 ;
     _name.category_id             audit_author
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -14961,7 +14960,7 @@ save_
 save_audit_author_role.id
 
     _definition.id                '_audit_author_role.id'
-    _definition.update            2020-08-06
+    _definition.update            2023-02-02
     _description.text
 ;
     Unique identifier for the author for whom a role is identified.
@@ -14975,7 +14974,7 @@ save_audit_author_role.id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -15234,10 +15233,10 @@ save_
 save_audit_contact_author.id
 
     _definition.id                '_audit_contact_author.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
-    Arbitrary identifier for this author
+    Arbitrary identifier for this author.
 ;
     _name.category_id             audit_contact_author
     _name.object_id               id
@@ -15245,7 +15244,7 @@ save_audit_contact_author.id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -15555,7 +15554,7 @@ save_
 save_audit_support.id
 
     _definition.id                '_audit_support.id'
-    _definition.update            2020-08-23
+    _definition.update            2023-02-02
     _description.text
 ;
     An arbitrary unique identifier for each source of support for
@@ -15566,7 +15565,7 @@ save_audit_support.id
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -15630,17 +15629,17 @@ save_citation.book_id_isbn
 
     _definition.id                '_citation.book_id_ISBN'
     _alias.definition_id          '_citation_book_id_ISBN'
-    _definition.update            2012-12-11
+    _definition.update            2023-02-02
     _description.text
 ;
-    International Standard Book Number (ISBN) for book chap. cited.
+    International Standard Book Number (ISBN) for book chapter cited.
 ;
     _name.category_id             citation
     _name.object_id               book_id_ISBN
     _type.purpose                 Encode
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Code
 
 save_
 
@@ -15822,7 +15821,7 @@ save_citation.id
     Unique identifier to the CITATION list. A value of 'primary'
     should be used to indicate the citation that the author(s)
     consider to be the most pertinent to the contents of the data
-    block.  Note that this item need not be a number;  it can be
+    block. Note that this item need not be a number; it can be
     any unique identifier.
 ;
     _name.category_id             citation
@@ -15929,7 +15928,7 @@ save_citation.journal_id_issn
     _description.text
 ;
     The International Standard Serial Number (ISSN) code assigned to
-    the journal cited;  relevant for journal articles.
+    the journal cited. Relevant for journal articles.
 ;
     _name.category_id             citation
     _name.object_id               journal_id_ISSN
@@ -16942,18 +16941,17 @@ save_
 save_database_related.database_id
 
     _definition.id                '_database_related.database_id'
-    _definition.update            2019-01-08
+    _definition.update            2023-02-02
     _description.text
 ;
-    An identifier for the database that contains the
-    related dataset.
+    An identifier for the database that contains the related dataset.
 ;
     _name.category_id             database_related
     _name.object_id               database_id
     _type.purpose                 State
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
     _import.get
         [{'file':templ_enum.cif  'save':database_list}]
@@ -16982,7 +16980,7 @@ save_
 save_database_related.id
 
     _definition.id                '_database_related.id'
-    _definition.update            2021-03-03
+    _definition.update            2023-02-02
     _description.text
 ;
     An identifier for this database reference.
@@ -16992,7 +16990,7 @@ save_database_related.id
     _type.purpose                 Key
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Word
 
 save_
 
@@ -18314,28 +18312,28 @@ save_
 save_publ_author.id
 
     _definition.id                '_publ_author.id'
-    _definition.update            2020-08-13
+    _definition.update            2023-02-02
     _description.text
 ;
-    Arbitrary identifier for this author
+    Arbitrary identifier for this author.
 ;
     _name.category_id             publ_author
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
 save_publ_author.id_audit
 
     _definition.id                '_publ_author.id_audit'
-    _definition.update            2020-08-13
+    _definition.update            2023-02-02
     _description.text
 ;
-    Identifier corresponding to this author in the audit_author
-    list, if present.
+    Identifier corresponding to this author in the AUDIT_AUTHOR category list,
+    if present.
 ;
     _name.category_id             publ_author
     _name.object_id               id_audit
@@ -18343,7 +18341,7 @@ save_publ_author.id_audit
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -18355,7 +18353,7 @@ save_publ_author.id_iucr
     _description.text
 ;
     Identifier in the IUCr contact database of a publication
-    author.  This identifier may be available from the World
+    author. This identifier may be available from the World
     Directory of Crystallographers (http://wdc.iucr.org).
 ;
     _name.category_id             publ_author
@@ -18708,10 +18706,10 @@ save_
 save_publ_contact_author.id
 
     _definition.id                '_publ_contact_author.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-02
     _description.text
 ;
-    Arbitrary identifier for this author
+    Arbitrary identifier for this author.
 ;
     _name.category_id             publ_contact_author
     _name.object_id               id
@@ -18719,7 +18717,7 @@ save_publ_contact_author.id
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -18747,7 +18745,7 @@ save_publ_contact_author.id_orcid
 
     _definition.id                '_publ_contact_author.id_ORCID'
     _alias.definition_id          '_publ_contact_author_id_ORCID'
-    _definition.update            2021-09-24
+    _definition.update            2023-02-02
     _description.text
 ;
     Identifier in the ORCID Registry of the author submitting
@@ -18760,7 +18758,7 @@ save_publ_contact_author.id_orcid
     _type.purpose                 Encode
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Text
+    _type.contents                Code
     _description_example.case     0000-0003-0391-0002
 
 save_
@@ -26940,7 +26938,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-29
+         3.2.0                    2023-02-02
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26986,4 +26984,6 @@ save_
        disorder.
 
        Added the _citation.URL and _journal.paper_URL data items.
+
+       Changed the content type of multiple id data items.
 ;


### PR DESCRIPTION
This PR resolves #316.

Few additional notes on the changes:
* `_journal_index.id` was left unchanged for now and a separate issue was filed to address it (#345).
* `_journal_index.id` was left unchanged for now and a separate issue was filed to address it (#346).
* `_citation.book_id_isbn` was assigned the `Code` content type since ISBN consist only of digits and dashes thus case-sensitivity is not an issue.
* `_chemical.identifier_inchi` and `_chemical.identifier_inchi_key` were assigned the `Word` content type since spaces are not allowed in these identifiers and case-sensitivity may be important (the previously assigned content type was `Text` which is also case-sensitive).