### PR TITLE
_type.source of many other SU items changed from `Related`

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -20617,7 +20617,7 @@ save_atom_site.b_equiv_geom_mean_su
          '_atom_site_B_equiv_geom_mean_su'
          '_atom_site.B_equiv_geom_mean_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the equivalent isotropic atomic displacement
@@ -20628,7 +20628,7 @@ save_atom_site.b_equiv_geom_mean_su
     _name.object_id               B_equiv_geom_mean_su
     _name.linked_item_id          '_atom_site.B_equiv_geom_mean'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstrom_squared

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25309,7 +25309,7 @@ save_refine_diff.density_min_su
          '_refine_diff_density_min_su'
          '_refine.diff_density_min_esd'
 
-    _definition.update            2023-01-12
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the minimum density value
@@ -25319,7 +25319,7 @@ save_refine_diff.density_min_su
     _name.object_id               density_min_su
     _name.linked_item_id          '_refine_diff.density_min'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _method.purpose               Definition

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -9229,7 +9229,7 @@ save_chemical.temperature_sublimation_su
          '_chemical_temperature_sublimation_su'
          '_chemical.temperature_sublimation_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the temperature at which
@@ -9239,7 +9239,7 @@ save_chemical.temperature_sublimation_su
     _name.object_id               temperature_sublimation_su
     _name.linked_item_id          '_chemical.temperature_sublimation'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kelvins

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -27597,5 +27597,6 @@ save_
 
        Redefined _exptl_absorpt.coefficient_mu as Derived Measurand. Added SU.
 
-
+       Redefined many *_su data names' type source from Related to matching
+       their associated data name type source.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1817,7 +1817,7 @@ save_cell_measurement.pressure_su
          '_cell_measurement_pressure_su'
          '_cell_measurement.pressure_esd'
 
-    _definition.update            2022-05-22
+    _definition.update            2023-06-25
     _description.text
 ;
     ** DEPRECATED **
@@ -1829,7 +1829,7 @@ save_cell_measurement.pressure_su
     _name.object_id               pressure_su
     _name.linked_item_id          '_cell_measurement.pressure'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kilopascals

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10247,7 +10247,7 @@ save_exptl_crystal.density_meas_su
          '_exptl_crystal_density_meas_su'
          '_exptl_crystal.density_meas_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the crystal density measured
@@ -10257,7 +10257,7 @@ save_exptl_crystal.density_meas_su
     _name.object_id               density_meas_su
     _name.linked_item_id          '_exptl_crystal.density_meas'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   megagrams_per_metre_cubed

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -21752,7 +21752,7 @@ save_atom_site.u_iso_or_equiv_su
          '_atom_site_U_iso_or_equiv_su'
          '_atom_site.U_iso_or_equiv_esd'
 
-    _definition.update            2012-11-20
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty values (esds) of the U(iso) or U(equiv).
@@ -21761,7 +21761,7 @@ save_atom_site.u_iso_or_equiv_su
     _name.object_id               U_iso_or_equiv_su
     _name.linked_item_id          '_atom_site.U_iso_or_equiv'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstrom_squared

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13744,7 +13744,7 @@ save_geom_torsion.angle_su
          '_geom_torsion_su'
          '_geom_torsion.value_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the torsion angle.
@@ -13753,7 +13753,7 @@ save_geom_torsion.angle_su
     _name.object_id               angle_su
     _name.linked_item_id          '_geom_torsion.angle'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   degrees

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13392,7 +13392,7 @@ save_geom_hbond.distance_da_su
          '_geom_hbond_distance_DA_su'
          '_geom_hbond.dist_DA_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the set of data items which specify
@@ -13402,7 +13402,7 @@ save_geom_hbond.distance_da_su
     _name.object_id               distance_DA_su
     _name.linked_item_id          '_geom_hbond.distance_DA'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -21699,7 +21699,7 @@ save_atom_site.u_equiv_geom_mean_su
          '_atom_site_U_equiv_geom_mean_su'
          '_atom_site.U_equiv_geom_mean_esd'
 
