### PR TITLE
Update URL of the Open Funder Registry repository.

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-01-29
+    _dictionary.date              2023-02-02
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -15509,13 +15509,13 @@ save_
 save_audit_support.funding_organization
 
     _definition.id                '_audit_support.funding_organization'
-    _definition.update            2023-01-13
+    _definition.update            2023-02-02
     _description.text
 ;
     The name of the organization providing funding support for
     the data collected and analysed in the data block. The
-    recommended source for such names is the Open Funder
-    Registry (https://github.com/CrossRef/open-funder-registry)
+    recommended source for such names is the Open Funder Registry
+    (https://gitlab.com/crossref/open_funder_registry).
 ;
     _name.category_id             audit_support
     _name.object_id               funding_organization
@@ -26940,7 +26940,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-01-29
+         3.2.0                    2023-02-02
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -26986,4 +26986,6 @@ save_
        disorder.
 
        Added the _citation.URL and _journal.paper_URL data items.
+
+       Updated URL of the Open Funder Registry repository.
 ;


### PR DESCRIPTION
The Open Funder Registry repository seems to have been moved from GitHub to GitLab. The GitHub repository is still available, however, it is archived and is no longer maintained.