### PR TITLE
Remove outdated dREL and update the content type in several definitions

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -16186,23 +16186,6 @@ save_citation_author.citation_id
 
 save_
 
-save_citation_author.key
-
-    _definition.id                '_citation_author.key'
-    _definition.update            2023-02-03
-    _description.text
-;
-    Value is a unique key to a set of CITATION_AUTHOR items in a looped list.
-;
-    _name.category_id             citation_author
-    _name.object_id               key
-    _type.purpose                 Key
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_citation_author.name
 
     _definition.id                '_citation_author.name'
@@ -16291,23 +16274,6 @@ save_citation_editor.citation_id
     _name.object_id               citation_id
     _name.linked_item_id          '_citation.id'
     _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_citation_editor.id
-
-    _definition.id                '_citation_editor.id'
-    _definition.update            2023-02-03
-    _description.text
-;
-    Value is a unique key to a set of CITATION_EDITOR items in a looped list.
-;
-    _name.category_id             citation_editor
-    _name.object_id               id
-    _type.purpose                 Key
     _type.source                  Related
     _type.container               Single
     _type.contents                Word

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-02-02
+    _dictionary.date              2023-02-03
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -11663,18 +11663,17 @@ save_
 save_space_group_generator.key
 
     _definition.id                '_space_group_generator.key'
-    _definition.update            2016-05-10
+    _definition.update            2023-02-03
     _description.text
 ;
-    Arbitrary identifier for each entry in the _space_group_generator.xyz
-    list.
+    Arbitrary identifier for each entry in the _space_group_generator.xyz list.
 ;
     _name.category_id             space_group_generator
     _name.object_id               key
     _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Word
 
 save_
 
@@ -16190,24 +16189,17 @@ save_
 save_citation_author.key
 
     _definition.id                '_citation_author.key'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-03
     _description.text
 ;
-    Value is a unique key to a set of CITATION_AUTHOR items
-    in a looped list.
+    Value is a unique key to a set of CITATION_AUTHOR items in a looped list.
 ;
     _name.category_id             citation_author
     _name.object_id               key
     _type.purpose                 Key
     _type.source                  Related
     _type.container               Single
-    _type.contents                Implied
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _citation_author.key =
-    [_citation_author.citation_id,_citation_author.ordinal]
-;
+    _type.contents                Word
 
 save_
 
@@ -16308,24 +16300,17 @@ save_
 save_citation_editor.id
 
     _definition.id                '_citation_editor.id'
-    _definition.update            2021-06-29
+    _definition.update            2023-02-03
     _description.text
 ;
-    Value is a unique key to a set of CITATION_EDITOR items
-    in a looped list.
+    Value is a unique key to a set of CITATION_EDITOR items in a looped list.
 ;
     _name.category_id             citation_editor
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Related
     _type.container               Single
-    _type.contents                Implied
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _citation_editor.id =
-    [_citation_editor.citation_id,_citation_editor.ordinal]
-;
+    _type.contents                Word
 
 save_
 
@@ -26992,7 +26977,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-02-02
+         3.2.0                    2023-02-03
 ;
        Added data names to allow multi-data-block expression of data sets.
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -27000,4 +27000,6 @@ save_
        Changed the scheme part in multiple URLs from 'http' to 'https'.
 
        Added the _journal.paper_number and _journal.paper_pages data items.
+
+       Removed the _citation_author.key and _citation_editor.id data items.
 ;


### PR DESCRIPTION
Resolves #346.

This PR removes the outdated dREL from `_citation_author.key` and `_citation_editor.id`.

Note, that these items are still not explicitly specified as category keys in the definitions of  corresponding categories, but this should be addressed in a separate PR if needed. 