### PR TITLE
Provide default values for author identifiers

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -18885,18 +18885,18 @@ save_publ_contact_author.id
 ;
     with pca as publ_contact_author
     count = 0
-    target = 0
+    target = ''
     loop pa as publ_author {
         if (pca.name == pa.name) {
             count++
             target = pa.id
             }
         }
-    if (count == 0 || count > 1) {
-        _enumeration.default = missing
+    if (count == 1) {
+        _enumeration.default = target
         }
     else {
-        _enumeration.default = target
+        _enumeration.default = missing
     }
 ;
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11869,7 +11869,7 @@ save_space_group_symop.id
     _method.purpose               Evaluation
     _method.expression
 ;
-    _space_group_symop.id = Current_Row(space_group_symop) + 1
+    _space_group_symop.id = Current_row(space_group_symop) + 1
 ;
 
 save_
@@ -14981,7 +14981,7 @@ save_audit_author.id
     _method.purpose               Definition
     _method.expression
 ;
-    _enumeration.default = Current_Row(audit_author) + 1
+    _enumeration.default = Unique_id(audit_author.id)
 ;
 
 save_
@@ -18483,7 +18483,7 @@ save_publ_author.id
     _method.purpose               Definition
     _method.expression
 ;
-    _enumeration.default = Current_Row(publ_author) + 1
+    _enumeration.default = Unique_id(publ_author.id)
 ;
 
 save_

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -15355,7 +15355,7 @@ save_audit_contact_author.id
 ;
     with aca as audit_contact_author
     count = 0
-    target = 0
+    target = ''
     loop aa as audit_author {
         if (aca.name == aa.name) {
             count++

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -15350,6 +15350,25 @@ save_audit_contact_author.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    with aca as audit_contact_author
+    count = 0
+    target = 0
+    loop aa as audit_author {
+        if (aca.name == aa.name) {
+            count++
+            target = aa.id
+            }
+        }
+    if (count == 0 || count > 1) {
+        _enumeration.default = missing
+        }
+    else {
+        _enumeration.default = target
+    }
+;
 
 save_
 
@@ -18861,6 +18880,25 @@ save_publ_contact_author.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    with pca as publ_contact_author
+    count = 0
+    target = 0
+    loop pa as publ_author {
+        if (pca.name == pa.name) {
+            count++
+            target = pa.id
+            }
+        }
+    if (count == 0 || count > 1) {
+        _enumeration.default = missing
+        }
+    else {
+        _enumeration.default = target
+    }
+;
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -14978,6 +14978,11 @@ save_audit_author.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = Current_Row(audit_author) + 1
+;
 
 save_
 
@@ -18456,6 +18461,11 @@ save_publ_author.id
     _type.source                  Related
     _type.container               Single
     _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = Current_Row(publ_author) + 1
+;
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -15362,11 +15362,11 @@ save_audit_contact_author.id
             target = aa.id
             }
         }
-    if (count == 0 || count > 1) {
-        _enumeration.default = missing
+    if (count == 1) {
+        _enumeration.default = target
         }
     else {
-        _enumeration.default = target
+        _enumeration.default = missing
     }
 ;
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11869,7 +11869,7 @@ save_space_group_symop.id
     _method.purpose               Evaluation
     _method.expression
 ;
-    _space_group_symop.id = Current_row(space_group_symop) + 1
+    _space_group_symop.id = Current_row(space_group_symop.id) + 1
 ;
 
 save_


### PR DESCRIPTION
Recent changes to the author categories introduced author identifiers, which were key data names. However, legacy data files will not have this data name and thus fail validation. The current changes introduce dREL methods that provide default values. Closes #103 .

Note that the dREL is implemented using a `Definition` method rather than an `Evaluation` method, as the `Evaluation` method would imply a single correct value, and validation would therefore fail if the file contained any values for the identifiers that were not the row numbers. `Evaluation` methods were appropriate for `_space_group_symop.id` because legacy CIFs used the `space_group_symop` category row number to refer to symops.

The `Definition` method creates a new value for the default value for each row. This is an original use of `Definition` methods, which up until now have been used in `Set` categories only, that is, `_enumeration.default` might be interpreted as creating a category-wide default. Now that `Set` categories are simply seen as `Loop` categories that have been split over several data blocks, there is no fundamental difference between a per-row default and a per-Set-category-row default. But please think if there is any reason not to allow this behaviour. 