-    _definition.update            2012-11-20
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty values (esds) of the U(equiv).
@@ -21708,7 +21708,7 @@ save_atom_site.u_equiv_geom_mean_su
     _name.object_id               U_equiv_geom_mean_su
     _name.linked_item_id          '_atom_site.U_equiv_geom_mean'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstrom_squared

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13456,7 +13456,7 @@ save_geom_hbond.distance_dh_su
          '_geom_hbond_distance_DH_su'
          '_geom_hbond.dist_DH_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the set of data items which specify
@@ -13466,7 +13466,7 @@ save_geom_hbond.distance_dh_su
     _name.object_id               distance_DH_su
     _name.linked_item_id          '_geom_hbond.distance_DH'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25487,7 +25487,7 @@ save_refine_ls.abs_structure_flack_su
          '_refine_ls_abs_structure_Flack_su'
          '_refine.ls_abs_structure_Flack_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the measure of absolute structure
@@ -25497,7 +25497,7 @@ save_refine_ls.abs_structure_flack_su
     _name.object_id               abs_structure_Flack_su
     _name.linked_item_id          '_refine_ls.abs_structure_Flack'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -6300,7 +6300,7 @@ save_refln.f_meas_su
          '_refln.F_meas_sigma'
          '_refln_F_meas_su'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the measured structure factor amplitude.
@@ -6309,7 +6309,7 @@ save_refln.f_meas_su
     _name.object_id               F_meas_su
     _name.linked_item_id          '_refln.F_meas'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _method.purpose               Definition

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25908,7 +25908,7 @@ save_refine_ls.goodness_of_fit_all_su
          '_refine_ls_goodness_of_fit_all_su'
          '_refine.ls_goodness_of_fit_all_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the least-squares goodness-of-fit
@@ -25918,7 +25918,7 @@ save_refine_ls.goodness_of_fit_all_su
     _name.object_id               goodness_of_fit_all_su
     _name.linked_item_id          '_refine_ls.goodness_of_fit_all'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -6693,7 +6693,7 @@ save_refln.intensity_meas_su
          '_refln.intensity_sigma'
          '_refln_intensity_sigma'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the measured intensity.
@@ -6702,7 +6702,7 @@ save_refln.intensity_meas_su
     _name.object_id               intensity_meas_su
     _name.linked_item_id          '_refln.intensity_meas'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -6414,7 +6414,7 @@ save_refln.f_squared_meas_su
          '_refln.F_squared_sigma'
          '_refln_F_squared_meas_su'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the measured structure factor squared.
@@ -6423,7 +6423,7 @@ save_refln.f_squared_meas_su
     _name.object_id               F_squared_meas_su
     _name.linked_item_id          '_refln.F_squared_meas'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _method.purpose               Definition

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -12679,7 +12679,7 @@ save_geom_angle.value_su
          '_geom_angle_su'
          '_geom_angle.value_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the angle defined by
@@ -12689,7 +12689,7 @@ save_geom_angle.value_su
     _name.object_id               value_su
     _name.linked_item_id          '_geom_angle.value'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   degrees

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-06-19
+    _dictionary.date              2023-06-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -9890,20 +9890,37 @@ save_exptl_absorpt.coefficient_mu
          '_exptl_absorpt_coefficient_mu'
          '_exptl.absorpt_coefficient_mu'
 
-    _definition.update            2012-11-22
+    _definition.update            2023-06-25
     _description.text
 ;
-    Absorption coefficient mu calculated from the atomic content of
+    Linear absorption coefficient, μ, calculated from the atomic content of
     the cell, the density and the radiation wavelength.
 ;
     _name.category_id             exptl_absorpt
     _name.object_id               coefficient_mu
-    _type.purpose                 Number
-    _type.source                  Recorded
+    _type.purpose                 Measurand
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   reciprocal_millimetres
+
+save_
+
+save_exptl_absorpt.coefficient_mu_su
+
+    _definition.id                'exptl_absorpt.coefficient_mu_su'
+    _definition.update            2023-06-25
+    _description.text
+;
+    Standard uncertainty of _exptl_absorpt.coefficient_mu.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               coefficient_mu_su
+    _name.linked_item_id          '_exptl_absorpt.coefficient_mu'
+    _units.code                   reciprocal_millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -27550,7 +27567,7 @@ save_
        inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
        the definition of form factors.
 ;
