### PR TITLE
Change the source of _citation.id to 'Assigned'

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -16059,7 +16059,7 @@ save_citation.id
     _name.category_id             citation
     _name.object_id               id
     _type.purpose                 Encode
-    _type.source                  Recorded
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 


### PR DESCRIPTION
The 'Recorded' source is probably not very suitable, since this (almost) arbitrary id was neither observed, nor measured.

Edit: changed "recorded" to "measured".