### PR TITLE
Format `templ_attr.cif`

### DIFF
--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -26,23 +26,21 @@ save_atom_site_label
     _definition.update            2021-10-25
     _description.text
 ;
-     This label is a unique identifier for a particular site in the
-     asymmetric unit of the crystal unit cell. It is made up of
-     components, _atom_site.label_component_0 to *_6, which may be
-     specified as separate data items. Component 0 usually matches one
-     of the specified _atom_type.symbol codes. This is not mandatory
-     if an _atom_site.type_symbol item is included in the atom site
-     list. The _atom_site.type_symbol always takes precedence over
-     an _atom_site.label in the identification of the atom type. The
-     label components 1 to 6 are optional, and normally only
-     components 0 and 1 are used. Note that components 0 and 1 are
-     concatenated, while all other components, if specified, are
-     separated by an underline character. Underline separators are
-     only used if higher-order components exist. If an intermediate
-     component is not used it may be omitted provided the underline
-     separators are inserted. For example the label 'C233__ggg' is
-     acceptable and represents the components C, 233, '', and ggg.
-     Each label may have a different number of components.
+     This label is a unique identifier for a particular site in the asymmetric
+     unit of the crystal unit cell. It is made up of components,
+     _atom_site.label_component_0 to *_6, which may be specified as separate
+     data items. Component 0 usually matches one of the specified
+     _atom_type.symbol codes. This is not mandatory if an _atom_site.type_symbol
+     item is included in the atom site list. The _atom_site.type_symbol always
+     takes precedence over an _atom_site.label in the identification of the atom
+     type. The label components 1 to 6 are optional, and normally only
+     components 0 and 1 are used. Note that components 0 and 1 are concatenated,
+     while all other components, if specified, are separated by an underline
+     character. Underline separators are only used if higher-order components
+     exist. If an intermediate component is not used it may be omitted provided
+     the underline separators are inserted. For example the label 'C233__ggg' is
+     acceptable and represents the components C, 233, '', and ggg. Each label
+     may have a different number of components.
 ;
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -81,8 +79,8 @@ save_atom_site_id
     _definition.update            2021-10-25
     _description.text
 ;
-     This label is a unique identifier for a particular site in the
-     asymmetric unit of the crystal unit cell.
+     This label is a unique identifier for a particular site in the asymmetric
+     unit of the crystal unit cell.
 ;
     _name.linked_item_id          '_atom_site.label'
     _type.purpose                 Link
@@ -97,8 +95,8 @@ save_rho_coeff
     _definition.update            2021-03-01
     _description.text
 ;
-     Specifies a multipole population coefficients P(l,m) for
-     the atom identified in atom_rho_multipole.atom_label.
+     Specifies a multipole population coefficients P(l,m) for the atom
+     identified in atom_rho_multipole.atom_label.
 ;
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -131,10 +129,10 @@ save_rho_slater
     _definition.update            2023-01-13
     _description.text
 ;
