### PR TITLE
Add _dictionary.doi to the list of items recommended in dictionaries

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -2371,7 +2371,8 @@ save_
          Dictionary  Recommended  ['_description.text'
                                    '_dictionary_audit.version'
                                    '_dictionary_audit.date'
-                                   '_dictionary_audit.revision']
+                                   '_dictionary_audit.revision'
+                                   '_dictionary.doi']
          Dictionary  Prohibited   [ALIAS  CATEGORY_KEY  DEFINITION
                                    DESCRIPTION_EXAMPLE  ENUMERATION  IMPORT
                                    METHOD  NAME  TYPE  UNITS]


### PR DESCRIPTION
The GitHub actions currently fail due to `_dictionary.doi` data item not being included in our dictionaries. In case we do not yet have a suitable DOI to be included in the dictionaries, we can simply silence the warning by filtering it out in the https://github.com/COMCIFS/dictionary_check_action repository. Should suppress such warnings for now?