-         3.3.0                    2023-06-19
+         3.3.0                    2023-06-25
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -27578,4 +27595,6 @@ save_
        units of several data items to 'unspecified'.
 
        Added the default value of '1_555' to the site symmetry data items.
+
+       Redefined _exptl_absorpt.coefficient_mu as Derived Measurand. Added SU.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -21300,7 +21300,7 @@ save_atom_site.occupancy_su
          '_atom_site_occupancy_su'
          '_atom_site.occupancy_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the fraction of the atom type
@@ -21310,7 +21310,7 @@ save_atom_site.occupancy_su
     _name.object_id               occupancy_su
     _name.linked_item_id          '_atom_site.occupancy'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -9908,7 +9908,7 @@ save_
 
 save_exptl_absorpt.coefficient_mu_su
 
-    _definition.id                'exptl_absorpt.coefficient_mu_su'
+    _definition.id                '_exptl_absorpt.coefficient_mu_su'
     _definition.update            2023-06-25
     _description.text
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25981,7 +25981,7 @@ save_refine_ls.goodness_of_fit_gt_su
          '_refine.ls_goodness_of_fit_gt_esd'
          '_refine.ls_goodness_of_fit_obs_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the least-squares goodness-of-fit
@@ -25991,7 +25991,7 @@ save_refine_ls.goodness_of_fit_gt_su
     _name.object_id               goodness_of_fit_gt_su
     _name.linked_item_id          '_refine_ls.goodness_of_fit_gt'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10341,7 +10341,7 @@ save_exptl_crystal.density_meas_temp_su
          '_exptl_crystal_density_meas_temp_su'
          '_exptl_crystal.density_meas_temp_esd'
 
-    _definition.update            2012-11-22
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the temperature at
@@ -10351,7 +10351,7 @@ save_exptl_crystal.density_meas_temp_su
     _name.object_id               density_meas_temp_su
     _name.linked_item_id          '_exptl_crystal.density_meas_temp'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kelvins

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13280,7 +13280,7 @@ save_geom_hbond.angle_dha_su
          '_geom_hbond_angle_DHA_su'
          '_geom_hbond.angle_DHA_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the angle subtended by the sites identified
@@ -13290,7 +13290,7 @@ save_geom_hbond.angle_dha_su
     _name.object_id               angle_DHA_su
     _name.linked_item_id          '_geom_hbond.angle_DHA'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   degrees

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25660,7 +25660,7 @@ save_refine_ls.extinction_coef_su
          '_refine_ls_extinction_coef_su'
          '_refine.ls_extinction_coef_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the extinction coefficient.
@@ -25669,7 +25669,7 @@ save_refine_ls.extinction_coef_su
     _name.object_id               extinction_coef_su
     _name.linked_item_id          '_refine_ls.extinction_coef'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -20677,7 +20677,7 @@ save_atom_site.b_iso_or_equiv_su
          '_atom_site_B_iso_or_equiv_su'
          '_atom_site.B_iso_or_equiv_esd'
 
-    _definition.update            2023-01-16
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the isotropic atomic displacement parameter,
@@ -20689,7 +20689,7 @@ save_atom_site.b_iso_or_equiv_su
     _name.object_id               B_iso_or_equiv_su
     _name.linked_item_id          '_atom_site.B_iso_or_equiv'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstrom_squared

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25242,7 +25242,7 @@ save_refine_diff.density_max_su
          '_refine_diff_density_max_su'
          '_refine.diff_density_max_esd'
 
-    _definition.update            2023-01-12
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the maximum density value
@@ -25252,7 +25252,7 @@ save_refine_diff.density_max_su
     _name.object_id               density_max_su
     _name.linked_item_id          '_refine_diff.density_max'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _method.purpose               Definition

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25381,7 +25381,7 @@ save_refine_diff.density_rms_su
          '_refine_diff_density_RMS_su'
          '_refine.diff_density_RMS_esd'
 
-    _definition.update            2023-01-12
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the root mean square density value
@@ -25391,7 +25391,7 @@ save_refine_diff.density_rms_su
     _name.object_id               density_RMS_su
     _name.linked_item_id          '_refine_diff.density_RMS'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _method.purpose               Definition

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25543,7 +25543,7 @@ save_refine_ls.abs_structure_rogers_su
          '_refine_ls_abs_structure_Rogers_su'
          '_refine.ls_abs_structure_Rogers_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the measure of absolute structure
