### PR TITLE
Add database related relation other state

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -16940,6 +16940,31 @@ save_DATABASE_RELATED
     _name.category_id             PUBLICATION
     _name.object_id               DATABASE_RELATED
     _category_key.name            '_database_related.id'
+    _description_example.case
+;
+    loop_
+      _database_related.id
+      _database_related.database_id
+      _database_related.entry_code
+      _database_related.relation
+      _database_related.special_details
+       1 CAS 58-55-9  Other     'Describes the same compound.'
+       2 COD 2006182  Identical .
+       3 CSD BAPLOT01 Identical .
+;
+    _description_example.detail
+;
+    The loop relates a specific instance of a theophylline crystal structure
+    to corresponding entries in the COD and CSD crystallographic databases
+    as well as to the general description of the theophyline compound in the
+    CAS registry.
+
+    This example loop could potentially be added to the CIF file that is
+    provided as supplementary material for the following publication:
+      Ebisuzaki, Y. et al. (1997). Acta Crystallographica, Section C:
+      Crystal Structure Communications, 53(6), 777-779.
+      https://doi.org/10.1107/S0108270197001960
+;
 
 save_
 
@@ -27058,5 +27083,6 @@ save_
        Added the _journal.paper_number and _journal.paper_pages data items.
 
        Added the 'Other' state to the enumeration set of the
-       _database_related.relation data item.
+       _database_related.relation data item. Added a usage example to
+       the DATABASE_RELATED category.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-02-02
+    _dictionary.date              2023-02-03
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -17002,7 +17002,7 @@ save_
 save_database_related.relation
 
     _definition.id                '_database_related.relation'
-    _definition.update            2019-01-08
+    _definition.update            2023-02-03
     _description.text
 ;
     The general relationship of the data in the data block
@@ -17038,6 +17038,13 @@ save_database_related.relation
          Common
 ;
          The dataset contents share a common source.
+;
+         Other
+;
+         The dataset contents are related to the contents of the data block in
+         a way not included elsewhere in this list. In case this value is used,
+         it is strongly recommended to also provide the specifics of the
+         relationship using the _database_related.special_details data item.
 ;
 
 save_
@@ -26992,7 +26999,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-02-02
+         3.2.0                    2023-02-03
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -27049,4 +27056,7 @@ save_
        Changed the scheme part in multiple URLs from 'http' to 'https'.
 
        Added the _journal.paper_number and _journal.paper_pages data items.
+
+       Added the 'Other' state to the enumeration set of the
+       _database_related.relation data item.
 ;


### PR DESCRIPTION
This PR contains the initial attempt at resolving issue #169.

Also, note that this PR adds the 'Other' relation type to accommodate a more flexible linking to databases that do not contain crystallographic data.