### PR TITLE
_atom_type.display_colour typo fix

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -23885,7 +23885,7 @@ save_atom_type.display_colour
     _enumeration.def_index_id     '_atom_type.symbol'
 
     _import.get                   [
-                                   {'file':templ_enum.cif  'save':colour_rgb}
+                                   {'file':templ_enum.cif  'save':colour_RGB}
                                    {'file':templ_enum.cif  'save':colour_hue}
                                   ]
 


### PR DESCRIPTION
Changed `colour_rgb` to `colour_RGB`.

Everything else uses uppercase RGB.