@@ -25553,7 +25553,7 @@ save_refine_ls.abs_structure_rogers_su
     _name.object_id               abs_structure_Rogers_su
     _name.linked_item_id          '_refine_ls.abs_structure_Rogers'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   none

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3464,7 +3464,7 @@ save_diffrn_radiation_wavelength.value_su
          '_diffrn_radiation_wavelength_su'
          '_diffrn_radiation_wavelength.wavelength_su'
 
-    _definition.update            2021-08-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the wavelength of radiation used in diffraction
@@ -3474,7 +3474,7 @@ save_diffrn_radiation_wavelength.value_su
     _name.object_id               value_su
     _name.linked_item_id          '_diffrn_radiation_wavelength.value'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -986,7 +986,7 @@ save_cell.reciprocal_angle_alpha_su
          '_cell_reciprocal_angle_alpha_su'
          '_cell.reciprocal_angle_alpha_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the reciprocal of the angle
@@ -996,7 +996,7 @@ save_cell.reciprocal_angle_alpha_su
     _name.object_id               reciprocal_angle_alpha_su
     _name.linked_item_id          '_cell.reciprocal_angle_alpha'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   degrees
@@ -1043,7 +1043,7 @@ save_cell.reciprocal_angle_beta_su
          '_cell_reciprocal_angle_beta_su'
          '_cell.reciprocal_angle_beta_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the reciprocal of the angle
@@ -1053,7 +1053,7 @@ save_cell.reciprocal_angle_beta_su
     _name.object_id               reciprocal_angle_beta_su
     _name.linked_item_id          '_cell.reciprocal_angle_beta'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   degrees
@@ -1151,7 +1151,7 @@ save_cell.reciprocal_length_a_su
          '_cell_reciprocal_length_a_su'
          '_cell.reciprocal_length_a_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the reciprocal of the _cell.length_a.
@@ -1160,7 +1160,7 @@ save_cell.reciprocal_length_a_su
     _name.object_id               reciprocal_length_a_su
     _name.linked_item_id          '_cell.reciprocal_length_a'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   reciprocal_angstroms
@@ -1201,7 +1201,7 @@ save_cell.reciprocal_length_b_su
          '_cell_reciprocal_length_b_su'
          '_cell.reciprocal_length_b_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the reciprocal of the _cell.length_b.
@@ -1210,7 +1210,7 @@ save_cell.reciprocal_length_b_su
     _name.object_id               reciprocal_length_b_su
     _name.linked_item_id          '_cell.reciprocal_length_b'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   reciprocal_angstroms
@@ -27596,4 +27596,6 @@ save_
        Added the default value of '1_555' to the site symmetry data items.
 
        Redefined _exptl_absorpt.coefficient_mu as Derived Measurand. Added SU.
+
+
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-06-19
+    _dictionary.date              2023-06-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -27549,7 +27549,7 @@ save_
        inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
        the definition of form factors.
 ;
-         3.3.0                    2023-06-19
+         3.3.0                    2023-06-25
 ;
        # Please update the date above and describe the change below until
        # ready for the next release

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1703,7 +1703,7 @@ save_cell.volume_su
          '_cell_volume_su'
          '_cell.volume_esd'
 
-    _definition.update            2014-06-08
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the volume of the crystal unit cell.
@@ -1712,7 +1712,7 @@ save_cell.volume_su
     _name.object_id               volume_su
     _name.linked_item_id          '_cell.volume'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstrom_cubed

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -12827,7 +12827,7 @@ save_geom_bond.distance_su
          '_geom_bond_distance_su'
          '_geom_bond.dist_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the intramolecular bond distance
@@ -12837,7 +12837,7 @@ save_geom_bond.distance_su
     _name.object_id               distance_su
     _name.linked_item_id          '_geom_bond.distance'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -1930,7 +1930,7 @@ save_cell_measurement.temperature_su
          '_cell_measurement_temp_su'
          '_cell_measurement.temp_esd'
 
-    _definition.update            2022-05-22
+    _definition.update            2023-06-25
     _description.text
 ;
     ** DEPRECATED **
