### PR TITLE
Add disorder example from ddl1

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-02-02
+    _dictionary.date              2023-02-03
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -20198,7 +20198,7 @@ save_ATOM_SITE
     _definition.id                ATOM_SITE
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2021-06-29
+    _definition.update            2023-02-03
     _description.text
 ;
     The CATEGORY of data items used to describe atom site information
@@ -20207,6 +20207,36 @@ save_ATOM_SITE
     _name.category_id             ATOM
     _name.object_id               ATOM_SITE
     _category_key.name            '_atom_site.label'
+    _description_example.case
+;
+    loop_
+      _atom_site.label
+      _atom_site.occupancy
+      _atom_site.disorder_assembly
+      _atom_site.disorder_group
+        C1     1      .     .
+        H11A   .5     M     1
+        H12A   .5     M     1
+        H13A   .5     M     1
+        H11B   .5     M     2
+        H12B   .5     M     2
+        H13B   .5     M     2
+;
+    _description_example.detail
+;
+    A hypothetical example to a description of positional disorder. Assembly 'M'
+    describes a methyl group with two configurations '1' and '2':
+
+                        H11B    H11A      H13B
+                          .      |      .
+                            .    |    .
+                              .  |  .
+                                 C1 --------C2---
+                               / .  \
+                             /   .    \
+                           /     .      \
+                        H12A    H12B    H13A
+;
 
 save_
 
@@ -26992,7 +27022,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-02-02
+         3.2.0                    2023-02-03
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -27049,4 +27079,6 @@ save_
        Changed the scheme part in multiple URLs from 'http' to 'https'.
 
        Added the _journal.paper_number and _journal.paper_pages data items.
+
+       Added several examples to the ATOM_SITE category.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -20207,35 +20207,64 @@ save_ATOM_SITE
     _name.category_id             ATOM
     _name.object_id               ATOM_SITE
     _category_key.name            '_atom_site.label'
-    _description_example.case
-;
-    loop_
-      _atom_site.label
-      _atom_site.occupancy
-      _atom_site.disorder_assembly
-      _atom_site.disorder_group
-        C1     1      .     .
-        H11A   .5     M     1
-        H12A   .5     M     1
-        H13A   .5     M     1
-        H11B   .5     M     2
-        H12B   .5     M     2
-        H13B   .5     M     2
-;
-    _description_example.detail
-;
-    A hypothetical example to a description of positional disorder. Assembly 'M'
-    describes a methyl group with two configurations '1' and '2':
 
-                        H11B    H11A      H13B
-                          .      |      .
-                            .    |    .
-                              .  |  .
-                                 C1 --------C2---
-                               / .  \
-                             /   .    \
-                           /     .      \
-                        H12A    H12B    H13A
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+       loop_
+         _atom_site.label
+         _atom_site.occupancy
+         _atom_site.disorder_assembly
+         _atom_site.disorder_group
+          C1     1      .     .
+          H11A   .5     M     1
+          H12A   .5     M     1
+          H13A   .5     M     1
+          H11B   .5     M     2
+          H12B   .5     M     2
+          H13B   .5     M     2
+;
+;
+       A hypothetical example of a positional disorder description. Disorder
+       assembly 'M' describes a methyl group with two alternative configurations
+       '1' and '2':
+
+                          H11B    H11A      H13B
+                            .      |      .
+                              .    |    .
+                                .  |  .
+                                   C1 --------C2---
+                                 / .  \
+                               /   .    \
+                             /     .      \
+                          H12A    H12B    H13A
+;
+;
+       loop_
+         _atom_site.label
+         _atom_site.type_symbol
+         _atom_site.fract_x
+         _atom_site.fract_y
+         _atom_site.fract_z
+         _atom_site.occupancy
+         _atom_site.disorder_assembly
+         _atom_site.disorder_group
+          Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
+          Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
+          Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
+          O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
+          O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
+          # ...
+;
+;
+       An example of a compositional disorder description. Disorder assembly 'A'
+       describes a site that is simultaneously occupied by Co and Mn atoms which
+       are assigned to disorder group '1' and disorder group '2' respectively.
+
+       The example was created based on data from:
+           Li, Ang et al. Dalton Transactions, 2021, 50(2), 681-688.
+           https://doi.org/10.1039/d0dt03269g
 ;
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -20263,7 +20263,7 @@ save_ATOM_SITE
        are assigned to disorder group '1' and disorder group '2' respectively.
 
        The example was created based on data from:
-           Li, Ang et al. Dalton Transactions, 2021, 50(2), 681-688.
+           Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
            https://doi.org/10.1039/d0dt03269g
 ;
 

--- a/examples/complex-compositional-disorder.cif
+++ b/examples/complex-compositional-disorder.cif
@@ -1,6 +1,6 @@
 ##
-# The example file showcases the use of the _atom_site_disorder_assembly and
-# _atom_site_disorder_group data items to describe complex positional disorder.
+# The example file showcases the use of the _atom_site.disorder_assembly and
+# _atom_site.disorder_group data items to describe complex positional disorder.
 # Disorder assembly "A" has two groups which describe two different molecular
 # entities that consist of multiple atoms (group "1" -- ClO4, group 2 -- NO3).
 #

--- a/examples/simple-compositional-disorder.cif
+++ b/examples/simple-compositional-disorder.cif
@@ -1,6 +1,6 @@
 ##
-# The example file showcases the use of the _atom_site_disorder_assembly and
-# _atom_site_disorder_group data items to describe positional disorder.
+# The example file showcases the use of the _atom_site.disorder_assembly and
+# _atom_site.disorder_group data items to describe positional disorder.
 # Disorder assembly "A" has two groups which describe two different atoms
 # (group "1" -- Co, group 2 -- Mn).
 #


### PR DESCRIPTION
This PR adapts the positional disorder description example which was originally provided in DDL1 version of the dictionary as discussed in issue #251.

I also added a new example of a compositional disorder description based on the `simple-compositional-disorder.cif` example file.