### PR TITLE
Add ability to record an arbitrary number of form-factor coefficients

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-04-04
+    _dictionary.date              2023-04-09
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -27440,7 +27440,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-04-04
+         3.2.0                    2023-04-09
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -27514,4 +27514,8 @@ save_
 
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
+
+       Added _atom_type_scat.exponential_polynomial_coefs, Gaussian_coefs, and
+       inv_Mott-Bethe_coefs to allow for an arbitrary number of coefficients in
+       the definition of form factors.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24801,13 +24801,13 @@ save_atom_type_scat.hi_ang_fox_coeffs
 
 save_
 
-save_atom_type_scat.inv_Mott-Bethe_coefs
+save_atom_type_scat.inv_Mott_Bethe_coefs
 
-    _definition.id                '_atom_type_scat.inv_Mott-Bethe_coefs'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
     _definition.update            2023-04-09
     _description.text
 ;
-    The set of Gaussian coefficients for use in the inverse Mott-Bethe
+    The set of Gaussian coefficients for use in the inverse Mott_Bethe
     relationship for generating X-ray scattering factors:
     [ c_1, d_1, c_2, d_2, ... , c_N, d_N, e ].
 
@@ -24818,7 +24818,7 @@ save_atom_type_scat.inv_Mott-Bethe_coefs
     number.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott-Bethe_coefs
+    _name.object_id               inv_Mott_Bethe_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               Matrix
@@ -24828,17 +24828,17 @@ save_atom_type_scat.inv_Mott-Bethe_coefs
 
 save_
 
-save_atom_type_scat.inv_Mott-Bethe_coefs_su
+save_atom_type_scat.inv_Mott_Bethe_coefs_su
 
-    _definition.id                '_atom_type_scat.inv_Mott-Bethe_coefs_su'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs_su'
     _definition.update            2023-04-09
     _description.text
 ;
-    Standard uncertainty of _atom_type_scat.inv_Mott-Bethe_coefs.
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_coefs.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott-Bethe_coefs_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott-Bethe_coefs'
+    _name.object_id               inv_Mott_Bethe_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
     _type.purpose                 SU
     _type.source                  Derived
     _type.container               Matrix
@@ -24847,19 +24847,19 @@ save_atom_type_scat.inv_Mott-Bethe_coefs_su
 
 save_
 
-save_atom_type_scat.inv_Mott-Bethe_lower_limit
+save_atom_type_scat.inv_Mott_Bethe_lower_limit
 
-    _definition.id                '_atom_type_scat.inv_Mott-Bethe_lower_limit'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'
     _definition.update            2023-04-09
     _description.text
 ;
     The inclusive lower limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.inv_Mott-Bethe_coefs.
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott-Bethe_lower_limit
+    _name.object_id               inv_Mott_Bethe_lower_limit
     _type.purpose                 Number
     _type.source                  Derived
     _type.container               Single
@@ -24868,19 +24868,19 @@ save_atom_type_scat.inv_Mott-Bethe_lower_limit
 
 save_
 
-save_atom_type_scat.inv_Mott-Bethe_upper_limit
+save_atom_type_scat.inv_Mott_Bethe_upper_limit
 
-    _definition.id                '_atom_type_scat.inv_Mott-Bethe_upper_limit'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_upper_limit'
     _definition.update            2023-04-09
     _description.text
 ;
     The exclusive upper limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.inv_Mott-Bethe_coefs.
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott-Bethe_upper_limit
+    _name.object_id               inv_Mott_Bethe_upper_limit
     _type.purpose                 Number
     _type.source                  Derived
     _type.container               Single
@@ -27516,6 +27516,6 @@ save_
        from 'Encode' to 'Key'.
 
        Added _atom_type_scat.exponential_polynomial_coefs, Gaussian_coefs, and
-       inv_Mott-Bethe_coefs to allow for an arbitrary number of coefficients in
+       inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
        the definition of form factors.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24637,7 +24637,7 @@ save_atom_type_scat.Gaussian_coefs
     _description.text
 ;
     The set of Gaussian coefficients for generating X-ray scattering factors:
-    [ a_1, b_1, a_2, b_2, ... , a_N, b_N, c ].
+    [ c, a_1, b_1, a_2, b_2, ... , a_N, b_N ].
 
     f(s; Z) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:N)
 
@@ -24809,7 +24809,7 @@ save_atom_type_scat.inv_Mott_Bethe_coefs
 ;
     The set of Gaussian coefficients for use in the inverse Mott_Bethe
     relationship for generating X-ray scattering factors:
-    [ c_1, d_1, c_2, d_2, ... , c_N, d_N, e ].
+    [ e, c_1, d_1, c_2, d_2, ... , c_N, d_N ].
 
     f(s; Z) =
     Z - 8 * Pi * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24542,6 +24542,179 @@ save_atom_type_scat.dispersion_source
 
 save_
 