@@ -1942,7 +1942,7 @@ save_cell_measurement.temperature_su
     _name.object_id               temperature_su
     _name.linked_item_id          '_cell_measurement.temperature'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kelvins

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -9141,7 +9141,7 @@ save_chemical.temperature_decomposition_su
          '_chemical_temperature_decomposition_su'
          '_chemical.temperature_decomposition_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the temperature at which
@@ -9151,7 +9151,7 @@ save_chemical.temperature_decomposition_su
     _name.object_id               temperature_decomposition_su
     _name.linked_item_id          '_chemical.temperature_decomposition'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kelvins

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13117,7 +13117,7 @@ save_geom_contact.distance_su
          '_geom_contact_distance_su'
          '_geom_contact.dist_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the intermolecular distance between
@@ -13127,7 +13127,7 @@ save_geom_contact.distance_su
     _name.object_id               distance_su
     _name.linked_item_id          '_geom_contact.distance'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -13520,7 +13520,7 @@ save_geom_hbond.distance_ha_su
          '_geom_hbond_distance_HA_su'
          '_geom_hbond.dist_HA_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
     Standard uncertainty of the set of data items which specify
@@ -13530,7 +13530,7 @@ save_geom_hbond.distance_ha_su
     _name.object_id               distance_HA_su
     _name.linked_item_id          '_geom_hbond.distance_HA'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Derived
     _type.container               Single
     _type.contents                Real
     _units.code                   angstroms

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -221,17 +221,16 @@ save_diffrn.ambient_temperature_su
          '_diffrn_ambient_temp_su'
          '_diffrn.ambient_temp_esd'
 
-    _definition.update            2021-03-03
+    _definition.update            2023-06-25
     _description.text
 ;
-    Standard uncertainty of the mean temperature
-    at which intensities were measured.
+    Standard uncertainty of _diffrn.ambient_temperature.
 ;
     _name.category_id             diffrn
     _name.object_id               ambient_temperature_su
     _name.linked_item_id          '_diffrn.ambient_temperature'
     _type.purpose                 SU
-    _type.source                  Related
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _units.code                   kelvins

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-06-25
+    _dictionary.date              2023-06-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.1.0
@@ -9889,37 +9889,20 @@ save_exptl_absorpt.coefficient_mu
          '_exptl_absorpt_coefficient_mu'
          '_exptl.absorpt_coefficient_mu'
 
-    _definition.update            2023-06-25
+    _definition.update            2012-11-22
     _description.text
 ;
-    Linear absorption coefficient, μ, calculated from the atomic content of
+    Absorption coefficient mu calculated from the atomic content of
     the cell, the density and the radiation wavelength.
 ;
     _name.category_id             exptl_absorpt
     _name.object_id               coefficient_mu
-    _type.purpose                 Measurand
-    _type.source                  Derived
+    _type.purpose                 Number
+    _type.source                  Recorded
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   reciprocal_millimetres
-
-save_
-
-save_exptl_absorpt.coefficient_mu_su
-
-    _definition.id                '_exptl_absorpt.coefficient_mu_su'
-    _definition.update            2023-06-25
-    _description.text
-;
-    Standard uncertainty of _exptl_absorpt.coefficient_mu.
-;
-    _name.category_id             exptl_absorpt
-    _name.object_id               coefficient_mu_su
-    _name.linked_item_id          '_exptl_absorpt.coefficient_mu'
-    _units.code                   reciprocal_millimetres
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -27566,7 +27549,7 @@ save_
        inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
        the definition of form factors.
 ;
-         3.3.0                    2023-06-25
+         3.3.0                    2023-06-19
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -27594,8 +27577,6 @@ save_
        units of several data items to 'unspecified'.
 
        Added the default value of '1_555' to the site symmetry data items.
-
-       Redefined _exptl_absorpt.coefficient_mu as Derived Measurand. Added SU.
 
        Redefined many *_su data names' type source from Related to matching
        their associated data name type source.


### PR DESCRIPTION
Split from #431

A bunch of SU data items' _type.source was Related, which doesn't seem to link up with the description of Related, so I changed them all to match the _type.source of the data item to which the SU belongs.