### PR TITLE
Describe primitive data items

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -1814,7 +1814,7 @@ save_method.purpose
 
     _definition.id                '_method.purpose'
     _definition.class             Attribute
-    _definition.update            2006-11-16
+    _definition.update            2023-06-28
     _description.text
 ;
     The purpose and scope of the method expression.
@@ -1829,9 +1829,19 @@ save_method.purpose
     loop_
       _enumeration_set.state
       _enumeration_set.detail
-         Evaluation   'Method evaluates an item from related item values.'
-         Definition   'Method generates attribute value(s) in the definition.'
-         Validation   'Method compares an evaluation with existing item value.'
+         Evaluation
+;
+         Method evaluates an item from related item values. Definitions of
+         primitive data items should normally not contain methods of this type.
+;
+         Definition
+;
+         Method generates attribute value(s) in the definition.
+;
+         Validation
+;
+         Method compares an evaluation with existing item value.
+;
 
     _enumeration.default          Evaluation
 

--- a/ddl.dic
+++ b/ddl.dic
@@ -2386,11 +2386,18 @@ save_type.source
 
     _definition.id                '_type.source'
     _definition.class             Attribute
-    _definition.update            2013-04-16
+    _definition.update            2023-06-28
     _description.text
 ;
     The origin or source of the defined data item, indicating by what
     recording process it has been added to the domain instance.
+
+    All data items can be classified as primitive or non-primitive based on
+    the origin of the data. Primitive data items record data that usually
+    cannot be deduced without repeating the entire experiment such as
+    measurements, observations (e.g. instrument settings) and decisions
+    made in nonlinear processes. Non-primitive data items record derivable
+    data that can be directly evaluated from other data.
 ;
     _name.category_id             type
     _name.object_id               source
@@ -2404,31 +2411,35 @@ save_type.source
       _enumeration_set.detail
          Recorded
 ;
-         A value (numerical or otherwise) recorded by observation or
-         measurement during the experimental collection of data. This item is
-         PRIMITIVE.
+         Data value (numerical or otherwise) was recorded by observation or
+         measurement during the experimental collection of data.
+
+         Data items of this type are considered primitive.
 ;
          Assigned
 ;
-         A value (numerical or otherwise) assigned as part of the data
+         Data value (numerical or otherwise) was assigned as part of the data
          collection, analysis or modelling required for a specific domain
-         instance. These assignments often represent a decision made that
-         determines the course of the experiment (and therefore may be deemed
-         PRIMITIVE) or a particular choice in the way the data was analysed
-         (and therefore may be considered NOT PRIMITIVE).
+         instance.
+
+         These assignments often represent a decision made that determines the
+         course of the experiment (and therefore the data item may be deemed
+         primitive) or a particular choice in the way the data was analysed
+         (and therefore the data item may be considered non-primitive).
 ;
          Related
 ;
-         A value or tag used in the construction of looped lists of data.
-         Typically identifying an item whose unique value is the reference key
-         for a loop category and/or an item which has values in common with
-         those of another loop category and is considered a Link between these
-         lists.
+         Data item was used in the construction of looped lists of data.
+         Typically identifies an item whose unique values are used as the
+         reference key for a loop category and/or an item which has values in
+         common with those of another loop category and is considered a Link
+         between these lists.
 ;
          Derived
 ;
-         A quantity derived from other data items within the domain instance.
-         This item is NOT PRIMITIVE.
+         Data item was derived from other data items within the domain instance.
+
+         Data items of this type are considered non-primitive.
 ;
 
     _enumeration.default          Assigned

--- a/ddl.dic
+++ b/ddl.dic
@@ -3046,4 +3046,6 @@ save_
        the source of default enumeration values to be recorded.
 
        Added 'Inherited' as an enumeration value to _type.contents.
+
+       Updated the description of _type.source and _method.purpose attributes
 ;


### PR DESCRIPTION
This PR rewords some of the definitions as discussed in #437.

Specifically, it properly defines the *primitive* and *non-primitive* data items, and explicitly specifies that Definition methods should not be used on primitive items.

I was not sure if `Related` items should be considered *primitive* or *non-primitive*. I guess they should be handled in the same way ass `Assigned` values (*primitive*/*non-primitive* depending on the context).