+save_atom_type_scat.exponential_polynomial_coefs
+
+    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The set of polynomial coefficients for generating X-ray scattering factors:
+    [ a_0, a_1, ... , a_N ].
+
+    f(s; Z) = exp(Sum( a~i~ * s^i^), i=0:N))
+
+    where s = sin(theta)/lambda.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.exponential_polynomial_coefs_su
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_coefs_su'
+    _definition.update            2023-04-09
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs_su
+    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.exponential_polynomial_lower_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.exponential_polynomial_upper_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.Gaussian_coefs
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The set of Gaussian coefficients for generating X-ray scattering factors:
+    [ a_1, b_1, a_2, b_2, ... , a_N, b_N, c ].
+
+    f(s; Z) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:N)
+
+    where s = sin(theta)/lambda.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.Gaussian_coefs_su
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs_su'
+    _definition.update            2023-04-09
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.Gaussian_lower_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.Gaussian_upper_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
 save_atom_type_scat.hi_ang_fox_c0
 
     _definition.id                '_atom_type_scat.hi_ang_Fox_c0'
@@ -24625,6 +24798,94 @@ save_atom_type_scat.hi_ang_fox_coeffs
     _atom_type_scat.hi_ang_Fox_coeffs  =
     [t.hi_ang_Fox_c0,t.hi_ang_Fox_c1,t.hi_ang_Fox_c2,t.hi_ang_Fox_c3]
 ;
+
+save_
+
+save_atom_type_scat.inv_Mott-Bethe_coefs
+
+    _definition.id                '_atom_type_scat.inv_Mott-Bethe_coefs'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The set of Gaussian coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ c_1, d_1, c_2, d_2, ... , c_N, d_N, e ].
+
+    f(s; Z) =
+    Z - 8 * Pi * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))
+
+    where s = sin(theta)/lambda, a~0~ is the Bohr radius, and Z is the atomic
+    number.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott-Bethe_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.inv_Mott-Bethe_coefs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott-Bethe_coefs_su'
+    _definition.update            2023-04-09
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott-Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott-Bethe_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott-Bethe_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.inv_Mott-Bethe_lower_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott-Bethe_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott-Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott-Bethe_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.inv_Mott-Bethe_upper_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott-Bethe_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott-Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott-Bethe_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.2.0
-    _dictionary.date              2023-03-02
+    _dictionary.date              2023-04-04
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -3390,15 +3390,15 @@ save_diffrn_radiation_wavelength.id
          '_diffrn_radiation_wavelength_id'
          '_diffrn_radiation.wavelength_id'
 
-    _definition.update            2021-10-27
+    _definition.update            2023-04-04
     _description.text
 ;
-    Code identifying a radiation used in the diffraction measurements.
+    Code identifying the radiation used in the diffraction measurements.
     This is linked to _diffrn_refln.wavelength_id and _refln.wavelength_id
 ;
     _name.category_id             diffrn_radiation_wavelength
     _name.object_id               id
-    _type.purpose                 Encode
+    _type.purpose                 Key
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
@@ -27179,7 +27179,7 @@ save_
        Changed the content type of the _journal.paper_doi data item from
        'Code' to 'Text' and added an example case.
 ;
-         3.2.0                    2023-03-02
+         3.2.0                    2023-04-04
 ;
        Added data names to allow multi-data-block expression of data sets.
 
@@ -27250,4 +27250,7 @@ save_
        Reparented CELL to DIFFRN category and added key data names to allow
        multiple cells for different diffraction conditions. Deprecated
        _cell_measurement.temperature,pressure data names.
+
+       Changed the purpose of the _diffrn_radiation_wavelength.id data item
+       from 'Encode' to 'Key'.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24559,7 +24559,7 @@ save_atom_type_scat.exponential_polynomial_coefs
     _name.object_id               exponential_polynomial_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -24580,7 +24580,7 @@ save_atom_type_scat.exponential_polynomial_coefs_su
     _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.contents                Real
     _units.code                   none
 
@@ -24647,7 +24647,7 @@ save_atom_type_scat.Gaussian_coefs
     _name.object_id               Gaussian_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -24667,7 +24667,7 @@ save_atom_type_scat.Gaussian_coefs_su
     _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.contents                Real
     _units.code                   none
 
@@ -24821,7 +24821,7 @@ save_atom_type_scat.inv_Mott_Bethe_coefs
     _name.object_id               inv_Mott_Bethe_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
     _units.code                   none
@@ -24841,7 +24841,7 @@ save_atom_type_scat.inv_Mott_Bethe_coefs_su
     _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
     _type.purpose                 SU
     _type.source                  Derived
-    _type.container               Matrix
+    _type.container               List
     _type.contents                Real
     _units.code                   none
 


### PR DESCRIPTION
Will close #357, eventually.

I've added the ability to record an arbitrary number of coefficients for the conventional sum-of-Gaussians (a la Cromer-Mann and Wassimier-Kirfel), and the exponential polynomial model (cf Fox), as well as an inverse Mott-Bethe relationship parameterised as a sum of Gaussians.

Each of the models also has an upper/lower limit, so that an element can have multiple models associated with it for different s ranges.

If this looks OK, I'll have a go at looking at 
>The tables in `templ_enum.cif` would then have a list of numbers for each atom type and we would change the dREL for `_refln.form_factor_table` to access `_atom_type_scat.Gaussian_coeff`. 