### PR TITLE
add _dictionary.doi

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.1.0
-    _dictionary.date              2023-06-10
+    _dictionary.date              2023-06-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.1.0
@@ -543,6 +543,24 @@ save_dictionary.ddl_conformance
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Version
+
+save_
+
+save_dictionary.doi
+
+    _definition.id                '_dictionary.doi'
+    _definition.class             Attribute
+    _definition.update            2023-06-19
+    _description.text
+;
+    The digital object identifier (DOI) for this dictionary.
+;
+    _name.category_id             dictionary
+    _name.object_id               doi
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -2842,7 +2860,7 @@ save_
 
        Unified the spelling of certain words.
 ;
-         4.1.0                    2023-06-10
+         4.1.0                    2023-06-19
 ;
        Added new 'Word' content type.
 
@@ -2876,4 +2894,7 @@ save_
 
        Added DICTIONARY_AUTHOR to allow details of dictionary authors to be
        recorded.
+
+       Added _dictionary.doi to record the persistent Digital Object Identifier
+       of a dictionary.
 ;

--- a/ddl.dic
+++ b/ddl.dic
@@ -553,7 +553,7 @@ save_dictionary.doi
     _definition.update            2023-06-19
     _description.text
 ;
-    The digital object identifier (DOI) for this dictionary.
+    The digital object identifier (DOI) of the dictionary.
 ;
     _name.category_id             dictionary
     _name.object_id               doi

--- a/ddl.dic
+++ b/ddl.dic
@@ -548,7 +548,7 @@ save_
 
 save_dictionary.doi
 
-    _definition.id                '_dictionary.doi'
+    _definition.id                '_dictionary.DOI'
     _definition.class             Attribute
     _definition.update            2023-06-19
     _description.text

--- a/ddl.dic
+++ b/ddl.dic
@@ -560,7 +560,7 @@ save_dictionary.doi
     _type.purpose                 Identify
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Word
+    _type.contents                Text
     _description_example.case     10.5555/12345678
 
 save_

--- a/ddl.dic
+++ b/ddl.dic
@@ -561,6 +561,7 @@ save_dictionary.doi
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
+    _description_example.case     10.5555/12345678
 
 save_
 


### PR DESCRIPTION
Will close #416

It is "The" DOI, as there should only be one (AFAIK).

It's "the DOI for this dictionary", as it should point to the actual dictionary file (https://github.com/COMCIFS/cif_core/issues/416#issuecomment-1594442167)

It's of type.content `Word`, as the DOI probably shouldn't be given as a URI ("I would (personally) prefer that _dictionary.DOI be given as 10.1107/cifdic_000002 etc., but that does run counter to CrossRef guidance and almost-universal practice." https://github.com/COMCIFS/cif_core/issues/416#issuecomment-1593324634)