### PR TITLE
Fix scattering factor units

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24751,6 +24751,7 @@ save_atom_type_scat.hi_ang_fox_c0
     _definition.id                '_atom_type_scat.hi_ang_Fox_c0'
     _name.category_id             atom_type_scat
     _name.object_id               hi_ang_Fox_c0
+    _units.code                   none
 
     _import.get
         [
@@ -24765,6 +24766,7 @@ save_atom_type_scat.hi_ang_fox_c1
     _definition.id                '_atom_type_scat.hi_ang_Fox_c1'
     _name.category_id             atom_type_scat
     _name.object_id               hi_ang_Fox_c1
+    _units.code                   angstroms
 
     _import.get
         [
@@ -24779,6 +24781,7 @@ save_atom_type_scat.hi_ang_fox_c2
     _definition.id                '_atom_type_scat.hi_ang_Fox_c2'
     _name.category_id             atom_type_scat
     _name.object_id               hi_ang_Fox_c2
+    _units.code                   angstrom_squared
 
     _import.get
         [
@@ -24793,6 +24796,7 @@ save_atom_type_scat.hi_ang_fox_c3
     _definition.id                '_atom_type_scat.hi_ang_Fox_c3'
     _name.category_id             atom_type_scat
     _name.object_id               hi_ang_Fox_c3
+    _units.code                   angstrom_cubed
 
     _import.get
         [

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-05-22
+    _dictionary.date              2023-06-03
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -27443,7 +27443,7 @@ save_
        inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
        the definition of form factors.
 ;
-         3.3.0                    2023-05-22
+         3.3.0                    2023-06-03
 ;
        # Please update the date above and describe the change below until
        # ready for the next release

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24584,7 +24584,8 @@ save_atom_type_scat.exponential_polynomial_coefs
 
     f(s; Z) = exp(Sum( a~i~ * s^i^), i=0:N))
 
-    where s = sin(theta)/lambda.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda is
+    the wavelength of the incident radiation in angstroms.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_coefs
@@ -24672,7 +24673,8 @@ save_atom_type_scat.gaussian_coefs
 
     f(s; Z) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:N)
 
-    where s = sin(theta)/lambda.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda is
+    the wavelength of the incident radiation in angstroms.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               Gaussian_coefs
@@ -24850,7 +24852,8 @@ save_atom_type_scat.inv_mott_bethe_coefs
     Z - 8 * Pi * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))
 
     where s = sin(theta)/lambda, a~0~ is the Bohr radius, and Z is the atomic