-      Items used when the radial dependence of the valence
-      electron density, R(kappa'(l),l,r), of the atom specified in
-      atom_rho_multipole.atom_label is expressed as a Slater-type
-      function [Hansen & Coppens (1978), equation (3)]
+      Items used when the radial dependence of the valence electron density,
+      R(kappa'(l),l,r), of the atom specified in _atom_rho_multipole.atom_label
+      is expressed as a Slater-type function; see
+      [Hansen & Coppens (1978), equation (3)]
 ;
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -180,8 +178,8 @@ save_ms_index
     _definition.update            2014-06-27
     _description.text
 ;
-     Additional Miller indices needed to write the reciprocal vector
-     in the definition of _diffrn_refln_index.m_list,
+     Additional Miller indices needed to write the reciprocal vector in the
+     definition of _diffrn_refln_index.m_list,
      _diffrn_standard_refln.index_m_list, _exptl_crystal_face.index_m_list.
 ;
     _type.purpose                 Number
@@ -331,9 +329,9 @@ save_cartn_coord
     _definition.update            2012-05-07
     _description.text
 ;
-     The atom site coordinates in angstroms specified according to a
-     set of orthogonal Cartesian axes related to the cell axes as
-     specified by the _atom_sites_Cartn_transform.axes description.
+     The atom site coordinates in angstroms specified according to a set of
+     orthogonal Cartesian axes related to the cell axes as specified by the
+     _atom_sites_Cartn_transform.axes description.
 ;
     _type.purpose                 Measurand
     _type.source                  Derived
@@ -348,10 +346,9 @@ save_cartn_coord_su
     _definition.update            2014-06-08
     _description.text
 ;
-     Standard uncertainty values of the atom site coordinates
-     in angstroms specified according to a
-     set of orthogonal Cartesian axes related to the cell axes as
-     specified by the _atom_sites_Cartn_transform.axes description.
+     Standard uncertainty values of the atom site coordinates, in angstroms,
+     specified according to a set of orthogonal Cartesian axes related to the
+     cell axes as specified by the _atom_sites_Cartn_transform.axes description.
 ;
     _type.purpose                 SU
     _type.source                  Derived
@@ -381,8 +378,8 @@ save_fract_coord_su
     _definition.update            2014-06-08
     _description.text
 ;
-     Standard uncertainty value of the atom site coordinates
-     as fractions of the cell length values.
+     Standard uncertainty value of the atom site coordinates as fractions of the
+     cell length values.
 ;
     _type.purpose                 SU
     _type.source                  Derived
@@ -397,20 +394,20 @@ save_label_component
     _definition.update            2021-10-21
     _description.text
 ;
-     Component_0 is normally a code which matches identically with
-     one of the _atom_type.symbol codes. If this is the case then the
-     rules governing the _atom_type.symbol code apply. If, however,
-     the data item _atom_site.type_symbol is also specified in the
-     atom site list, component 0 need not match this symbol or adhere
-     to any of the _atom_type.symbol rules.
-     Component_1 is referred to as the "atom number". When component 0
-     is the atom type code, it is used to number the sites with the
-     same atom type. This component code must start with at least one
-     digit which is not followed by a + or - sign (to distinguish it
-     from the component 0 rules).
-     Components_2 to 6 contain the identifier, residue, sequence,
-     asymmetry identifier and alternate codes, respectively. These
-     codes may be composed of any characters except an underline.
+     Component_0 is normally a code which matches identically with one of the
+     _atom_type.symbol codes. If this is the case then the rules governing the
+     _atom_type.symbol code apply. If, however, the data item
+     _atom_site.type_symbol is also specified in the atom site list, component 0
+     need not match this symbol or adhere to any of the _atom_type.symbol rules.
+
+     Component_1 is referred to as the "atom number". When component 0 is the
+     atom type code, it is used to number the sites with the same atom type.
+     This component code must start with at least one digit which is not
+     followed by a + or - sign (to distinguish it from the component 0 rules).
+
+     Components_2 to 6 contain the identifier, residue, sequence, asymmetry
+     identifier and alternate codes, respectively. These codes may be composed
+     of any characters except an underline.
 ;
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -482,8 +479,8 @@ save_ncs_matrix_ij
     _definition.update            2021-03-01
     _description.text
 ;
-     The [I][J] element of the 3x3 matrix component of a
-     non-crystallographic symmetry operation.
+     The [I][J] element of the 3x3 matrix component of a non-crystallographic
+     symmetry operation.
 ;
     _type.purpose                 Number
     _type.source                  Derived
@@ -596,8 +593,8 @@ save_aniso_bij2
     _definition.update            2014-06-12
     _description.text
 ;
-     The [I][J] tdf elements define the overall anisotropic
-     displacement model if one was refined for this structure.
+     The [I][J] tdf elements define the overall anisotropic displacement model
+     if one was refined for this structure.
 ;
     _type.purpose                 Number
     _type.source                  Derived
@@ -612,10 +609,10 @@ save_aniso_bij_su
     _definition.update            2021-03-18
     _description.text
 ;
-     These are the standard uncertainty values (SU) for the standard
-     form of the B^ij^ anisotropic atomic displacement components (see
-     aniso_BIJ). Because these values are TYPE measurand, the su values
-     may in practice be auto generated as part of the B^ij^ calculation.
+     These are the standard uncertainty values (SU) for the standard form of the
+     B^ij^ anisotropic atomic displacement components (see aniso_bij). Because
+     these values are TYPE measurand, the su values may in practice be auto
+     generated as part of the B^ij^ calculation.
 ;
     _type.purpose                 SU
     _type.source                  Derived
@@ -639,8 +636,8 @@ save_aniso_betaij
 
      The unique elements of the real symmetric matrix are entered by row.
 
-     The IUCr Commission on Nomenclature recommends against the use
-     of \b for reporting atomic displacement parameters; U is preferred [1].
+     The IUCr Commission on Nomenclature recommends against the use of \b for
+     reporting atomic displacement parameters; U is preferred [1].
 
      Note that U^ij^ = \b^ij^/(2 pi^2^ a*~i~ a*~j~) = B^ij^/(8 pi^2^) [1].
 
@@ -659,10 +656,10 @@ save_aniso_betaij_su
     _definition.update            2023-02-15
     _description.text
 ;
-     These are the standard uncertainty values (SU) for the standard
-     form of the \b^ij^ anisotropic atomic displacement components (see
-     aniso_betaIJ). Because these values are TYPE measurand, the su values
-     may in practice be auto generated as part of the \b^ij^ calculation.
+     These are the standard uncertainty values (SU) for the standard form of the
+     \b^ij^ anisotropic atomic displacement components (see aniso_betaij).
+     Because these values are TYPE measurand, the su values may in practice be
+     auto generated as part of the \b^ij^ calculation.
 ;
     _type.purpose                 SU
     _type.source                  Derived
@@ -707,10 +704,10 @@ save_aniso_uij_su
     _definition.update             2021-03-18
     _description.text
 ;
-     These are the standard uncertainty values (SU) for the standard
-     form of the U^ij^ anisotropic atomic displacement components (see
-     aniso_UIJ). Because these values are TYPE measurand, the su values
-     may in practice be auto generated as part of the U^ij^ calculation.
+     These are the standard uncertainty values (SU) for the standard form of the
+     U^ij^ anisotropic atomic displacement components (see aniso_uij). Because
+     these values are TYPE measurand, the su values may in practice be auto
+     generated as part of the U^ij^ calculation.
 ;
     _type.purpose                 SU
     _type.source                  Derived
@@ -734,8 +731,8 @@ save_cromer_mann_coeff
     _definition.update            2012-11-29
     _description.text
 ;
-     The set of data items used to define Cromer-Mann coefficients
-     for generation of X-ray scattering factors.
+     The set of data items used to define Cromer-Mann coefficients for
+     generation of X-ray scattering factors.
 
         Ref: International Tables for X-ray Crystallography, Vol. IV
              (1974) Table 2.2B
@@ -756,8 +753,8 @@ save_hi_ang_fox_coeffs
     _definition.update            2012-11-29
     _description.text
 ;
-    The set of data items used to define Fox et al.  coefficients
-     for generation of high angle (s >2.0) X-ray scattering factors.
+    The set of data items used to define Fox et al. coefficients for generation
+    of high angle (s > 2.0) X-ray scattering factors.
 
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5
@@ -791,8 +788,8 @@ save_orient_matrix
     _definition.update            2012-05-07
     _description.text
 ;
-     The set of data items which specify the elements of the matrix of
-     the orientation of the crystal axes to the diffractometer goniometer.
+     The set of data items which specify the elements of the matrix of the
+     orientation of the crystal axes to the diffractometer goniometer.
 ;
     _type.purpose                 Number
     _type.source                  Recorded
@@ -807,9 +804,8 @@ save_transf_matrix
     _definition.update            2012-05-07
     _description.text
 ;
-     The set of data items which specify the elements of the matrix
-     used to transform the reflection indices _diffrn_refln.hkl
-     into _refln.hkl.
+     The set of data items which specify the elements of the matrix used to
+     transform the reflection indices _diffrn_refln.hkl into _refln.hkl.
 ;
     _type.purpose                 Number
     _type.source                  Recorded
@@ -824,9 +820,9 @@ save_face_angle
     _definition.update            2013-04-15
     _description.text
 ;
-    Diffractometer angle setting when the perpendicular to the specified
-    crystal face is aligned along a specified direction (e.g. the
-    bisector of the incident and reflected beams in an optical goniometer.
+    Diffractometer angle setting when the perpendicular to the specified crystal
+    face is aligned along a specified direction (e.g. the bisector of the
+    incident and reflected beams in an optical goniometer.
 ;
     _type.purpose                 Measurand
     _type.source                  Recorded
@@ -877,9 +873,8 @@ save_display_colour
     _definition.update            2019-01-09
     _description.text
 ;
-     Integer value between 0 and 255 giving the intensity of a
-     specific colour component (red, green or blue) for the RGB
-     display colour code.
+     Integer value between 0 and 255 giving the intensity of a specific colour
+     component (red, green or blue) for the RGB display colour code.
 ;
     _type.purpose                 Number
     _type.source                  Recorded

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -7,12 +7,12 @@
 
 data_TEMPL_ATTR
 
-    _dictionary.title            TEMPL_ATTR
-    _dictionary.class            Template
-    _dictionary.version          1.4.10
-    _dictionary.date             2023-01-13
-    _dictionary.uri              www.iucr.org/cif/dic/com_att.dic
-    _dictionary.ddl_conformance  4.1.0
+    _dictionary.title             TEMPL_ATTR
+    _dictionary.class             Template
+    _dictionary.version           1.4.10
+    _dictionary.date              2023-02-16
+    _dictionary.uri               www.iucr.org/cif/dic/com_att.dic
+    _dictionary.ddl_conformance   4.1.0
     _description.text
 ;
      This dictionary contains definition attribute sets that are common
@@ -23,7 +23,7 @@ data_TEMPL_ATTR
 
 save_atom_site_label
 
-    _definition.update           2021-10-25
+    _definition.update            2021-10-25
     _description.text
 ;
      This label is a unique identifier for a particular site in the
@@ -44,66 +44,73 @@ save_atom_site_label
      acceptable and represents the components C, 233, '', and ggg.
      Each label may have a different number of components.
 ;
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Word
-     loop_
-    _description_example.case   C12     Ca3g28     Fe3+17     H*251
-                                C_a_phe_83_a_0  Zn_Zn_301_A_0
-     save_
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         C12
+         Ca3g28
+         Fe3+17
+         H*251
+         C_a_phe_83_a_0
+         Zn_Zn_301_A_0
+
+save_
 
 save_restr_label
 
-    _definition.update           2021-10-25
+    _definition.update            2021-10-25
     _description.text
 ;
       Labels of atom sites subtending distance or angle. Atom 2 is the apex for
       angular restraints.
 ;
-    _name.linked_item_id       '_atom_site.label'
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Word
-     save_
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
+save_
 
 save_atom_site_id
 
-    _definition.update           2021-10-25
+    _definition.update            2021-10-25
     _description.text
 ;
      This label is a unique identifier for a particular site in the
      asymmetric unit of the crystal unit cell.
 ;
-    _name.linked_item_id       '_atom_site.label'
-    _type.purpose                Link
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Word
-     save_
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
+save_
 
 save_rho_coeff
 
-    _definition.update           2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      Specifies a multipole population coefficients P(l,m) for
      the atom identified in atom_rho_multipole.atom_label.
 ;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_rho_kappa
 
-    _definition.update           2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
       A radial function expansion-contraction coefficient
@@ -111,17 +118,17 @@ save_rho_kappa
       kappa'(l) = atom_rho_multipole_kappa.prime[l])
       for the atom specified in atom_rho_multipole.atom_label.
 ;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_rho_slater
 
-    _definition.update           2023-01-13
+    _definition.update            2023-01-13
     _description.text
 ;
       Items used when the radial dependence of the valence
@@ -129,158 +136,158 @@ save_rho_slater
       atom_rho_multipole.atom_label is expressed as a Slater-type
       function [Hansen & Coppens (1978), equation (3)]
 ;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_matrix_pdb
 
-    _definition.update           2021-03-18
+    _definition.update            2021-03-18
     _description.text
 ;
      Element of the PDB ORIGX matrix or vector.
 ;
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_matrix_w
 
-    _definition.update           2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      Element of the matrix W defined by van Smaalen (1991); (1995)
 ;
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _name.category_id            cell_subsystem
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _name.category_id             cell_subsystem
+    _units.code                   none
 
+save_
 
 save_ms_index
 
-    _definition.update           2014-06-27
+    _definition.update            2014-06-27
     _description.text
 ;
      Additional Miller indices needed to write the reciprocal vector
      in the definition of _diffrn_refln_index.m_list,
      _diffrn_standard_refln.index_m_list, _exptl_crystal_face.index_m_list.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Integer
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
 
+save_
 
 save_index_limit_max
 
-    _definition.update           2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      Maximum value of the additional Miller indices appearing in
      _diffrn_reflns.index_m_* and _reflns.index_m_*.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Integer
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
 
+save_
 
 save_index_limit_min
 
-    _definition.update           2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      Minimum value of the additional Miller indices appearing in
      _diffrn_reflns.index_m_* and _reflns.index_m_*.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Integer
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
 
+save_
 
 save_cell_angle
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      The angle between the bounding cell axes.
 ;
-    _type.purpose                Measurand
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           0.0:180.0
-    _units.code                  degrees
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
 
+save_
 
 save_cell_angle_su
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      Standard uncertainty of the angle between the bounding cell axes.
 ;
-    _type.purpose                SU
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  degrees
-     save_
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   degrees
 
+save_
 
 save_cell_length
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      The length of each cell axis.
 ;
-    _type.purpose                Measurand
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           1.:
-    _units.code                  angstroms
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.:
+    _units.code                   angstroms
 
+save_
 
 save_cell_length_su
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      Standard uncertainty of the length of each cell axis.
 ;
-    _type.purpose                SU
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstroms
-     save_
+    _type.purpose                 SU
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
 
+save_
 
 save_site_symmetry
 
-    _definition.update           2023-01-10
+    _definition.update            2023-01-10
     _description.text
 ;
      Data item specifying the symmetry operation codes applied to the atom
@@ -305,37 +312,40 @@ save_site_symmetry
               q = 5 + y
               r = 5 + z
 ;
-    _type.purpose                Composite
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Symop
-     loop_
-    _description_example.case
-    _description_example.detail '4'     '4th symmetry operation applied.'
-                                '7_645' '7th symm. posn.; +a on x; -b on y.'
-                                 .      'No symmetry or translation to site.'
-     save_
+    _type.purpose                 Composite
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Symop
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         '4'        '4th symmetry operation applied.'
+         '7_645'    '7th symm. posn.; +a on x; -b on y.'
+         .          'No symmetry or translation to site.'
+
+save_
 
 save_cartn_coord
 
-    _definition.update           2012-05-07
+    _definition.update            2012-05-07
     _description.text
 ;
      The atom site coordinates in angstroms specified according to a
      set of orthogonal Cartesian axes related to the cell axes as
      specified by the _atom_sites_Cartn_transform.axes description.
 ;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstroms
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
 
+save_
 
 save_cartn_coord_su
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      Standard uncertainty values of the atom site coordinates
@@ -343,48 +353,48 @@ save_cartn_coord_su
      set of orthogonal Cartesian axes related to the cell axes as
      specified by the _atom_sites_Cartn_transform.axes description.
 ;
-    _type.purpose                SU
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstroms
-     save_
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
 
+save_
 
 save_fract_coord
 
-    _definition.update           2012-05-07
+    _definition.update            2012-05-07
     _description.text
 ;
      Atom site coordinates as fractions of the cell length values.
 ;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_fract_coord_su
 
-    _definition.update           2014-06-08
+    _definition.update            2014-06-08
     _description.text
 ;
      Standard uncertainty value of the atom site coordinates
      as fractions of the cell length values.
 ;
-    _type.purpose                SU
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_label_component
 
-    _definition.update           2021-10-21
+    _definition.update            2021-10-21
     _description.text
 ;
      Component_0 is normally a code which matches identically with
@@ -402,23 +412,24 @@ save_label_component
      asymmetry identifier and alternate codes, respectively. These
      codes may be composed of any characters except an underline.
 ;
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Word
-     save_
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
 
 save_label_comp
 
-    _definition.update           2021-10-21
+    _definition.update            2021-10-21
     _description.text
 ;
      See label_component_0 description.
 ;
-    _type.purpose                Encode
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Word
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -468,23 +479,23 @@ save_
 
 save_ncs_matrix_ij
 
-    _definition.update          2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      The [I][J] element of the 3x3 matrix component of a
      non-crystallographic symmetry operation.
 ;
-    _type.purpose               Number
-    _type.source                Derived
-    _type.container             Single
-    _type.contents              Real
-    _units.code                 none
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
 save_
 
 save_rot_matrix_ij
 
-    _definition.update          2021-03-01
+    _definition.update            2021-03-01
     _description.text
 ;
      The [I][J] element of the matrix used to rotate the subset of the
@@ -497,11 +508,11 @@ save_rot_matrix_ij
      |y'|~reoriented Cartesian~ = |21 22 23| |y|~Cartesian~
      |z'|                         |31 32 33| |z|
 ;
-    _type.purpose               Number
-    _type.source                Derived
-    _type.container             Single
-    _type.contents              Real
-    _units.code                 none
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -551,117 +562,176 @@ save_
 
 save_aniso_bij
 
-    _definition.update           2013-03-08
+    _definition.update            2023-02-16
     _description.text
 ;
-     These are the standard anisotropic atomic displacement components
-     in angstroms squared which appear in the structure factor term:
+     These are the standard anisotropic atomic displacement components, in
+     angstroms squared, which appear in the structure factor term:
 
          T = exp{-1/4 sum~i~ [ sum~j~ (B^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
      a* = the reciprocal-space cell lengths
+
      The unique elements of the real symmetric matrix are entered by row.
 
-     The IUCr Commission on Nomenclature recommends against the use
-     of B for reporting atomic displacement parameters. U, being
-     directly proportional to B, is preferred.
-;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstrom_squared
-     save_
+     The IUCr Commission on Nomenclature recommends against the use of B for
+     reporting atomic displacement parameters. U, being directly proportional
+     to B, is preferred [1].
 
+     Note that U^ij^ = \b^ij^/(2 pi^2^ a*~i~ a*~j~) = B^ij^/(8 pi^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
 
 save_aniso_bij2
 
-    _definition.update          2014-06-12
+    _definition.update            2014-06-12
     _description.text
 ;
      The [I][J] tdf elements define the overall anisotropic
      displacement model if one was refined for this structure.
 ;
-    _type.purpose               Number
-    _type.source                Derived
-    _type.container             Single
-    _type.contents              Real
-    _units.code                 angstrom_squared
-     save_
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
 
+save_
 
 save_aniso_bij_su
 
-    _definition.update           2021-03-18
+    _definition.update            2021-03-18
     _description.text
 ;
      These are the standard uncertainty values (SU) for the standard
-     form of the Bij anisotropic atomic displacement components (see
-     _aniso_BIJ). Because these values are TYPE measurand, the su values
-     may in practice be auto generated as part of the Bij calculation.
+     form of the B^ij^ anisotropic atomic displacement components (see
+     aniso_BIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the B^ij^ calculation.
 ;
-    _type.purpose                SU
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstrom_squared
-     save_
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
 
+save_
+
+save_aniso_betaij
+
+    _definition.update            2023-02-16
+    _description.text
+;
+     These are the standard unitless anisotropic atomic displacement components
+     which appear in the structure factor term:
+
+         T = exp{-1 sum~i~ [ sum~j~ (\b^ij^ h~i~ h~j~) ] }
+
+     h = the Miller indices
+
+     The unique elements of the real symmetric matrix are entered by row.
+
+     The IUCr Commission on Nomenclature recommends against the use
+     of \b for reporting atomic displacement parameters; U is preferred [1].
+
+     Note that U^ij^ = \b^ij^/(2 pi^2^ a*~i~ a*~j~) = B^ij^/(8 pi^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_aniso_betaij_su
+
+    _definition.update            2023-02-15
+    _description.text
+;
+     These are the standard uncertainty values (SU) for the standard
+     form of the \b^ij^ anisotropic atomic displacement components (see
+     aniso_betaIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the \b^ij^ calculation.
+;
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
 
 save_aniso_uij
 
-    _definition.update           2013-03-08
+    _definition.update            2023-02-16
     _description.text
 ;
-     These are the standard anisotropic atomic displacement
-     components in angstroms squared which appear in the
-     structure factor term:
+     These are the standard anisotropic atomic displacement components, in
+     angstroms squared, which appear in the structure factor term:
 
-        T = exp{-2pi^2^ sum~i~ [sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
+        T = exp{-2 pi^2^ sum~i~ [sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
      a* = the reciprocal-space cell lengths
 
      The unique elements of the real symmetric matrix are entered by row.
-;
-    _type.purpose                Measurand
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstrom_squared
-     save_
 
+     The IUCr Commission on Nomenclature recommends the use of U for reporting
+     atomic displacement parameters [1].
+
+     Note that U^ij^ = \b^ij^/(2 pi^2^ a*~i~ a*~j~) = B^ij^/(8 pi^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
 
 save_aniso_uij_su
 
-    _definition.update           2021-03-18
+    _definition.update             2021-03-18
     _description.text
 ;
      These are the standard uncertainty values (SU) for the standard
-     form of the Uij anisotropic atomic displacement components (see
-     _aniso_UIJ). Because these values are TYPE measurand, the su values
-     may in practice be auto generated as part of the Uij calculation.
+     form of the U^ij^ anisotropic atomic displacement components (see
+     aniso_UIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the U^ij^ calculation.
 ;
-    _type.purpose                SU
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  angstrom_squared
-     save_
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
 
 save_general_su
 
-    _type.purpose                SU
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
 
 save_
 
 save_cromer_mann_coeff
 
-    _definition.update           2012-11-29
+    _definition.update            2012-11-29
     _description.text
 ;
      The set of data items used to define Cromer-Mann coefficients
@@ -672,18 +742,18 @@ save_cromer_mann_coeff
         or   International Tables for Crystallography, Vol. C
              (1991) Tables 6.1.1.4 and 6.1.1.5
 ;
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.def_index_id  '_atom_type.symbol'
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.symbol'
+    _units.code                   none
 
+save_
 
 save_hi_ang_fox_coeffs
 
-    _definition.update           2012-11-29
+    _definition.update            2012-11-29
     _description.text
 ;
     The set of data items used to define Fox et al.  coefficients
@@ -692,132 +762,133 @@ save_hi_ang_fox_coeffs
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5
 ;
-    _type.purpose                Number
-    _type.source                 Assigned
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.def_index_id  '_atom_type.symbol'
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.symbol'
+    _units.code                   none
 
+save_
 
 save_miller_index
 
-    _definition.update           2013-04-16
+    _definition.update            2013-04-16
     _description.text
 ;
      The index of a reciprocal space vector.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Integer
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
 
+save_
 
 save_orient_matrix
 
-    _definition.update           2012-05-07
+    _definition.update            2012-05-07
     _description.text
 ;
      The set of data items which specify the elements of the matrix of
      the orientation of the crystal axes to the diffractometer goniometer.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_transf_matrix
 
-    _definition.update           2012-05-07
+    _definition.update            2012-05-07
     _description.text
 ;
      The set of data items which specify the elements of the matrix
      used to transform the reflection indices _diffrn_refln.hkl
      into _refln.hkl.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
 
+save_
 
 save_face_angle
 
-    _definition.update           2013-04-15
+    _definition.update            2013-04-15
     _description.text
 ;
     Diffractometer angle setting when the perpendicular to the specified
     crystal face is aligned along a specified direction (e.g. the
     bisector of the incident and reflected beams in an optical goniometer.
 ;
-    _type.purpose                Measurand
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.:180.
-    _units.code                  degrees
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.:180.
+    _units.code                   degrees
 
+save_
 
 save_orient_angle
 
-    _definition.update           2013-04-15
+    _definition.update            2013-04-15
     _description.text
 ;
      Diffractometer angle of a reflection measured at the centre of the
      diffraction peak and used to determine _diffrn_orient_matrix.UBIJ.
 ;
-    _type.purpose                Measurand
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.:180.
-    _units.code                  degrees
-     save_
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.:180.
+    _units.code                   degrees
 
+save_
 
 save_diffr_angle
 
-    _definition.update           2013-04-15
+    _definition.update            2013-04-15
     _description.text
 ;
      Diffractometer angle at which the intensity is measured. This was
      calculated from the specified  orientation matrix and the original
      measured cell dimensions before any subsequent transformations.
 ;
-    _type.purpose                Number
-    _type.source                 Derived
-    _type.container              Single
-    _type.contents               Real
-    _enumeration.range           -180.:180.
-    _units.code                  degrees
-     save_
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.:180.
+    _units.code                   degrees
 
+save_
 
 save_display_colour
 
-    _definition.update           2019-01-09
+    _definition.update            2019-01-09
     _description.text
 ;
      Integer value between 0 and 255 giving the intensity of a
      specific colour component (red, green or blue) for the RGB
      display colour code.
 ;
-    _type.purpose                Number
-    _type.source                 Recorded
-    _type.container              Single
-    _type.contents               Integer
-    _enumeration.range           0:255
-    _units.code                  none
-     save_
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:255
+    _units.code                   none
+
+save_
 
 #=============================================================================
 #  The dictionary's attribute creation history.
@@ -948,7 +1019,7 @@ save_display_colour
        Changed the data type in the 'diffr_counts' save frame from 'Count' to
        'Integer'.
 ;
-         1.4.10                   2023-01-13
+         1.4.10                   2023-02-15
 ;
        Corrected a few typos in the descriptions of several save frames.
 
@@ -969,4 +1040,7 @@ save_display_colour
        Changed atomic labels to 'Word' for conformance with DDL1.
 
        Updated description of _site_symmetry.
+
+       Added descriptions for aniso_betaIJ, and aniso_betaIJ_su.
+       Updated descriptions of aniso_BIJ and aniso_UIJ
 ;


### PR DESCRIPTION
From #386

I've applied the same (hopefully) formatting requirements for `cif_core.dic` to `templ_attr.cif`, wrt which columns different things should be in.

I've also reformatted the descriptions to go up to the 80 character mark. Not completely sure if this is a good idea or not.