### PR TITLE
add unit to allow `_units.code` to express and arbitrary mixture of units

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -2325,8 +2325,9 @@ save_units.code
 ;
     A code which identifies the units of measurement.
 
-    'unspecified' is used only for List, Array, Matrix, or Table data types
-    where the constituent values have differing units.
+    The 'unspecified' code should only be used in cases when the units cannot
+    be properly expressed in DDLm. A typical example of such situation is a
+    List data item with constituent values that may have differing units.
 ;
     _name.category_id             units
     _name.object_id               code

--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.1.0
-    _dictionary.date              2023-01-13
+    _dictionary.date              2023-06-10
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.1.0
@@ -2089,10 +2089,13 @@ save_units.code
 
     _definition.id                '_units.code'
     _definition.class             Attribute
-    _definition.update            2021-03-01
+    _definition.update            2023-06-10
     _description.text
 ;
     A code which identifies the units of measurement.
+
+    'unspecified' is used only for List, Array, Matrix, or Table data types
+    where the constituent values have differing units.
 ;
     _name.category_id             units
     _name.object_id               code
@@ -2607,7 +2610,7 @@ save_
 
        Unified the spelling of certain words.
 ;
-         4.1.0                    2023-01-13
+         4.1.0                    2023-06-10
 ;
        Added new 'Word' content type.
 
@@ -2633,4 +2636,7 @@ save_
        Clarified the definition of the "Version" state in _type.contents
        by explicitly specifying that is adheres to the formal grammar
        provided in SemVer version 2.0.0.
+
+       Added 'unspecified' as a valid units.code for compound data types where
+       the constituent values have differing units.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -2869,8 +2869,7 @@ save_
        by explicitly specifying that is adheres to the formal grammar
        provided in SemVer version 2.0.0.
 
-       Added 'unspecified' as a valid units.code for compound data types where
-       the constituent values have differing units.
+       Added the "unspecified" enumeration value for the _units.code attribute.
 
        Added ENUMERATION_SOURCE and _enumeration_default.source_id to allow the
        source of default enumeration values to be recorded.

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -751,6 +751,7 @@ save_units_code
          _enumeration_set.state
          _enumeration_set.detail
 
+   .      "no unit(s) supplied; i.e. the user must derive the correct unit(s)."
    'none' "dimensionless - e.g. a ratio, factor, weight or scale"
 
    'coulomb'        "electronic charge in coulombs"

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -754,7 +754,7 @@ save_units_code
    'none' "dimensionless - e.g. a ratio, factor, weight or scale"
 
    'unspecified'
-   "no units supplied; the user must derive the correct units from context."
+   "no units supplied - the correct units should be derived based on the context"
 
    'coulomb'        "electronic charge in coulombs"
    'electron_volts' "electronic charge in electron volts eV"

--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -751,8 +751,10 @@ save_units_code
          _enumeration_set.state
          _enumeration_set.detail
 
-   .      "no unit(s) supplied; i.e. the user must derive the correct unit(s)."
    'none' "dimensionless - e.g. a ratio, factor, weight or scale"
+
+   'unspecified'
+   "no units supplied; the user must derive the correct units from context."
 
    'coulomb'        "electronic charge in coulombs"
    'electron_volts' "electronic charge in electron volts eV"


### PR DESCRIPTION
will close #409 

as mentioned in https://github.com/COMCIFS/cif_core/issues/409#issuecomment-1576037690

Where a dataitem consists of an arbitrary number of values, or a mixture of values with different units, use `.` to indicate that the user (either a person or a program) must decide which units to apply to any single value taken from the item.