-    number.
+    number. theta is the diffraction angle and lambda is the wavelength of the
+    incident radiation in angstroms.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               inv_Mott_Bethe_coefs

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -24145,6 +24145,7 @@ save_atom_type_scat.cromer_mann_a1
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_a1
+    _units.code                   none
 
     _import.get
         [
@@ -24165,6 +24166,7 @@ save_atom_type_scat.cromer_mann_a2
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_a2
+    _units.code                   none
 
     _import.get
         [
@@ -24185,6 +24187,7 @@ save_atom_type_scat.cromer_mann_a3
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_a3
+    _units.code                   none
 
     _import.get
         [
@@ -24205,6 +24208,7 @@ save_atom_type_scat.cromer_mann_a4
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_a4
+    _units.code                   none
 
     _import.get
         [
@@ -24225,6 +24229,7 @@ save_atom_type_scat.cromer_mann_b1
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_b1
+    _units.code                   angstrom_squared
 
     _import.get
         [
@@ -24245,6 +24250,7 @@ save_atom_type_scat.cromer_mann_b2
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_b2
+    _units.code                   angstrom_squared
 
     _import.get
         [
@@ -24265,6 +24271,7 @@ save_atom_type_scat.cromer_mann_b3
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_b3
+    _units.code                   angstrom_squared
 
     _import.get
         [
@@ -24285,6 +24292,7 @@ save_atom_type_scat.cromer_mann_b4
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_b4
+    _units.code                   angstrom_squared
 
     _import.get
         [
@@ -24305,6 +24313,7 @@ save_atom_type_scat.cromer_mann_c
 
     _name.category_id             atom_type_scat
     _name.object_id               Cromer_Mann_c
+    _units.code                   none
 
     _import.get
         [

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -665,7 +665,7 @@ save_cromer_mann_coeff
     _description.text
 ;
     The set of data items used to define Cromer-Mann coefficients for generation
-    of X-ray scattering factors (0.0 < s < 2.0).
+    of X-ray scattering factors (0.0 < s < 2.0 \%A^-1^).
 
     f(s) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:4)
 
@@ -691,7 +691,7 @@ save_hi_ang_fox_coeffs
     _description.text
 ;
     The set of data items used to define Fox et al. coefficients for generation
-    of high angle (2.0 < s < 6.0) X-ray scattering factors.
+    of high angle (2.0 < s < 6.0 \%A^-1^) X-ray scattering factors.
 
     f(s) = exp(Sum( c~i~ * s^i^, i=0:3))
 

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -696,7 +696,6 @@ save_hi_ang_fox_coeffs
     _type.container              Single
     _type.contents               Real
     _enumeration.def_index_id  '_atom_type.symbol'
-    _units.code                  none
      save_
 
 

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -669,8 +669,8 @@ save_cromer_mann_coeff
 
     f(s) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:4)
 
-    where s = sin(theta)/lambda and theta is the diffraction angle and lambda
-    is the wavelength of the incident radiation in angstroms.
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength of
+    the incident radiation in angstroms.
 
         Ref: International Tables for X-ray Crystallography, Vol. IV
              (1974) Table 2.2B
@@ -695,8 +695,8 @@ save_hi_ang_fox_coeffs
 
     f(s) = exp(Sum( c~i~ * s^i^, i=0:3))
 
-    where s = sin(theta)/lambda and theta is the diffraction angle and lambda
-    is the wavelength of the incident radiation in angstroms.
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength of
+    the incident radiation in angstroms.
 
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -954,7 +954,7 @@ save_display_colour
        Changed the data type in the 'diffr_counts' save frame from 'Count' to
        'Integer'.
 ;
-         1.4.10                   2023-01-13
+         1.4.10                   2023-06-03
 ;
        Corrected a few typos in the descriptions of several save frames.
 
@@ -975,4 +975,6 @@ save_display_colour
        Changed atomic labels to 'Word' for conformance with DDL1.
 
        Updated description of _site_symmetry.
+
+       Updated descriptions of cromer_mann_coeff and hi_ang_fox_coeffs.
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -677,7 +677,6 @@ save_cromer_mann_coeff
     _type.container              Single
     _type.contents               Real
     _enumeration.def_index_id  '_atom_type.symbol'
-    _units.code                  none
      save_
 
 

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -665,12 +665,12 @@ save_cromer_mann_coeff
     _description.text
 ;
     The set of data items used to define Cromer-Mann coefficients for generation
-    of X-ray scattering factors (0.0 < s < 2.0 Å^-1^).
+    of X-ray scattering factors (0.0 < s < 2.0).
 
     f(s) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:4)
 
-    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength of
-    the incident radiation in angstroms.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda is
+    the wavelength of the incident radiation in angstroms.
 
         Ref: International Tables for X-ray Crystallography, Vol. IV
              (1974) Table 2.2B
@@ -691,12 +691,12 @@ save_hi_ang_fox_coeffs
     _description.text
 ;
     The set of data items used to define Fox et al. coefficients for generation
-    of high angle (2.0 < s < 6.0 Å^-1^) X-ray scattering factors.
+    of high angle (2.0 < s < 6.0) X-ray scattering factors.
 
     f(s) = exp(Sum( c~i~ * s^i^, i=0:3))
 
-    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength of
-    the incident radiation in angstroms.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda is
+    the wavelength of the incident radiation in angstroms.
 
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -682,11 +682,15 @@ save_cromer_mann_coeff
 
 save_hi_ang_fox_coeffs
 
-    _definition.update           2012-11-29
+    _definition.update           2023-06-03
     _description.text
 ;
     The set of data items used to define Fox et al.  coefficients
-     for generation of high angle (s >2.0) X-ray scattering factors.
+     for generation of high angle (2.0 < s < 6.0) X-ray scattering factors.
+
+    f(s) = exp(Sum( c~i~ * s^i^, i=0:3))
+
+    where s = sin(theta)/lambda.
 
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -661,11 +661,15 @@ save_
 
 save_cromer_mann_coeff
 
-    _definition.update           2012-11-29
+    _definition.update           2023-06-03
     _description.text
 ;
      The set of data items used to define Cromer-Mann coefficients
-     for generation of X-ray scattering factors.
+     for generation of X-ray scattering factors (0.0 < s < 2.0).
+
+    f(s) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:4)
+
+    where s = sin(theta)/lambda.
 
         Ref: International Tables for X-ray Crystallography, Vol. IV
              (1974) Table 2.2B

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -664,12 +664,13 @@ save_cromer_mann_coeff
     _definition.update           2023-06-03
     _description.text
 ;
-     The set of data items used to define Cromer-Mann coefficients
-     for generation of X-ray scattering factors (0.0 < s < 2.0).
+    The set of data items used to define Cromer-Mann coefficients for generation
+    of X-ray scattering factors (0.0 < s < 2.0 Å^-1^).
 
     f(s) = c + Sum( a~i~ * exp(-b~i~ * s^2^), i=1:4)
 
-    where s = sin(theta)/lambda.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda
+    is the wavelength of the incident radiation in angstroms.
 
         Ref: International Tables for X-ray Crystallography, Vol. IV
              (1974) Table 2.2B
@@ -689,12 +690,13 @@ save_hi_ang_fox_coeffs
     _definition.update           2023-06-03
     _description.text
 ;
-    The set of data items used to define Fox et al.  coefficients
-     for generation of high angle (2.0 < s < 6.0) X-ray scattering factors.
+    The set of data items used to define Fox et al. coefficients for generation
+    of high angle (2.0 < s < 6.0 Å^-1^) X-ray scattering factors.
 
     f(s) = exp(Sum( c~i~ * s^i^, i=0:3))
 
-    where s = sin(theta)/lambda.
+    where s = sin(theta)/lambda and theta is the diffraction angle and lambda
+    is the wavelength of the incident radiation in angstroms.
 
         Ref: International Tables for Crystallography, Vol. C
              (1991) Table 6.1.1.5


### PR DESCRIPTION
Discussion started in #409

I noticed that that the `_atom_type_scat.hi_ang_fox_c?` and `_atom_type_scat.cromer_mann_b?` dataitems had units which didn't match what they should be. So I changed them.

I also updated the descriptions to give equations so there is more clarity behind the use of the values.