### PR TITLE
Alter CELL-related saveframes from Recorded to Derived

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-06-25
+    _dictionary.date              2023-07-01
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -27542,7 +27542,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2023-06-25
+         3.3.0                    2023-07-01
 ;
        # Please update the date above and describe the change below until
        # ready for the next release

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -218,13 +218,13 @@ save_index_limit_min
 
 save_cell_angle
 
-    _definition.update           2014-06-08
+    _definition.update           2023-07-01
     _description.text
 ;
      The angle between the bounding cell axes.
 ;
     _type.purpose                Measurand
-    _type.source                 Recorded
+    _type.source                 Derived
     _type.container              Single
     _type.contents               Real
     _enumeration.range           0.0:180.0
@@ -240,7 +240,7 @@ save_cell_angle_su
      Standard uncertainty of the angle between the bounding cell axes.
 ;
     _type.purpose                SU
-    _type.source                 Recorded
+    _type.source                 Derived
     _type.container              Single
     _type.contents               Real
     _units.code                  degrees
@@ -249,13 +249,13 @@ save_cell_angle_su
 
 save_cell_length
 
-    _definition.update           2014-06-08
+    _definition.update           2023-07-01
     _description.text
 ;
      The length of each cell axis.
 ;
     _type.purpose                Measurand
-    _type.source                 Recorded
+    _type.source                 Derived
     _type.container              Single
     _type.contents               Real
     _enumeration.range           1.0:
@@ -271,7 +271,7 @@ save_cell_length_su
      Standard uncertainty of the length of each cell axis.
 ;
     _type.purpose                SU
-    _type.source                 Recorded
+    _type.source                 Derived
     _type.container              Single
     _type.contents               Real
     _units.code                  angstroms

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -240,7 +240,7 @@ save_cell_angle_su
      Standard uncertainty of the angle between the bounding cell axes.
 ;
     _type.purpose                SU
-    _type.source                 Derived
+    _type.source                 Related
     _type.container              Single
     _type.contents               Real
     _units.code                  degrees
@@ -271,7 +271,7 @@ save_cell_length_su
      Standard uncertainty of the length of each cell axis.
 ;
     _type.purpose                SU
-    _type.source                 Derived
+    _type.source                 Related
     _type.container              Single
     _type.contents               Real
     _units.code                  angstroms


### PR DESCRIPTION
will close #439 

With moving `CELL` from `EXPTL` to `DIFFRN`, the related parameters should no longer be `Recorded`.