### PR TITLE
Repurpose the `STRUCTURE` category

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CORE_DIC
     _dictionary.title             CORE_DIC
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2023-07-05
+    _dictionary.date              2023-07-10
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -34,6 +34,5614 @@ save_CIF_CORE
 ;
     _name.category_id             CORE_DIC
     _name.object_id               CIF_CORE
+
+save_
+
+save_ATOM
+
+    _definition.id                ATOM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic information
+    used in crystallographic structure studies.
+;
+    _name.category_id             CIF_CORE
+    _name.object_id               ATOM
+
+save_
+
+save_ATOM_ANALYTICAL
+
+    _definition.id                ATOM_ANALYTICAL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe elemental
+    composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL
+    _category_key.name            '_atom_analytical.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical.id
+    _atom_analytical.analyte
+    _atom_analytical.meas_id
+    _atom_analytical.chemical_species
+    _atom_analytical.analyte_mass_percent
+    _atom_analytical.chemical_species_mass_percent
+    1 Si  a 'Si O2'   ?     22.7
+    2 Al  a 'Al2 O3'  ?     27.4
+    3 Ti  b 'Ti O2'   ?      2.7
+    4 Si  c .         10.5  .
+    5 Si  d Si        11.7  11.7
+;
+    _description_example.detail
+;
+    There are three separate determinations of Si content, and one each
+    of Al and Ti. The amount of Al is reported as the mass percent of
+    Al2O3. The equivalent amount of Al is not given. There are four
+    different measurements presented in this table.
+;
+
+save_
+
+save_atom_analytical.analyte
+
+    _definition.id                '_atom_analytical.analyte'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Symbol of the element for which a particular composition
+    refers to, as given by _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol}]
+
+save_
+
+save_atom_analytical.analyte_mass_percent
+
+    _definition.id                '_atom_analytical.analyte_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the analyte element derived from elemental analysis.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_analytical.analyte_mass_percent_su
+
+    _definition.id                '_atom_analytical.analyte_mass_percent_su'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent_su
+    _name.linked_item_id          '_atom_analytical.analyte_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical.chemical_species
+
+    _definition.id                '_atom_analytical.chemical_species'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Chemical formula of the species for which the corresponding
+    _atom_analytical.chemical_species_mass_percent refers.
+
+    The following rules apply in the construction of the formula:
+
+    1. Only recognized element symbols may be used.
+
+    2. The first element corresponds to the analyte. The remaining
+       elements should be given in alphabetical order by symbol.
+
+    3. Each element symbol is followed by a 'count' number. A count of
+       '1' may be omitted.
+
+    4. A space or parenthesis must separate each cluster of (element
+       symbol + count). A formula cannot begin with a paranthesis.
+
+    5. Where a group of elements is enclosed in parentheses, the
+       multiplier for the group must follow the closing parentheses.
+       That is, all element and group multipliers are assumed to be
+       printed as subscripted numbers.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Fe2 O3'
+         'Li'
+         'Si O2'
+         'Ca S O4 (H2 O)2'
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent
+
+    _definition.id
+        '_atom_analytical.chemical_species_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the chemical species given in
+    _atom_analytical.chemical_species as derived from elemental analysis.
+
+    This is most often used in elemental compositions determined by XRF,
+    where elements are reported as equivalent mass percentages of their
+    relevant oxide. For example: Al is reported as Al2O3, P is reported
+    as P2O5.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent_su
+
+    _definition.id
+        '_atom_analytical.chemical_species_mass_percent_su'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.chemical_species_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent_su
+    _name.linked_item_id
+        '_atom_analytical.chemical_species_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical.id
+
+    _definition.id                '_atom_analytical.id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label uniquely identifying a single composition value.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical.meas_id
+
+    _definition.id                '_atom_analytical.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_ANALYTICAL_MASS_LOSS
+
+    _definition.id                ATOM_ANALYTICAL_MASS_LOSS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-21
+    _description.text
+;
+    The CATEGORY of data items used to describe information
+    pertaining to mass loss during specimen preparation for
+    the purposes of determining elemental composition
+    information for use in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL_MASS_LOSS
+    _category_key.name            '_atom_analytical_mass_loss.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical_mass_loss.id
+    _atom_analytical_mass_loss.meas_id
+    _atom_analytical_mass_loss.percent
+    _atom_analytical_mass_loss.temperature
+    LOD1 a   2  328
+    LOI1 a   5  623
+    LOI2 a  10 1023
+    LOI3 a  15 1373
+    LOI4 b   5  673
+    LOI5 b  10 1123
+;
+    _description_example.detail
+;
+    Four mass-loss percentages are given for measurement 'a', and two
+    for measurement 'b'. The mass losses were recorded after exposing
+    the specimen to the listed temperatures. The mass lost at a lower
+    temperature for the same measurement should be included in the
+    higher temperatures; that is, for measurement 'a', the total mass
+    loss after four measurements is 15 wt%, not (2+5+10+15) wt%.
+;
+
+save_
+
+save_atom_analytical_mass_loss.id
+
+    _definition.id                '_atom_analytical_mass_loss.id'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_mass_loss.meas_id
+
+    _definition.id                '_atom_analytical_mass_loss.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_mass_loss.percent
+
+    _definition.id                '_atom_analytical_mass_loss.percent'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Mass lost by the specimen during specimen preparation expressed
+    as a percentage. The temperature at which the mass loss was recorded
+    is given by _atom_analytical_mass_loss.temperature. A mass gain
+    is represented by a negative value.
+
+    This data name would be used to record mass loss on drying, or mass
+    loss on ignition, during, for example, fusion bead preparation for
+    XRF analysis.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         12.5
+;
+         Represents a mass loss of 12.5 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+         -7.2
+;
+         Represents a mass gain of 7.2 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+
+save_
+
+save_atom_analytical_mass_loss.percent_su
+
+    _definition.id                '_atom_analytical_mass_loss.percent_su'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_mass_loss.percent.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical_mass_loss.special_details
+
+    _definition.id                '_atom_analytical_mass_loss.special_details'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Text describing the conditions under which the data were collected
+    that are not able to be captured using other data names
+    within the ATOM_ANALYTICAL_MASS_LOSS category.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_atom_analytical_mass_loss.temperature
+
+    _definition.id                '_atom_analytical_mass_loss.temperature'
+    _definition.update            2022-11-21
+    _description.text
+;
+    The temperature, in kelvin, at which the mass loss was recorded
+    as given by _atom_analytical_mass_loss.percent.
+
+    This would be used to record the temperature of drying or ignition,
+    during, for example, fusion bead preparation for XRF analysis.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_atom_analytical_mass_loss.temperature_su
+
+    _definition.id                '_atom_analytical_mass_loss.temperature_su'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_mass_loss.temperature.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               analysis_temperature_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_ATOM_ANALYTICAL_SOURCE
+
+    _definition.id                ATOM_ANALYTICAL_SOURCE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe the source
+    of elemental composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL_SOURCE
+    _category_key.name            '_atom_analytical_source.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical_source.id
+    _atom_analytical_source.technique
+    _atom_analytical_source.equipment_make
+    a  XRF 'Hitachi Lab-X5000'
+    b  'X-ray fluorescence EDS' 'Hitachi Lab-X5000'
+    c  ICP .
+    d  EDS .
+;
+    _description_example.detail
+;
+    Four different measurements of elemental composition are enumerated.
+;
+
+save_
+
+save_atom_analytical_source.equipment_make
+
+    _definition.id                '_atom_analytical_source.equipment_make'
+    _definition.update            2022-11-18
+    _description.text
+;
+    The make, model or name of the equipment used to determine the
+    elemental composition.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               equipment_make
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Bruker'
+         'ELEMISSION'
+         'Thermo Fisher Scientific'
+
+save_
+
+save_atom_analytical_source.id
+
+    _definition.id                '_atom_analytical_source.id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_source.special_details
+
+    _definition.id                '_atom_analytical_source.special_details'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Text describing the equipment or conditions under which the
+    data were collected that are not able to be captured using
+    _atom_analytical_source.equipment_make or
+    _atom_analytical_source.technique.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       XRF utilising a WDS detector system calibrated for the analysis
+       of iron ores.
+;
+;
+       Laser Induced Breakdown Spectroscopy. Measurements carried out
+       by commercial laboratory, report #P90.
+;
+;
+       Detector calibrated following Smith (2018).
+;
+
+save_
+
+save_atom_analytical_source.technique
+
+    _definition.id                '_atom_analytical_source.technique'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Succinct text or acronym describing the experimental technique used
+    to find the elemental composition.
+
+    If further details are required to properly describe the experimental
+    technique, or the given acronym is not in common use, use
+    _atom_analytical_source.special_details.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               technique
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'XRF'
+         'LIBS'
+         'ICP OES'
+
+save_
+
+save_ATOM_SCAT_VERSUS_STOL
+
+    _definition.id                ATOM_SCAT_VERSUS_STOL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-07-05
+    _description.text
+;
+    The CATEGORY of data items used to list atomic scattering factor values for
+    use in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SCAT_VERSUS_STOL
+
+    loop_
+      _category_key.name
+         '_atom_scat_versus_stol.atom_type'
+         '_atom_scat_versus_stol.stol_value'
+
+    _description_example.case
+;
+        loop_
+        _atom_scat_versus_stol.atom_type
+        _atom_scat_versus_stol.stol_value
+        _atom_scat_versus_stol.scat_value
+        Ac  0.00  89.00000
+        Ac  0.01  88.91457
+        Ac  0.02  88.66288
+        #...
+        Ac  4.00   8.24987
+        Ac  5.00   5.98858
+        Ac  6.00   4.90623
+        O   0.00   8.00000
+        O   0.01   7.99171
+        O   0.02   7.96693
+        #...
+        O   4.00   0.13431
+        O   5.00   0.06740
+        O   6.00   0.03670
+;
+    _description_example.detail
+;
+        A listing of the scattering factors for Ac and O in the range
+        (0, 6.00) reciprocal angstroms.
+;
+save_
+
+save_atom_scat_versus_stol.atom_type
+
+    _definition.id                '_atom_scat_versus_stol.atom_type'
+    _definition.update            2023-07-05
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    See _atom_type.symbol for further details.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               atom_type
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_scat_versus_stol.scat_value
+
+    _definition.id                '_atom_scat_versus_stol.scat_value'
+    _definition.update            2023-07-05
+    _description.text
+;
+    The value of the scattering factor of a particular atom type at a particular
+    stol value.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               scat_value
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   electrons
+
+save_
+
+save_atom_scat_versus_stol.scat_value_su
+
+    _definition.id                '_atom_scat_versus_stol.scat_value_su'
+    _definition.update            2023-07-05
+    _description.text
+;
+    Standard uncertainty of _atom_scat_versus_stol.scat_value.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               scat_value_su
+    _name.linked_item_id          '_atom_scat_versus_stol.scat_value'
+    _units.code                   electrons
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_scat_versus_stol.stol_value
+
+    _definition.id                '_atom_scat_versus_stol.stol_value'
+    _definition.update            2023-07-05
+    _description.text
+;
+    The value of sin(θ)/λ (sin theta over lambda, stol) to which the
+    accompanying atom symbol and scattering factor value correspond to.
+
+    A regularly spaced grid is strongly recommended.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               stol_value
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_ATOM_SITE
+
+    _definition.id                ATOM_SITE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-02-03
+    _description.text
+;
+    The CATEGORY of data items used to describe atom site information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITE
+    loop_
+      _category_key.name
+         '_atom_site.label'
+         '_atom_site.structure_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+           _atom_site.label
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            C1     1      .     .
+            H11A   .5     M     1
+            H12A   .5     M     1
+            H13A   .5     M     1
+            H11B   .5     M     2
+            H12B   .5     M     2
+            H13B   .5     M     2
+;
+;
+         A hypothetical example of a positional disorder description. Disorder
+         assembly 'M' describes a methyl group with two alternative
+         configurations '1' and '2':
+
+                            H11B    H11A      H13B
+                              .      |      .
+                                .    |    .
+                                  .  |  .
+                                     C1 --------C2---
+                                   / .  \
+                                 /   .    \
+                               /     .      \
+                            H12A    H12B    H13A
+;
+;
+         loop_
+           _atom_site.label
+           _atom_site.type_symbol
+           _atom_site.fract_x
+           _atom_site.fract_y
+           _atom_site.fract_z
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
+            Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
+            Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
+            O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
+            O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
+            # ...
+;
+;
+         An example of a compositional disorder description. Disorder assembly
+         'A' describes a site that is simultaneously occupied by Co and Mn
+         atoms which are assigned to disorder group '1' and disorder group '2'
+         respectively.
+
+         The example was created based on data from:
+             Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
+             https://doi.org/10.1039/d0dt03269g
+;
+
+save_
+
+save_atom_site.adp_type
+
+    _definition.id                '_atom_site.ADP_type'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_ADP_type'
+         '_atom_site_thermal_displace_type'
+         '_atom_site.thermal_displace_type'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    Code for type of atomic displacement parameters used for the site.
+;
+    _name.category_id             atom_site
+    _name.object_id               ADP_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Uani                     'Anisotropic Uij.'
+         Uiso                     'Isotropic U.'
+         Uovl                     'Overall U.'
+         Umpe                     'Multipole expansion U.'
+         Bani                     'Anisotropic Bij.'
+         Biso                     'Isotropic B.'
+         Bovl                     'Overall B.'
+         betaani                  'Anisotropic betaij.'
+
+save_
+
+save_atom_site.attached_hydrogens
+
+    _definition.id                '_atom_site.attached_hydrogens'
+    _alias.definition_id          '_atom_site_attached_hydrogens'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of hydrogen atoms attached to the atom at this site
+    excluding any H atoms for which coordinates (measured or calculated)
+    are given.
+;
+    _name.category_id             atom_site
+    _name.object_id               attached_hydrogens
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:8
+    _units.code                   none
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         2                        'Water oxygen.'
+         1                        'Hydroxyl oxygen.'
+         4                        'Ammonium nitrogen.'
+
+save_
+
+save_atom_site.b_equiv_geom_mean
+
+    _definition.id                '_atom_site.B_equiv_geom_mean'
+    _alias.definition_id          '_atom_site_B_equiv_geom_mean'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Equivalent isotropic atomic displacement parameter, B(equiv),
+    in angstroms squared, calculated as the geometric mean of
+    the anisotropic atomic displacement parameters.
+
+                B(equiv) = (B~i~ B~j~ B~k~)^1/3^
+
+    B~n~  = the principal components of the orthogonalised B^ij^
+
+    The IUCr Commission on Nomenclature recommends against the use
+    of B for reporting atomic displacement parameters. U, being
+    directly proportional to B, is preferred.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_equiv_geom_mean
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.b_equiv_geom_mean_su
+
+    _definition.id                '_atom_site.B_equiv_geom_mean_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_B_equiv_geom_mean_su'
+         '_atom_site.B_equiv_geom_mean_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the equivalent isotropic atomic displacement
+    parameter, B(equiv), in angstroms squared, calculated as the geometric
+    mean of the anisotropic atomic displacement parameters.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_equiv_geom_mean_su
+    _name.linked_item_id          '_atom_site.B_equiv_geom_mean'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.b_iso_or_equiv
+
+    _definition.id                '_atom_site.B_iso_or_equiv'
+    _alias.definition_id          '_atom_site_B_iso_or_equiv'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Isotropic atomic displacement parameter, or equivalent isotropic
+    atomic displacement parameter, B(equiv), in angstroms squared,
+    calculated from anisotropic atomic displacement parameters.
+
+        B(equiv) = (1/3) sum~i~[sum~j~(B^ij^ a*~i~ a*~j~ a~i~.a~j~)]
+
+    a     = the real-space cell vectors
+    a*    = the reciprocal-space cell lengths
+    B^ij^ = 8 π^2^ U^ij^
+    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
+
+    The IUCr Commission on Nomenclature recommends against the use
+    of B for reporting atomic displacement parameters. U, being
+    directly proportional to B, is preferred.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_iso_or_equiv
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.b_iso_or_equiv_su
+
+    _definition.id                '_atom_site.B_iso_or_equiv_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_B_iso_or_equiv_su'
+         '_atom_site.B_iso_or_equiv_esd'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    Standard uncertainty of the isotropic atomic displacement parameter,
+    or equivalent isotropic atomic displacement parameter, B(equiv),
+    in angstroms squared, calculated from anisotropic atomic displacement
+    parameters.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_iso_or_equiv_su
+    _name.linked_item_id          '_atom_site.B_iso_or_equiv'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.calc_attached_atom
+
+    _definition.id                '_atom_site.calc_attached_atom'
+    _alias.definition_id          '_atom_site_calc_attached_atom'
+    _definition.update            2023-01-13
+    _description.text
+;
+    The _atom_site.label of the atom site to which the 'geometry-calculated'
+    atom site is attached.
+;
+    _name.category_id             atom_site
+    _name.object_id               calc_attached_atom
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site.calc_flag
+
+    _definition.id                '_atom_site.calc_flag'
+    _alias.definition_id          '_atom_site_calc_flag'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A standard code to signal if the site coordinates have been
+    determined from the intensities or calculated from the geometry
+    of surrounding sites, or have been assigned dummy coordinates.
+;
+    _name.category_id             atom_site
+    _name.object_id               calc_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         d                        'Determined from diffraction measurements.'
+         calc                     'Calculated from molecular geometry.'
+         c                        'Abbreviation for "calc".'
+         dum                      'Dummy site with meaningless coordinates.'
+
+save_
+
+save_atom_site.cartn_x
+
+    _definition.id                '_atom_site.Cartn_x'
+    _alias.definition_id          '_atom_site_Cartn_x'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_x
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_x_su
+
+    _definition.id                '_atom_site.Cartn_x_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_x_su'
+         '_atom_site.Cartn_x_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_x_su
+    _name.linked_item_id          '_atom_site.Cartn_x'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.cartn_xyz
+
+    _definition.id                '_atom_site.Cartn_xyz'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Vector of Cartesian (orthogonal angstrom) atom site coordinates.
+;
+    _name.category_id             atom_site
+    _name.object_id               Cartn_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a  as  atom_site
+
+    _atom_site.Cartn_xyz =   [a.Cartn_x, a.Cartn_y, a.Cartn_z]
+;
+
+save_
+
+save_atom_site.cartn_xyz_su
+
+    _definition.id                '_atom_site.Cartn_xyz_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_site.Cartn_xyz.
+;
+    _name.category_id             atom_site
+    _name.object_id               Cartn_xyz_su
+    _name.linked_item_id          '_atom_site.Cartn_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_atom_site.cartn_y
+
+    _definition.id                '_atom_site.Cartn_y'
+    _alias.definition_id          '_atom_site_Cartn_y'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_y
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_y_su
+
+    _definition.id                '_atom_site.Cartn_y_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_y_su'
+         '_atom_site.Cartn_y_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_y_su
+    _name.linked_item_id          '_atom_site.Cartn_y'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.cartn_z
+
+    _definition.id                '_atom_site.Cartn_z'
+    _alias.definition_id          '_atom_site_Cartn_z'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_z
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_z_su
+
+    _definition.id                '_atom_site.Cartn_z_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_z_su'
+         '_atom_site.Cartn_z_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_z_su
+    _name.linked_item_id          '_atom_site.Cartn_z'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.chemical_conn_number
+
+    _definition.id                '_atom_site.chemical_conn_number'
+    _alias.definition_id          '_atom_site_chemical_conn_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    This number links an atom site to the chemical connectivity list.
+    It must match a number specified by _chemical_conn_atom.number.
+;
+    _name.category_id             atom_site
+    _name.object_id               chemical_conn_number
+    _name.linked_item_id          '_chemical_conn_atom.number'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_atom_site.constraints
+
+    _definition.id                '_atom_site.constraints'
+    _alias.definition_id          '_atom_site_constraints'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A description of the constraints applied to parameters at this
+    site during refinement. See also _atom_site.refinement_flags_*
+    and _refine_ls.number_constraints.
+;
+    _name.category_id             atom_site
+    _name.object_id               constraints
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     pop=1.0-pop(Zn3)
+
+save_
+
+save_atom_site.description
+
+    _definition.id                '_atom_site.description'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_description'
+         '_atom_site.details'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of special aspects of this site. See also
+    _atom_site.refinement_flags_*.
+;
+    _name.category_id             atom_site
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Ag/Si disordered'
+
+save_
+
+save_atom_site.disorder_assembly
+
+    _definition.id                '_atom_site.disorder_assembly'
+    _alias.definition_id          '_atom_site_disorder_assembly'
+    _definition.update            2023-01-29
+    _description.text
+;
+    A code which identifies a cluster of atoms that show long range disorder
+    but are locally ordered. Within each such cluster of atoms,
+    _atom_site.disorder_group is used to identify the sites that are
+    simultaneously occupied. This field is only needed if there is more than
+    one cluster of disordered atoms showing independent local order.
+;
+    _name.category_id             atom_site
+    _name.object_id               disorder_assembly
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         A
+;
+         Disordered methyl assembly with groups 1 and 2.
+;
+         B
+;
+         Disordered sites related by a mirror.
+;
+         C
+;
+         Assembly with groups that describe alternative compositions of a
+         compositionally disordered site.
+;
+         S
+;
+         Disordered sites independent of symmetry.
+;
+
+save_
+
+save_atom_site.disorder_group
+
+    _definition.id                '_atom_site.disorder_group'
+    _alias.definition_id          '_atom_site_disorder_group'
+    _definition.update            2023-01-29
+    _description.text
+;
+    A code that identifies a group of disordered atom sites that are locally
+    simultaneously occupied. Atoms that are positionally disordered over two or
+    more sites (e.g. the H atoms of a methyl group that exists in two
+    orientations) should be assigned to two or more groups. Similarly, atoms
+    that describe a specific alternative composition of a compositionally
+    disordered site should be assigned to a distinct disorder group (e.g. a site
+    that is partially occupied by Mg and Mn atoms should be described by
+    assigning the Mg atom to one group and the Mn atom to another group). Sites
+    belonging to the same group are simultaneously occupied, but those belonging
+    to different groups are not. A minus prefix (e.g. "-1") is used to indicate
+    sites disordered about a special position.
+;
+    _name.category_id             atom_site
+    _name.object_id               disorder_group
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         1
+;
+         Unique disordered site in group 1.
+;
+         2
+;
+         Unique disordered site in group 2.
+;
+         3
+;
+         Group describes a specific alternative composition of a compositionally
+         disordered site.
+;
+         -1
+;
+         Symmetry-independent disordered site.'
+;
+
+save_
+
+save_atom_site.fract_x
+
+    _definition.id                '_atom_site.fract_x'
+    _alias.definition_id          '_atom_site_fract_x'
+    _name.category_id             atom_site
+    _name.object_id               fract_x
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_x_su
+
+    _definition.id                '_atom_site.fract_x_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_x_su'
+         '_atom_site.fract_x_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_x_su
+    _name.linked_item_id          '_atom_site.fract_x'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.fract_xyz
+
+    _definition.id                '_atom_site.fract_xyz'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Vector of atom site coordinates projected onto the crystal unit
+    cell as fractions of the cell lengths.
+;
+    _name.category_id             atom_site
+    _name.object_id               fract_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a  as  atom_site
+
+    _atom_site.fract_xyz =  [a.fract_x, a.fract_y, a.fract_z]
+;
+
+save_
+
+save_atom_site.fract_xyz_su
+
+    _definition.id                '_atom_site.fract_xyz_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_site.fract_xyz.
+;
+    _name.category_id             atom_site
+    _name.object_id               fract_xyz_su
+    _name.linked_item_id          '_atom_site.fract_xyz'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_site.fract_y
+
+    _definition.id                '_atom_site.fract_y'
+    _alias.definition_id          '_atom_site_fract_y'
+    _name.category_id             atom_site
+    _name.object_id               fract_y
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_y_su
+
+    _definition.id                '_atom_site.fract_y_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_y_su'
+         '_atom_site.fract_y_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_y_su
+    _name.linked_item_id          '_atom_site.fract_y'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.fract_z
+
+    _definition.id                '_atom_site.fract_z'
+    _alias.definition_id          '_atom_site_fract_z'
+    _name.category_id             atom_site
+    _name.object_id               fract_z
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_z_su
+
+    _definition.id                '_atom_site.fract_z_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_z_su'
+         '_atom_site.fract_z_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_z_su
+    _name.linked_item_id          '_atom_site.fract_z'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.label
+
+    _definition.id                '_atom_site.label'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_label'
+         '_atom_site.id'
+
+    _name.category_id             atom_site
+    _name.object_id               label
+
+    _import.get
+        [{'file':templ_attr.cif  'save':atom_site_label}]
+
+save_
+
+save_atom_site.label_component_0
+
+    _definition.id                '_atom_site.label_component_0'
+    _alias.definition_id          '_atom_site_label_component_0'
+    _name.category_id             atom_site
+    _name.object_id               label_component_0
+
+    _import.get
+        [{'file':templ_attr.cif  'save':label_component}]
+
+save_
+
+save_atom_site.label_component_1
+
+    _definition.id                '_atom_site.label_component_1'
+    _alias.definition_id          '_atom_site_label_component_1'
+    _name.category_id             atom_site
+    _name.object_id               label_component_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_2
+
+    _definition.id                '_atom_site.label_component_2'
+    _alias.definition_id          '_atom_site_label_component_2'
+    _name.category_id             atom_site
+    _name.object_id               label_component_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_3
+
+    _definition.id                '_atom_site.label_component_3'
+    _alias.definition_id          '_atom_site_label_component_3'
+    _name.category_id             atom_site
+    _name.object_id               label_component_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_4
+
+    _definition.id                '_atom_site.label_component_4'
+    _alias.definition_id          '_atom_site_label_component_4'
+    _name.category_id             atom_site
+    _name.object_id               label_component_4
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_5
+
+    _definition.id                '_atom_site.label_component_5'
+    _alias.definition_id          '_atom_site_label_component_5'
+    _name.category_id             atom_site
+    _name.object_id               label_component_5
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_6
+
+    _definition.id                '_atom_site.label_component_6'
+    _alias.definition_id          '_atom_site_label_component_6'
+    _name.category_id             atom_site
+    _name.object_id               label_component_6
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.occupancy
+
+    _definition.id                '_atom_site.occupancy'
+    _alias.definition_id          '_atom_site_occupancy'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The fraction of the atom type present at this site.
+    The sum of the occupancies of all the atom types at this site
+    may not significantly exceed 1.0 unless it is a dummy site. The
+    value must lie in the 99.97% Gaussian confidence interval
+    -3u =< x =< 1 + 3u. The _enumeration.range of 0.0:1.0 is thus
+    correctly interpreted as meaning (0.0 - 3u) =< x =< (1.0 + 3u).
+;
+    _name.category_id             atom_site
+    _name.object_id               occupancy
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_atom_site.occupancy_su
+
+    _definition.id                '_atom_site.occupancy_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_occupancy_su'
+         '_atom_site.occupancy_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of the fraction of the atom type
+    present at this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               occupancy_su
+    _name.linked_item_id          '_atom_site.occupancy'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_site.refinement_flags
+
+    _definition.id                '_atom_site.refinement_flags'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_atom_site.refinement_flags_posn'
+         2                        '_atom_site.refinement_flags_ADP'
+         3                        '_atom_site.refinement_flags_occupancy'
+
+    _alias.definition_id          '_atom_site_refinement_flags'
+    _definition.update            2021-09-24
+    _description.text
+;
+    A concatenated series of single-letter codes which indicate the
+    refinement restraints or constraints applied to this site. This
+    item should not be used. It has been replaced by
+    _atom_site.refinement_flags_posn, _ADP and _occupancy. It is
+    retained in this dictionary only to provide compatibility with
+    legacy CIFs.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         S                      'Special position constraint on site.'
+         G                      'Rigid group refinement of site.'
+         R                      'Riding-atom site attached to non-riding atom.'
+         D                      'Distance or angle restraint on site.'
+         T                      'Thermal displacement constraints.'
+         U                      'Uiso or Uij restraint (rigid bond).'
+         P                      'Partial occupancy constraint.'
+         .                      'No refinement constraints.'
+
+save_
+
+save_atom_site.refinement_flags_adp
+
+    _definition.id                '_atom_site.refinement_flags_ADP'
+    _alias.definition_id          '_atom_site_refinement_flags_ADP'
+    _definition.update            2021-09-24
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the atomic displacement parameters of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_ADP
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .    'No constraints on atomic displacement parameters.'
+         T    'Special-position constraints on atomic displacement parameters.'
+         U    'Uiso or Uij restraint (rigid bond).'
+         TU   'Both constraints applied.'
+
+save_
+
+save_atom_site.refinement_flags_occupancy
+
+    _definition.id                '_atom_site.refinement_flags_occupancy'
+    _alias.definition_id          '_atom_site_refinement_flags_occupancy'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the occupancy of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_occupancy
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .                       'No constraints on site-occupancy parameters.'
+         P                       'Site-occupancy constraint.'
+
+save_
+
+save_atom_site.refinement_flags_posn
+
+    _definition.id                '_atom_site.refinement_flags_posn'
+    _alias.definition_id          '_atom_site_refinement_flags_posn'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the positional coordinates of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_posn
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .             'No constraints on positional coordinates.'
+         D             'Distance or angle restraint on positional coordinates.'
+         G             'Rigid-group refinement of positional coordinates.'
+         R             'Riding-atom site attached to non-riding atom.'
+         S             'Special-position constraint on positional coordinates.'
+         DG            'Combination of the above constraints.'
+         DR            'Combination of the above constraints.'
+         DS            'Combination of the above constraints.'
+         GR            'Combination of the above constraints.'
+         GS            'Combination of the above constraints.'
+         RS            'Combination of the above constraints.'
+         DGR           'Combination of the above constraints.'
+         DGS           'Combination of the above constraints.'
+         DRS           'Combination of the above constraints.'
+         GRS           'Combination of the above constraints.'
+         DGRS          'Combination of the above constraints.'
+
+save_
+
+save_atom_site.restraints
+
+    _definition.id                '_atom_site.restraints'
+    _alias.definition_id          '_atom_site_restraints'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of restraints applied to specific parameters at
+    this site during refinement. See also _atom_site.refinement_flags_*
+    and _refine_ls.number_restraints.
+;
+    _name.category_id             atom_site
+    _name.object_id               restraints
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'restrained to planar ring'
+
+save_
+
+save_atom_site.site_symmetry_multiplicity
+
+    _definition.id                '_atom_site.site_symmetry_multiplicity'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_site_symmetry_multiplicity'
+         '_atom_site_symmetry_multiplicity'
+         '_atom_site.symmetry_multiplicity'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    The number of different sites that are generated by the
+    application of the space-group symmetry to the coordinates
+    given for this site. It is equal to the multiplicity given
+    for this Wyckoff site in International Tables for Cryst.
+    Vol. A (2002). It is equal to the multiplicity of the general
+    position divided by the order of the site symmetry given in
+    _atom_site.site_symmetry_order.
+
+    The _atom_site_symmetry_multiplicity form of this data name is
+    deprecated because of historical inconsistencies in practice among
+    structure refinement software packages and should not be used.
+;
+    _name.category_id             atom_site
+    _name.object_id               site_symmetry_multiplicity
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With  a  as  atom_site
+
+        mul  =   0
+        xyz  =   a.fract_xyz
+
+          Loop  s  as  space_group_symop  {
+             sxyz  =   s.R * xyz + s.T
+             diff  =   Mod( 99.5 + xyz - sxyz, 1.0) - 0.5
+             If ( Norm ( diff ) < 0.1 ) mul +=  1
+       }
+    _atom_site.site_symmetry_multiplicity =  _space_group.multiplicity / mul
+;
+
+save_
+
+save_atom_site.site_symmetry_order
+
+    _definition.id                '_atom_site.site_symmetry_order'
+    _alias.definition_id          '_atom_site_site_symmetry_order'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of times application of the crystallographic symmetry
+    to the coordinates for this site generates the same coordinates.
+    That is:
+            multiplicity of the general position
+            ------------------------------------
+            _atom_site.site_symmetry_multiplicity
+;
+    _name.category_id             atom_site
+    _name.object_id               site_symmetry_order
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:48
+    _units.code                   none
+
+save_
+
+save_atom_site.structure_id
+
+    _definition.id                '_atom_site.structure_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    Identifier for the structure to which the atom site belongs.
+;
+    _name.category_id             atom_site
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site.type_symbol
+
+    _definition.id                '_atom_site.type_symbol'
+    _alias.definition_id          '_atom_site_type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    A code to identify the atom specie(s) occupying this site.
+    This code must match a corresponding _atom_type.symbol. The
+    specification of this code is optional if component_0 of the
+    _atom_site.label is used for this purpose. See _atom_type.symbol.
+;
+    _name.category_id             atom_site
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         Cu
+         Cu2+
+         S
+         O1-
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_site.type_symbol  =   AtomType ( _atom_site.label )
+;
+
+save_
+
+save_atom_site.u_equiv_geom_mean
+
+    _definition.id                '_atom_site.U_equiv_geom_mean'
+    _alias.definition_id          '_atom_site_U_equiv_geom_mean'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Equivalent isotropic atomic displacement parameter, U(equiv),
+    in angstroms squared, calculated as the geometric mean of
+    the anisotropic atomic displacement parameters.
+
+               U(equiv) = (U~i~ U~j~ U~k~)^1/3^
+
+    U~n~ = the principal components of the orthogonalised U^ij^
+;
+    _name.category_id             atom_site
+    _name.object_id               U_equiv_geom_mean
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.u_equiv_geom_mean_su
+
+    _definition.id                '_atom_site.U_equiv_geom_mean_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_U_equiv_geom_mean_su'
+         '_atom_site.U_equiv_geom_mean_esd'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Standard uncertainty values (esds) of the U(equiv).
+;
+    _name.category_id             atom_site
+    _name.object_id               U_equiv_geom_mean_su
+    _name.linked_item_id          '_atom_site.U_equiv_geom_mean'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.u_iso_or_equiv
+
+    _definition.id                '_atom_site.U_iso_or_equiv'
+    _alias.definition_id          '_atom_site_U_iso_or_equiv'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Isotropic atomic displacement parameter, or equivalent isotropic
+    atomic displacement parameter, U(equiv), in angstroms squared,
+    calculated from anisotropic atomic displacement parameters.
+
+       U(equiv) = (1/3) sum~i~[sum~j~(U^ij^ a*~i~ a*~j~ a~i~.a~j~)]
+
+    a  = the real-space cell vectors
+    a* = the reciprocal-space cell lengths
+    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
+;
+    _name.category_id             atom_site
+    _name.object_id               U_iso_or_equiv
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.u_iso_or_equiv_su
+
+    _definition.id                '_atom_site.U_iso_or_equiv_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_U_iso_or_equiv_su'
+         '_atom_site.U_iso_or_equiv_esd'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Standard uncertainty values (esds) of the U(iso) or U(equiv).
+;
+    _name.category_id             atom_site
+    _name.object_id               U_iso_or_equiv_su
+    _name.linked_item_id          '_atom_site.U_iso_or_equiv'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.wyckoff_symbol
+
+    _definition.id                '_atom_site.Wyckoff_symbol'
+    _alias.definition_id          '_atom_site_Wyckoff_symbol'
+    _definition.update            2021-09-23
+    _description.text
+;
+    The Wyckoff symbol (letter) as listed in the space-group section
+    of International Tables for Crystallography, Vol. A (1987).
+;
+    _name.category_id             atom_site
+    _name.object_id               Wyckoff_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    _import.get
+        [{'file':templ_enum.cif  'save':wyckoff_letter}]
+
+save_
+
+save_ATOM_SITE_ANISO
+
+    _definition.id                ATOM_SITE_ANISO
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the anisotropic atomic
+    displacement parameters of the atomic sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITE
+    _name.object_id               ATOM_SITE_ANISO
+
+    loop_
+      _category_key.name
+         '_atom_site_aniso.label'
+         '_atom_site_aniso.structure_id'
+
+save_
+
+save_atom_site_aniso.b_11
+
+    _definition.id                '_atom_site_aniso.B_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_11'
+         '_atom_site.aniso_B[1][1]'
+         '_atom_site_anisotrop.B[1][1]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_11_su
+
+    _definition.id                '_atom_site_aniso.B_11_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_11_su'
+         '_atom_site.aniso_B[1][1]_esd'
+         '_atom_site_anisotrop.B[1][1]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_11_su
+    _name.linked_item_id          '_atom_site_aniso.B_11'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_12
+
+    _definition.id                '_atom_site_aniso.B_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_12'
+         '_atom_site.aniso_B[1][2]'
+         '_atom_site_anisotrop.B[1][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_12_su
+
+    _definition.id                '_atom_site_aniso.B_12_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_12_su'
+         '_atom_site.aniso_B[1][2]_esd'
+         '_atom_site_anisotrop.B[1][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_12_su
+    _name.linked_item_id          '_atom_site_aniso.B_12'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_13
+
+    _definition.id                '_atom_site_aniso.B_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_13'
+         '_atom_site.aniso_B[1][3]'
+         '_atom_site_anisotrop.B[1][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_13_su
+
+    _definition.id                '_atom_site_aniso.B_13_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_13_su'
+         '_atom_site.aniso_B[1][3]_esd'
+         '_atom_site_anisotrop.B[1][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_13_su
+    _name.linked_item_id          '_atom_site_aniso.B_13'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_22
+
+    _definition.id                '_atom_site_aniso.B_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_22'
+         '_atom_site.aniso_B[2][2]'
+         '_atom_site_anisotrop.B[2][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_22_su
+
+    _definition.id                '_atom_site_aniso.B_22_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_22_su'
+         '_atom_site.aniso_B[2][2]_esd'
+         '_atom_site_anisotrop.B[2][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_22_su
+    _name.linked_item_id          '_atom_site_aniso.B_22'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_23
+
+    _definition.id                '_atom_site_aniso.B_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_23'
+         '_atom_site.aniso_B[2][3]'
+         '_atom_site_anisotrop.B[2][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_23_su
+
+    _definition.id                '_atom_site_aniso.B_23_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_23_su'
+         '_atom_site.aniso_B[2][3]_esd'
+         '_atom_site_anisotrop.B[2][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_23_su
+    _name.linked_item_id          '_atom_site_aniso.B_23'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_33
+
+    _definition.id                '_atom_site_aniso.B_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_33'
+         '_atom_site.aniso_B[3][3]'
+         '_atom_site_anisotrop.B[3][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_33_su
+
+    _definition.id                '_atom_site_aniso.B_33_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_33_su'
+         '_atom_site.aniso_B[3][3]_esd'
+         '_atom_site_anisotrop.B[3][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_33_su
+    _name.linked_item_id          '_atom_site_aniso.B_33'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.beta_11
+
+    _definition.id                '_atom_site_aniso.beta_11'
+    _alias.definition_id          '_atom_site_aniso_beta_11'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_11_su
+
+    _definition.id                '_atom_site_aniso.beta_11_su'
+    _alias.definition_id          '_atom_site_aniso_beta_11_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_11_su
+    _name.linked_item_id          '_atom_site_aniso.beta_11'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_12
+
+    _definition.id                '_atom_site_aniso.beta_12'
+    _alias.definition_id          '_atom_site_aniso_beta_12'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_12_su
+
+    _definition.id                '_atom_site_aniso.beta_12_su'
+    _alias.definition_id          '_atom_site_aniso_beta_12_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_12_su
+    _name.linked_item_id          '_atom_site_aniso.beta_12'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_13
+
+    _definition.id                '_atom_site_aniso.beta_13'
+    _alias.definition_id          '_atom_site_aniso_beta_13'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_13_su
+
+    _definition.id                '_atom_site_aniso.beta_13_su'
+    _alias.definition_id          '_atom_site_aniso_beta_13_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_13_su
+    _name.linked_item_id          '_atom_site_aniso.beta_13'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_22
+
+    _definition.id                '_atom_site_aniso.beta_22'
+    _alias.definition_id          '_atom_site_aniso_beta_22'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_22_su
+
+    _definition.id                '_atom_site_aniso.beta_22_su'
+    _alias.definition_id          '_atom_site_aniso_beta_22_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_22_su
+    _name.linked_item_id          '_atom_site_aniso.beta_22'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_23
+
+    _definition.id                '_atom_site_aniso.beta_23'
+    _alias.definition_id          '_atom_site_aniso_beta_23'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_23_su
+
+    _definition.id                '_atom_site_aniso.beta_23_su'
+    _alias.definition_id          '_atom_site_aniso_beta_23_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_23_su
+    _name.linked_item_id          '_atom_site_aniso.beta_23'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_33
+
+    _definition.id                '_atom_site_aniso.beta_33'
+    _alias.definition_id          '_atom_site_aniso_beta_33'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_33_su
+
+    _definition.id                '_atom_site_aniso.beta_33_su'
+    _alias.definition_id          '_atom_site_aniso_beta_33_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_33_su
+    _name.linked_item_id          '_atom_site_aniso.beta_33'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.label
+
+    _definition.id                '_atom_site_aniso.label'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_label'
+         '_atom_site_anisotrop.id'
+
+    _definition.update            2019-04-03
+    _description.text
+;
+    Anisotropic atomic displacement parameters are usually looped in
+    a separate list. If this is the case, this code must match the
+    _atom_site.label of the associated atom in the atom coordinate
+    list and conform with the same rules described in _atom_site.label.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               label
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site_aniso.matrix_b
+
+    _definition.id                '_atom_site_aniso.matrix_B'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The symmetric anisotropic atomic displacement matrix B.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_B
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+     a.matrix_B =  [[ a.B_11, a.B_12, a.B_13 ],
+                    [ a.B_12, a.B_22, a.B_23 ],
+                    [ a.B_13, a.B_23, a.B_33 ]]
+;
+
+save_
+
+save_atom_site_aniso.matrix_b_su
+
+    _definition.id                '_atom_site_aniso.matrix_B_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_B.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_B_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_B'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site_aniso.matrix_beta
+
+    _definition.id                '_atom_site_aniso.matrix_beta'
+    _alias.definition_id          '_atom_site.tensor_beta'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The symmetric anisotropic atomic displacement parameter (ADP) matrix, β,
+    which appears in a structure factor expression.
+
+    The contribution of the ADPs to the calculation of the structure factor is
+    given as:
+
+        T = exp(-1 * Sum(Sum(β^ij^ * h~i~ * h~j~, j=1:3), i=1:3))
+
+    where β^ij^ are the matrix elements, and h~m~ are the Miller indices.
+
+    The ADP matrix β, is related to the ADP matrices U and B, as follows:
+
+                |a~1~*   0     0  |   |t^11^ t^12^ t^13^|   |a~1~*   0     0  |
+        β = C * |  0   a~2~*   0  | * |t^12^ t^22^ t^23^| * |  0   a~2~*   0  |
+                |  0     0   a~3~*|   |t^13^ t^23^ t^33^|   |  0     0   a~3~*|
+
+    where C is a constant (2 * π^2^ for U, and 0.25 for B), a~i~* is the
+    length of the respective reciprocal unit cell vector, and t represents
+    the individual anisotropic values, U^ij^ or B^ij^.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_beta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+        label = a.label
+
+        If (a.ADP_type == 'betaani')
+        {
+            a.matrix_beta =  [[ a.beta_11, a.beta_12, a.beta_13 ],
+                              [ a.beta_12, a.beta_22, a.beta_23 ],
+                              [ a.beta_13, a.beta_23, a.beta_33 ]]
+        }
+        Else
+        {
+            If (a.ADP_type == 'Uani')
+            {
+                UIJ = b.matrix_U
+            }
+            Else If (a.ADP_type == 'Bani')
+            {
+                UIJ = b.matrix_B / (8 * Pi**2)
+            }
+            Else {
+                If (a.ADP_type == 'Uiso')
+                {
+                    Loop b as atom_site
+                    {
+                        If(label == b.label)
+                        {
+                            U  =  b.U_iso_or_equiv
+                            Break
+                        }
+                    }
+                }
+                Else If (a.ADP_type == 'Biso')
+                {
+                    Loop b as atom_site
+                    {
+                        If(label == b.label)
+                        {
+                            U  = b.B_iso_or_equiv / (8 * Pi**2)
+                            Break
+                        }
+                    }
+                }
+                UIJ = U * _cell.convert_Uiso_to_Uij
+            }
+            CUB = _cell.convert_Uij_to_betaij
+            a.matrix_beta =  CUB * UIJ * CUB
+        }
+;
+
+save_
+
+save_atom_site_aniso.matrix_beta_su
+
+    _definition.id                '_atom_site_aniso.matrix_beta_su'
+    _alias.definition_id          '_atom_site.tensor_beta_su'
+    _definition.update            2023-02-15
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_beta.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_beta_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_beta'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_site_aniso.matrix_u
+
+    _definition.id                '_atom_site_aniso.matrix_U'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The symmetric anisotropic atomic displacement matrix U.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_U
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+       a.matrix_U =  [[ a.U_11, a.U_12, a.U_13 ],
+                      [ a.U_12, a.U_22, a.U_23 ],
+                      [ a.U_13, a.U_23, a.U_33 ]]
+;
+
+save_
+
+save_atom_site_aniso.matrix_u_su
+
+    _definition.id                '_atom_site_aniso.matrix_U_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_U.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_U_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_U'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site_aniso.ratio
+
+    _definition.id                '_atom_site_aniso.ratio'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_ratio'
+         '_atom_site_anisotrop.ratio'
+         '_atom_site.aniso_ratio'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    Ratio of the maximum to minimum eigenvalues of the atomic displacement
+    ellipsoids.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               ratio
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   none
+
+save_
+
+save_atom_site_aniso.structure_id
+
+    _definition.id                '_atom_site_aniso.structure_id'
+    _definition.update            2023-07-06
+    _description.text
+;
+    Identifier for the structure to which the atom site belongs.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               structure_id
+    _name.linked_item_id          '_atom_site.structure_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site_aniso.type_symbol
+
+    _definition.id                '_atom_site_aniso.type_symbol'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_type_symbol'
+         '_atom_site_anisotrop.type_symbol'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    This _atom_type.symbol code links the anisotropic atomic displacement
+    parameters to the atom type data associated with this site and must match
+    one of the _atom_type.symbol codes in this list.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_site_aniso.type_symbol  =   AtomType ( _atom_site_aniso.label )
+;
+
+save_
+
+save_atom_site_aniso.u_11
+
+    _definition.id                '_atom_site_aniso.U_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_11'
+         '_atom_site.aniso_U[1][1]'
+         '_atom_site_anisotrop.U[1][1]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_11_su
+
+    _definition.id                '_atom_site_aniso.U_11_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_11_su'
+         '_atom_site.aniso_U[1][1]_esd'
+         '_atom_site_anisotrop.U[1][1]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_11_su
+    _name.linked_item_id          '_atom_site_aniso.U_11'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_12
+
+    _definition.id                '_atom_site_aniso.U_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_12'
+         '_atom_site.aniso_U[1][2]'
+         '_atom_site_anisotrop.U[1][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_12_su
+
+    _definition.id                '_atom_site_aniso.U_12_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_12_su'
+         '_atom_site.aniso_U[1][2]_esd'
+         '_atom_site_anisotrop.U[1][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_12_su
+    _name.linked_item_id          '_atom_site_aniso.U_12'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_13
+
+    _definition.id                '_atom_site_aniso.U_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_13'
+         '_atom_site.aniso_U[1][3]'
+         '_atom_site_anisotrop.U[1][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_13_su
+
+    _definition.id                '_atom_site_aniso.U_13_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_13_su'
+         '_atom_site.aniso_U[1][3]_esd'
+         '_atom_site_anisotrop.U[1][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_13_su
+    _name.linked_item_id          '_atom_site_aniso.U_13'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_22
+
+    _definition.id                '_atom_site_aniso.U_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_22'
+         '_atom_site.aniso_U[2][2]'
+         '_atom_site_anisotrop.U[2][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_22_su
+
+    _definition.id                '_atom_site_aniso.U_22_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_22_su'
+         '_atom_site.aniso_U[2][2]_esd'
+         '_atom_site_anisotrop.U[2][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_22_su
+    _name.linked_item_id          '_atom_site_aniso.U_22'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_23
+
+    _definition.id                '_atom_site_aniso.U_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_23'
+         '_atom_site.aniso_U[2][3]'
+         '_atom_site_anisotrop.U[2][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_23_su
+
+    _definition.id                '_atom_site_aniso.U_23_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_23_su'
+         '_atom_site.aniso_U[2][3]_esd'
+         '_atom_site_anisotrop.U[2][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_23_su
+    _name.linked_item_id          '_atom_site_aniso.U_23'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_33
+
+    _definition.id                '_atom_site_aniso.U_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_33'
+         '_atom_site.aniso_U[3][3]'
+         '_atom_site_anisotrop.U[3][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_33_su
+
+    _definition.id                '_atom_site_aniso.U_33_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_33_su'
+         '_atom_site.aniso_U[3][3]_esd'
+         '_atom_site_anisotrop.U[3][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_33_su
+    _name.linked_item_id          '_atom_site_aniso.U_33'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_ATOM_SITES
+
+    _definition.id                ATOM_SITES
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to describe information which applies
+    to all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITES
+
+save_
+
+save_atom_sites.solution_hydrogens
+
+    _definition.id                '_atom_sites.solution_hydrogens'
+    _alias.definition_id          '_atom_sites_solution_hydrogens'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_hydrogens
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         mixed
+;
+         A mixture of "geom" and "difmap".
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.solution_primary
+
+    _definition.id                '_atom_sites.solution_primary'
+    _alias.definition_id          '_atom_sites_solution_primary'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_primary
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.solution_secondary
+
+    _definition.id                '_atom_sites.solution_secondary'
+    _alias.definition_id          '_atom_sites_solution_secondary'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_secondary
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.special_details
+
+    _definition.id                '_atom_sites.special_details'
+    _alias.definition_id          '_atom_sites_special_details'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Information about atomic coordinates not coded elsewhere in the CIF.
+;
+    _name.category_id             atom_sites
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_ATOM_SITES_CARTN_TRANSFORM
+
+    _definition.id                ATOM_SITES_CARTN_TRANSFORM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2021-03-03
+    _description.text
+;
+    The CATEGORY of data items used to describe the matrix elements
+    used to transform fractional coordinates into Cartesian coordinates
+    of all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITES
+    _name.object_id               ATOM_SITES_CARTN_TRANSFORM
+
+save_
+
+save_atom_sites_cartn_transform.axes
+
+    _definition.id                '_atom_sites_Cartn_transform.axes'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_transform_axes'
+         '_atom_sites.Cartn_transform_axes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of the relative alignment of the crystal cell axes to the
+    Cartesian orthogonal axes as applied in the transformation matrix
+    _atom_sites_Cartn_transform.matrix.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               axes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'a parallel to x; b in the plane of x & y'
+
+save_
+
+save_atom_sites_cartn_transform.mat_11
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_11'
+         '_atom_sites.Cartn_transf_matrix[1][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c as cell
+
+    _enumeration.default =
+    c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_11_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_11_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_11.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_11_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_11'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_12
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_12'
+         '_atom_sites.Cartn_transf_matrix[1][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_12_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_12_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_12.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_12_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_12'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_13
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_13'
+         '_atom_sites.Cartn_transf_matrix[1][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_13_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_13_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_13.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_13_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_13'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_21
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_21'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_21'
+         '_atom_sites.Cartn_transf_matrix[2][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_21
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     with c as cell
+
+    _enumeration.default =
+    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_21_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_21_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_21.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_21_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_21'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_22
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_22'
+         '_atom_sites.Cartn_transf_matrix[2][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_b * Sind(c.angle_alpha)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_22_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_22_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_22.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_22_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_22'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_23
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_23'
+         '_atom_sites.Cartn_transf_matrix[2][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_23_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_23_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_23.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_23_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_23'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_31
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_31'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_31'
+         '_atom_sites.Cartn_transf_matrix[3][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_31
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_a * Cosd(c.angle_beta)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_31_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_31_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_31.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_31_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_31'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_32
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_32'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_32'
+         '_atom_sites.Cartn_transf_matrix[3][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_32
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_b * Cosd(c.angle_alpha)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_32_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_32_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_32.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_32_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_32'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_33
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_33'
+         '_atom_sites.Cartn_transf_matrix[3][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  _cell.length_c
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_33_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_33_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_33.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_33_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_33'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.matrix
+
+    _definition.id                '_atom_sites_Cartn_transform.matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Matrix used to transform fractional coordinates in the ATOM_SITE
+    category to Cartesian coordinates. The axial alignments of this
+    transformation are described in _atom_sites_Cartn_transform.axes.
+    The 3 x 1 translation is defined in _atom_sites_Cartn_transform.vector.
+
+      x'                   |11 12 13|     x                  | 1 |
+    ( y' ) Cartesian   =   |21 22 23| * ( y ) fractional  + v| 2 |
+      z'                   |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial
+    assignments with cell vectors a,b,c aligned with orthogonal
+    axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_sites_Cartn_transform
+
+    _atom_sites_Cartn_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
+                                          [a.mat_21, a.mat_22, a.mat_23],
+                                          [a.mat_31, a.mat_32, a.mat_33]]
+;
+
+save_
+
+save_atom_sites_cartn_transform.matrix_su
+
+    _definition.id                '_atom_sites_Cartn_transform.matrix_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.matrix.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_atom_sites_cartn_transform.vec_1
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_1'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_1'
+         '_atom_sites.Cartn_transf_vector[1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_1_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_1_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_1.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_1_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_1'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_2
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_2'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_2'
+         '_atom_sites.Cartn_transf_vector[2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_2_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_2_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_2.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_2_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_2'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_3
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_3'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_3'
+         '_atom_sites.Cartn_transf_vector[3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_3_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_3_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_3.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_3_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_3'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vector
+
+    _definition.id                '_atom_sites_Cartn_transform.vector'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The 3x1 translation is used with _atom_sites_Cartn_transform.matrix
+    used to transform fractional coordinates to Cartesian coordinates.
+    The axial alignments of this transformation are described in
+    _atom_sites_Cartn_transform.axes.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vector
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t as atom_sites_Cartn_transform
+
+    _atom_sites_Cartn_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
+;
+
+save_
+
+save_atom_sites_cartn_transform.vector_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vector_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vector.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_ATOM_SITES_FRACT_TRANSFORM
+
+    _definition.id                ATOM_SITES_FRACT_TRANSFORM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2021-03-03
+    _description.text
+;
+    The CATEGORY of data items used to describe the matrix elements
+    used to transform Cartesian coordinates into fractional coordinates
+    of all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITES
+    _name.object_id               ATOM_SITES_FRACT_TRANSFORM
+
+save_
+
+save_atom_sites_fract_transform.axes
+
+    _definition.id                '_atom_sites_fract_transform.axes'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_transform_axes'
+         '_atom_sites.fract_transform_axes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of the relative alignment of the crystal cell axes to the
+    Cartesian orthogonal axes as applied in the transformation matrix
+    _atom_sites_fract_transform.matrix.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               axes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'a parallel to x; b in the plane of x & y'
+
+save_
+
+save_atom_sites_fract_transform.mat_11
+
+    _definition.id                '_atom_sites_fract_transform.mat_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_11'
+         '_atom_sites.fract_transf_matrix[1][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_11_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_11_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_11.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_11_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_11'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_12
+
+    _definition.id                '_atom_sites_fract_transform.mat_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_12'
+         '_atom_sites.fract_transf_matrix[1][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_12_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_12_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_12.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_12_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_12'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_13
+
+    _definition.id                '_atom_sites_fract_transform.mat_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_13'
+         '_atom_sites.fract_transf_matrix[1][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_13_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_13_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_13.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_13_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_13'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_21
+
+    _definition.id                '_atom_sites_fract_transform.mat_21'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_21'
+         '_atom_sites.fract_transf_matrix[2][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_21
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_21_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_21_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_21.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_21_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_21'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_22
+
+    _definition.id                '_atom_sites_fract_transform.mat_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_22'
+         '_atom_sites.fract_transf_matrix[2][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_22_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_22_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_22.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_22_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_22'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_23
+
+    _definition.id                '_atom_sites_fract_transform.mat_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_23'
+         '_atom_sites.fract_transf_matrix[2][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_23_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_23_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_23.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_23_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_23'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_31
+
+    _definition.id                '_atom_sites_fract_transform.mat_31'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_31'
+         '_atom_sites.fract_transf_matrix[3][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_31
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_31_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_31_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_31.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_31_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_31'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_32
+
+    _definition.id                '_atom_sites_fract_transform.mat_32'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_32'
+         '_atom_sites.fract_transf_matrix[3][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_32
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_32_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_32_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_32.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_32_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_32'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_33
+
+    _definition.id                '_atom_sites_fract_transform.mat_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_33'
+         '_atom_sites.fract_transf_matrix[3][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_33_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_33_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_33.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_33_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_33'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.matrix
+
+    _definition.id                '_atom_sites_fract_transform.matrix'
+    _definition.update            2021-07-21
+    _description.text
+;
+    Matrix used to transform Cartesian coordinates in the ATOM_SITE
+    category to fractional coordinates. The axial alignments of this
+    transformation are described in _atom_sites_fract_transform.axes.
+    The 3 x 1 translation is defined in _atom_sites_fract_transform.vector.
+
+      x'                   |11 12 13|     x                  | 1 |
+    ( y' )fractional = mat |21 22 23| * ( y ) Cartesian + vec| 2 |
+      z'                   |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial
+    assignments with cell vectors a,b,c aligned with orthogonal
+    axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_sites_fract_transform
+
+    _atom_sites_fract_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
+                                          [a.mat_21, a.mat_22, a.mat_23],
+                                          [a.mat_31, a.mat_32, a.mat_33]]
+;
+
+save_
+
+save_atom_sites_fract_transform.matrix_su
+
+    _definition.id                '_atom_sites_fract_transform.matrix_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.matrix.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_fract_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_sites_fract_transform.vec_1
+
+    _definition.id                '_atom_sites_fract_transform.vec_1'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_1'
+         '_atom_sites.fract_transf_vector[1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_1_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_1_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_1.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_1_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_1'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vec_2
+
+    _definition.id                '_atom_sites_fract_transform.vec_2'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_2'
+         '_atom_sites.fract_transf_vector[2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_2_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_2_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_2.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_2_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_2'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vec_3
+
+    _definition.id                '_atom_sites_fract_transform.vec_3'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_3'
+         '_atom_sites.fract_transf_vector[3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_3_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_3_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_3.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_3_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_3'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vector
+
+    _definition.id                '_atom_sites_fract_transform.vector'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The 3x1 translation is used with _atom_sites_fract_transform.matrix
+    used to transform Cartesian coordinates to fractional coordinates.
+    The axial alignments of this transformation are described in
+    _atom_sites_fract_transform.axes.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vector
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t as atom_sites_fract_transform
+
+    _atom_sites_fract_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
+;
+
+save_
+
+save_atom_sites_fract_transform.vector_su
+
+    _definition.id                '_atom_sites_fract_transform.vector_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vector.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_ATOM_TYPE
+
+    _definition.id                ATOM_TYPE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic type information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_TYPE
+    _category_key.name            '_atom_type.symbol'
+    _method.purpose               Evaluation
+    _method.expression
+;
+    typelist  = List()
+
+    Loop  a  as  atom_site  {
+       type = AtomType ( a.label )
+       If( type not in typelist )  typelist ++= type
+     }
+     For type in typelist {
+                             atom_type(.symbol         = type,
+                                       .number_in_cell = '?'   )
+     }
+;
+
+save_
+
+save_atom_type.analytical_mass_percent
+
+    _definition.id                '_atom_type.analytical_mass_percent'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_analytical_mass_%'
+         '_atom_type.analytical_mass_%'
+
+    _definition.update            2013-04-11
+    _description.text
+;
+    Mass percentage of this atom type derived from chemical analysis.
+;
+    _name.category_id             atom_type
+    _name.object_id               analytical_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_type.analytical_mass_percent_su
+
+    _definition.id                '_atom_type.analytical_mass_percent_su'
+    _definition.update            2021-09-23
+    _description.text
+;
+    Standard uncertainty of _atom_type.analytical_mass_percent.
+;
+    _name.category_id             atom_type
+    _name.object_id               analytical_mass_percent_su
+    _name.linked_item_id          '_atom_type.analytical_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_type.atomic_mass
+
+    _definition.id                '_atom_type.atomic_mass'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Mass of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               atomic_mass
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [{'file':templ_enum.cif  'save':atomic_mass}]
+
+save_
+
+save_atom_type.atomic_number
+
+    _definition.id                '_atom_type.atomic_number'
+    _definition.update            2023-06-01
+    _description.text
+;
+    Atomic number of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               atomic_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':atomic_number}]
+
+save_
+
+save_atom_type.description
+
+    _definition.id                '_atom_type.description'
+    _alias.definition_id          '_atom_type_description'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of the atom(s) designated by this atom type. In
+    most cases this will be the element name and oxidation state of
+    a single atom species. For disordered or nonstoichiometric
+    structures it will describe a combination of atom species.
+;
+    _name.category_id             atom_type
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         deuterium
+         0.34Fe+0.66Ni
+
+save_
+
+save_atom_type.display_colour
+
+    _definition.id                '_atom_type.display_colour'
+    _definition.update            2023-02-06
+    _description.text
+;
+    The display colour assigned to this atom type. Note that the
+    possible colours are enumerated in the DISPLAY_COLOUR list
+    category of items.
+;
+    _name.category_id             atom_type
+    _name.object_id               display_colour
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [
+                                   {'file':templ_enum.cif  'save':colour_rgb}
+                                   {'file':templ_enum.cif  'save':colour_hue}
+                                  ]
+
+save_
+
+save_atom_type.electron_count
+
+    _definition.id                '_atom_type.electron_count'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of electrons in this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               electron_count
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':electron_count}]
+
+save_
+
+save_atom_type.element_symbol
+
+    _definition.id                '_atom_type.element_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Element symbol for of this atom type. The default value is extracted
+    from the ion-to-element enumeration_default list using the index
+    value of _atom_type.symbol.
+;
+    _name.category_id             atom_type
+    _name.object_id               element_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get
+        [
+         {'file':templ_enum.cif  'save':element_symbol}
+         {'file':templ_enum.cif  'save':ion_to_element}
+        ]
+
+save_
+
+save_atom_type.key
+
+    _definition.id                '_atom_type.key'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Value is a unique key to a set of ATOM_TYPE items
+    in a looped list.
+;
+    _name.category_id             atom_type
+    _name.object_id               key
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_type.key = _atom_type.symbol
+;
+
+save_
+
+save_atom_type.mass_number
+
+    _definition.id                '_atom_type.mass_number'
+    _definition.update            2023-05-22
+    _description.text
+;
+    Mass number of this atom type.
+
+    Used to denote a specific isotope. Special value '.' indicates
+    that the element is present in natural isotopic abundance.
+;
+    _name.category_id             atom_type
+    _name.object_id               mass_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_atom_type.number_in_cell
+
+    _definition.id                '_atom_type.number_in_cell'
+    _alias.definition_id          '_atom_type_number_in_cell'
+    _definition.update            2013-01-28
+    _description.text
+;
+    Total number of atoms of this atom type in the unit cell.
+;
+    _name.category_id             atom_type
+    _name.object_id               number_in_cell
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as atom_type
+
+    cnt =  0.
+
+    Loop a  as  atom_site  {
+
+       if ( a.type_symbol == t.symbol ) {
+
+          cnt +=  a.occupancy * a.site_symmetry_multiplicity
+    }  }
+    _atom_type.number_in_cell =  cnt
+;
+
+save_
+
+save_atom_type.oxidation_number
+
+    _definition.id                '_atom_type.oxidation_number'
+    _alias.definition_id          '_atom_type_oxidation_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Formal oxidation state of this atom type in the structure.
+;
+    _name.category_id             atom_type
+    _name.object_id               oxidation_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            -8:8
+    _units.code                   none
+
+save_
+
+save_atom_type.radius_bond
+
+    _definition.id                '_atom_type.radius_bond'
+    _alias.definition_id          '_atom_type_radius_bond'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The effective intra-molecular bonding radius of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               radius_bond
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:5.0
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [{'file':templ_enum.cif  'save':radius_bond}]
+
+save_
+
+save_atom_type.radius_contact
+
+    _definition.id                '_atom_type.radius_contact'
+    _alias.definition_id          '_atom_type_radius_contact'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The effective inter-molecular bonding radius of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               radius_contact
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:5.0
+    _units.code                   angstroms
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _atom_type.radius_bond + 1.25
+;
+
+save_
+
+save_atom_type.symbol
+
+    _definition.id                '_atom_type.symbol'
+    _alias.definition_id          '_atom_type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    Normally this code is the element symbol followed by the charge
+    if there is one. The symbol may be composed of any character except
+    an underline or a blank, with the proviso that digits designate an
+    oxidation state and must be followed by a + or - character.
+;
+    _name.category_id             atom_type
+    _name.object_id               symbol
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         Mg
+         Cu2+
+         dummy
+         FeNi
+
+save_
+
+save_ATOM_TYPE_SCAT
+
+    _definition.id                ATOM_TYPE_SCAT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic scattering
+    information used in crystallographic structure studies.
+;
+    _name.category_id             ATOM_TYPE
+    _name.object_id               ATOM_TYPE_SCAT
+    _category_key.name            '_atom_type_scat.symbol'
+
+save_
+
+save_atom_type_scat.cromer_mann_a1
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a1'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a1'
+         '_atom_type.scat_Cromer_Mann_a1'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a1}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a2
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a2'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a2'
+         '_atom_type.scat_Cromer_Mann_a2'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a2}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a3
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a3'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a3'
+         '_atom_type.scat_Cromer_Mann_a3'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a3}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a4
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a4'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a4'
+         '_atom_type.scat_Cromer_Mann_a4'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a4
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a4}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b1
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b1'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b1'
+         '_atom_type.scat_Cromer_Mann_b1'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b1}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b2
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b2'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b2'
+         '_atom_type.scat_Cromer_Mann_b2'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b2}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b3
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b3'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b3'
+         '_atom_type.scat_Cromer_Mann_b3'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b3}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b4
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b4'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b4'
+         '_atom_type.scat_Cromer_Mann_b4'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b4
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b4}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_c
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_c'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_c'
+         '_atom_type.scat_Cromer_Mann_c'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_c
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_c}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_coeffs
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_coeffs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Cromer-Mann coefficients for generating X-ray scattering
+    factors. [ c, a1, b1, a2, b2, a3, b3, a4, b4 ]
+    Ref: International Tables for Crystallography, Vol. C
+            (1991) Table 6.1.1.4
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_coeffs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[9]'
+    _type.contents                Real
+    _units.code                   unspecified
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t  as  atom_type_scat
+
+     _atom_type_scat.Cromer_Mann_coeffs  =          [ t.Cromer_Mann_c,
+                                    t.Cromer_Mann_a1, t.Cromer_Mann_b1,
+                                    t.Cromer_Mann_a2, t.Cromer_Mann_b2,
+                                    t.Cromer_Mann_a3, t.Cromer_Mann_b3,
+                                    t.Cromer_Mann_a4, t.Cromer_Mann_b4 ]
+;
+
+save_
+
+save_atom_type_scat.dispersion
+
+    _definition.id                '_atom_type_scat.dispersion'
+    _definition.update            2013-04-28
+    _description.text
+;
+    The anomalous dispersion scattering factor in its complex form
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With s as atom_type_scat
+
+            d = Complex( s.dispersion_real, s.dispersion_imag )
+
+       if(_reflns.apply_dispersion_to_Fcalc == 'no')   d = 0.
+
+                _atom_type_scat.dispersion = d
+;
+
+save_
+
+save_atom_type_scat.dispersion_imag
+
+    _definition.id                '_atom_type_scat.dispersion_imag'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_imag'
+         '_atom_type.scat_dispersion_imag'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With q as atom_type_scat
+
+     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_imag_Cu
+     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_imag_Mo
+
+             _atom_type_scat.dispersion_imag = a
+;
+
+save_
+
+save_atom_type_scat.dispersion_imag_cu
+
+    _definition.id                '_atom_type_scat.dispersion_imag_Cu'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and Cu Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag_Cu
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_imag_cu}]
+
+save_
+
+save_atom_type_scat.dispersion_imag_mo
+
+    _definition.id                '_atom_type_scat.dispersion_imag_Mo'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and Mo Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag_Mo
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_imag_mo}]
+
+save_
+
+save_atom_type_scat.dispersion_real
+
+    _definition.id                '_atom_type_scat.dispersion_real'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_real'
+         '_atom_type.scat_dispersion_real'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With q as atom_type_scat
+
+     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_real_Cu
+     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_real_Mo
+
+             _atom_type_scat.dispersion_real = a
+;
+
+save_
+
+save_atom_type_scat.dispersion_real_cu
+
+    _definition.id                '_atom_type_scat.dispersion_real_Cu'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and Cu Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real_Cu
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_real_cu}]
+
+save_
+
+save_atom_type_scat.dispersion_real_mo
+
+    _definition.id                '_atom_type_scat.dispersion_real_Mo'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and Mo Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real_Mo
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_real_mo}]
+
+save_
+
+save_atom_type_scat.dispersion_source
+
+    _definition.id                '_atom_type_scat.dispersion_source'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_source'
+         '_atom_type.scat_dispersion_source'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Reference to source of real and imaginary dispersion
+    corrections for scattering factors used for this atom type.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_source
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'International Tables Vol. IV Table 2.3.1'
+
+save_
+
+save_atom_type_scat.exponential_polynomial_coefs
+
+    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of polynomial coefficients for generating X-ray scattering factors:
+    [ a_0, a_1, ... , a_N ].
+
+    f(s; Z) = exp(Sum(a~i~ * s^i^), i=0:N)
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.exponential_polynomial_coefs_su
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_coefs_su'
+    _definition.update            2023-06-16
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs_su
+    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.exponential_polynomial_lower_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.exponential_polynomial_upper_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.gaussian_coefs
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Gaussian coefficients for generating X-ray scattering factors:
+    [ c, a_1, b_1, a_2, b_2, ... , a_N, b_N ].
+
+    f(s; Z) = c + Sum(a~i~ * exp(-b~i~ * s^2^), i=1:N)
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.gaussian_coefs_su
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs_su'
+    _definition.update            2023-06-16
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.gaussian_lower_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.gaussian_upper_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c0
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c0'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c0
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c0}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c1
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c1'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c1}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c2
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c2'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c2}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c3
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c3'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c3}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_coeffs
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_coeffs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Fox et al. coefficients for generating high angle
+    X-ray scattering factors. [ c0, c1, c2, c3 ]
+    Ref: International Tables for Crystallography, Vol. C
+         (1991) Table 6.1.1.5
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_coeffs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[4]'
+    _type.contents                Real
+    _units.code                   unspecified
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t  as  atom_type_scat
+
+    _atom_type_scat.hi_ang_Fox_coeffs  =
+    [t.hi_ang_Fox_c0,t.hi_ang_Fox_c1,t.hi_ang_Fox_c2,t.hi_ang_Fox_c3]
+;
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_coefs
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Gaussian coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ e, c_1, d_1, c_2, d_2, ... , c_N, d_N ].
+
+    f(s; Z) =
+    Z - 8π * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z is the atomic number.
+    θ is the diffraction angle and λ is the wavelength of the incident
+    radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_coefs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs_su'
+    _definition.update            2023-06-16
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
+    _type.purpose                 SU
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_lower_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_upper_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.length_neutron
+
+    _definition.id                '_atom_type_scat.length_neutron'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_length_neutron'
+         '_atom_type.scat_length_neutron'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The bound coherent scattering length for the atom type at the
+    isotopic composition used for the diffraction experiment.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               length_neutron
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   femtometres
+
+save_
+
+save_atom_type_scat.source
+
+    _definition.id                '_atom_type_scat.source'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_source'
+         '_atom_type.scat_source'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Reference to source of scattering factors used for this atom type.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               source
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'International Tables Vol. IV Table 2.4.6B'
+
+save_
+
+save_atom_type_scat.symbol
+
+    _definition.id                '_atom_type_scat.symbol'
+    _alias.definition_id          '_atom_type_scat_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    See _atom_type.symbol for further details.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_type_scat.versus_stol_list
+
+    _definition.id                '_atom_type_scat.versus_stol_list'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_atom_scat_versus_stol.atom_type'
+         2                        '_atom_scat_versus_stol.stol_value'
+         3                        '_atom_scat_versus_stol.scat_value'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_versus_stol_list'
+         '_atom_type.scat_versus_stol_list'
+
+    _definition.update            2023-07-05
+    _description.text
+;
+    Deprecated. Data items from the ATOM_SCAT_VERSUS_STOL category should be
+    used instead of this item.
+
+    A table of scattering factors as a function of sin(θ)/λ (sin theta over
+    lambda, stol). This table should be well-commented to indicate the items
+    present. Regularly formatted lists are strongly recommended.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               versus_stol_list
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
 
 save_
 
@@ -11155,7 +16763,7 @@ save_SPACE_GROUP
     _name.category_id             EXPTL
     _name.object_id               SPACE_GROUP
     _category_key.name            '_space_group.id'
-        
+
 save_
 
 save_space_group.bravais_type
@@ -11265,6 +16873,23 @@ save_space_group.crystal_system
          trigonal
          hexagonal
          cubic
+
+save_
+
+save_space_group.id
+
+    _definition.id                '_space_group.id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    An arbitrary identifier for this space group description.
+;
+    _name.category_id             space_group
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -11745,23 +17370,6 @@ save_space_group.point_group_h-m
 
 save_
 
-save_space_group.id
-
-    _definition.id                '_space_group.id'
-    _definition.update            2023-07-10
-    _description.text
-;
-    An arbitrary identifier for this space group description.
-;
-    _name.category_id             space_group
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_symmetry.cell_setting
 
     _definition.id                '_symmetry.cell_setting'
@@ -11813,8 +17421,8 @@ save_SPACE_GROUP_GENERATOR
     _name.object_id               SPACE_GROUP_GENERATOR
     loop_
       _category_key.name
-        '_space_group_generator.key'
-        '_space_group_generator.space_group_id'
+         '_space_group_generator.key'
+         '_space_group_generator.space_group_id'
 
 save_
 
@@ -11916,8 +17524,8 @@ save_SPACE_GROUP_SYMOP
     _name.object_id               SPACE_GROUP_SYMOP
     loop_
       _category_key.name
-        '_space_group_symop.id'
-        '_space_group_symop.space_group_id'
+         '_space_group_symop.id'
+         '_space_group_symop.space_group_id'
 
 save_
 
@@ -12178,8 +17786,8 @@ save_SPACE_GROUP_WYCKOFF
     _name.object_id               SPACE_GROUP_WYCKOFF
     loop_
       _category_key.name
-        '_space_group_Wyckoff.id'
-        '_space_group_Wyckoff.space_group_id'
+         '_space_group_Wyckoff.id'
+         '_space_group_Wyckoff.space_group_id'
 
 save_
 
@@ -20015,5614 +25623,6 @@ save_structure.space_group_id
     _type.contents                Word
 
 save_
-    
-save_ATOM
-
-    _definition.id                ATOM
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2012-11-20
-    _description.text
-;
-    The CATEGORY of data items used to describe atomic information
-    used in crystallographic structure studies.
-;
-    _name.category_id             CIF_CORE
-    _name.object_id               ATOM
-
-save_
-
-save_ATOM_ANALYTICAL
-
-    _definition.id                ATOM_ANALYTICAL
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2022-11-19
-    _description.text
-;
-    The CATEGORY of data items used to describe elemental
-    composition information used in crystallographic
-    structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_ANALYTICAL
-    _category_key.name            '_atom_analytical.id'
-    _description_example.case
-;
-    loop_
-    _atom_analytical.id
-    _atom_analytical.analyte
-    _atom_analytical.meas_id
-    _atom_analytical.chemical_species
-    _atom_analytical.analyte_mass_percent
-    _atom_analytical.chemical_species_mass_percent
-    1 Si  a 'Si O2'   ?     22.7
-    2 Al  a 'Al2 O3'  ?     27.4
-    3 Ti  b 'Ti O2'   ?      2.7
-    4 Si  c .         10.5  .
-    5 Si  d Si        11.7  11.7
-;
-    _description_example.detail
-;
-    There are three separate determinations of Si content, and one each
-    of Al and Ti. The amount of Al is reported as the mass percent of
-    Al2O3. The equivalent amount of Al is not given. There are four
-    different measurements presented in this table.
-;
-
-save_
-
-save_atom_analytical.analyte
-
-    _definition.id                '_atom_analytical.analyte'
-    _definition.update            2022-11-19
-    _description.text
-;
-    Symbol of the element for which a particular composition
-    refers to, as given by _atom_analytical.analyte_mass_percent.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               analyte
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-    _import.get
-        [{'file':templ_enum.cif  'save':element_symbol}]
-
-save_
-
-save_atom_analytical.analyte_mass_percent
-
-    _definition.id                '_atom_analytical.analyte_mass_percent'
-    _definition.update            2022-11-19
-    _description.text
-;
-    Mass percentage of the analyte element derived from elemental analysis.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               analyte_mass_percent
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:100.0
-    _units.code                   none
-
-save_
-
-save_atom_analytical.analyte_mass_percent_su
-
-    _definition.id                '_atom_analytical.analyte_mass_percent_su'
-    _definition.update            2022-11-19
-    _description.text
-;
-    Standard uncertainty of _atom_analytical.analyte_mass_percent.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               analyte_mass_percent_su
-    _name.linked_item_id          '_atom_analytical.analyte_mass_percent'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_analytical.chemical_species
-
-    _definition.id                '_atom_analytical.chemical_species'
-    _definition.update            2023-01-13
-    _description.text
-;
-    Chemical formula of the species for which the corresponding
-    _atom_analytical.chemical_species_mass_percent refers.
-
-    The following rules apply in the construction of the formula:
-
-    1. Only recognized element symbols may be used.
-
-    2. The first element corresponds to the analyte. The remaining
-       elements should be given in alphabetical order by symbol.
-
-    3. Each element symbol is followed by a 'count' number. A count of
-       '1' may be omitted.
-
-    4. A space or parenthesis must separate each cluster of (element
-       symbol + count). A formula cannot begin with a paranthesis.
-
-    5. Where a group of elements is enclosed in parentheses, the
-       multiplier for the group must follow the closing parentheses.
-       That is, all element and group multipliers are assumed to be
-       printed as subscripted numbers.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               chemical_species
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'Fe2 O3'
-         'Li'
-         'Si O2'
-         'Ca S O4 (H2 O)2'
-
-save_
-
-save_atom_analytical.chemical_species_mass_percent
-
-    _definition.id
-        '_atom_analytical.chemical_species_mass_percent'
-    _definition.update            2022-11-19
-    _description.text
-;
-    Mass percentage of the chemical species given in
-    _atom_analytical.chemical_species as derived from elemental analysis.
-
-    This is most often used in elemental compositions determined by XRF,
-    where elements are reported as equivalent mass percentages of their
-    relevant oxide. For example: Al is reported as Al2O3, P is reported
-    as P2O5.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               chemical_species_mass_percent
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:100.0
-    _units.code                   none
-
-save_
-
-save_atom_analytical.chemical_species_mass_percent_su
-
-    _definition.id
-        '_atom_analytical.chemical_species_mass_percent_su'
-    _definition.update            2022-11-19
-    _description.text
-;
-    Standard uncertainty of _atom_analytical.chemical_species_mass_percent.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               chemical_species_mass_percent_su
-    _name.linked_item_id
-        '_atom_analytical.chemical_species_mass_percent'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_analytical.id
-
-    _definition.id                '_atom_analytical.id'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Arbitrary label uniquely identifying a single composition value.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_analytical.meas_id
-
-    _definition.id                '_atom_analytical.meas_id'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Arbitrary label identifying the source of an elemental composition.
-    This code must match the _atom_analytical_source.id of the associated
-    technique in the analytical source list.
-;
-    _name.category_id             atom_analytical
-    _name.object_id               meas_id
-    _name.linked_item_id          '_atom_analytical_source.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_ATOM_ANALYTICAL_MASS_LOSS
-
-    _definition.id                ATOM_ANALYTICAL_MASS_LOSS
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2022-11-21
-    _description.text
-;
-    The CATEGORY of data items used to describe information
-    pertaining to mass loss during specimen preparation for
-    the purposes of determining elemental composition
-    information for use in crystallographic structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_ANALYTICAL_MASS_LOSS
-    _category_key.name            '_atom_analytical_mass_loss.id'
-    _description_example.case
-;
-    loop_
-    _atom_analytical_mass_loss.id
-    _atom_analytical_mass_loss.meas_id
-    _atom_analytical_mass_loss.percent
-    _atom_analytical_mass_loss.temperature
-    LOD1 a   2  328
-    LOI1 a   5  623
-    LOI2 a  10 1023
-    LOI3 a  15 1373
-    LOI4 b   5  673
-    LOI5 b  10 1123
-;
-    _description_example.detail
-;
-    Four mass-loss percentages are given for measurement 'a', and two
-    for measurement 'b'. The mass losses were recorded after exposing
-    the specimen to the listed temperatures. The mass lost at a lower
-    temperature for the same measurement should be included in the
-    higher temperatures; that is, for measurement 'a', the total mass
-    loss after four measurements is 15 wt%, not (2+5+10+15) wt%.
-;
-
-save_
-
-save_atom_analytical_mass_loss.id
-
-    _definition.id                '_atom_analytical_mass_loss.id'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Arbitrary label uniquely identifying the source of an elemental
-    composition value. This value is used by _atom_analytical.meas_id
-    to link individual composition values to their corresponding
-    technique of determination.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_analytical_mass_loss.meas_id
-
-    _definition.id                '_atom_analytical_mass_loss.meas_id'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Arbitrary label identifying the source of an elemental composition.
-    This code must match the _atom_analytical_source.id of the associated
-    technique in the analytical source list.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               meas_id
-    _name.linked_item_id          '_atom_analytical_source.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_analytical_mass_loss.percent
-
-    _definition.id                '_atom_analytical_mass_loss.percent'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Mass lost by the specimen during specimen preparation expressed
-    as a percentage. The temperature at which the mass loss was recorded
-    is given by _atom_analytical_mass_loss.temperature. A mass gain
-    is represented by a negative value.
-
-    This data name would be used to record mass loss on drying, or mass
-    loss on ignition, during, for example, fusion bead preparation for
-    XRF analysis.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               percent
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   none
-
-    loop_
-      _description_example.case
-      _description_example.detail
-         12.5
-;
-         Represents a mass loss of 12.5 wt% upon exposure of the specimen
-         to the temperature given in _atom_analytical_mass_loss.temperature.
-;
-         -7.2
-;
-         Represents a mass gain of 7.2 wt% upon exposure of the specimen
-         to the temperature given in _atom_analytical_mass_loss.temperature.
-;
-
-save_
-
-save_atom_analytical_mass_loss.percent_su
-
-    _definition.id                '_atom_analytical_mass_loss.percent_su'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Standard uncertainty of _atom_analytical_mass_loss.percent.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               percent_su
-    _name.linked_item_id          '_atom_analytical_mass_loss.percent'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_analytical_mass_loss.special_details
-
-    _definition.id                '_atom_analytical_mass_loss.special_details'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Text describing the conditions under which the data were collected
-    that are not able to be captured using other data names
-    within the ATOM_ANALYTICAL_MASS_LOSS category.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_atom_analytical_mass_loss.temperature
-
-    _definition.id                '_atom_analytical_mass_loss.temperature'
-    _definition.update            2022-11-21
-    _description.text
-;
-    The temperature, in kelvin, at which the mass loss was recorded
-    as given by _atom_analytical_mass_loss.percent.
-
-    This would be used to record the temperature of drying or ignition,
-    during, for example, fusion bead preparation for XRF analysis.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               temperature
-    _type.purpose                 Measurand
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   kelvins
-
-save_
-
-save_atom_analytical_mass_loss.temperature_su
-
-    _definition.id                '_atom_analytical_mass_loss.temperature_su'
-    _definition.update            2022-11-21
-    _description.text
-;
-    Standard uncertainty of _atom_analytical_mass_loss.temperature.
-;
-    _name.category_id             atom_analytical_mass_loss
-    _name.object_id               analysis_temperature_su
-    _name.linked_item_id          '_atom_analytical_mass_loss.temperature'
-    _units.code                   kelvins
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_ATOM_ANALYTICAL_SOURCE
-
-    _definition.id                ATOM_ANALYTICAL_SOURCE
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2022-11-19
-    _description.text
-;
-    The CATEGORY of data items used to describe the source
-    of elemental composition information used in crystallographic
-    structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_ANALYTICAL_SOURCE
-    _category_key.name            '_atom_analytical_source.id'
-    _description_example.case
-;
-    loop_
-    _atom_analytical_source.id
-    _atom_analytical_source.technique
-    _atom_analytical_source.equipment_make
-    a  XRF 'Hitachi Lab-X5000'
-    b  'X-ray fluorescence EDS' 'Hitachi Lab-X5000'
-    c  ICP .
-    d  EDS .
-;
-    _description_example.detail
-;
-    Four different measurements of elemental composition are enumerated.
-;
-
-save_
-
-save_atom_analytical_source.equipment_make
-
-    _definition.id                '_atom_analytical_source.equipment_make'
-    _definition.update            2022-11-18
-    _description.text
-;
-    The make, model or name of the equipment used to determine the
-    elemental composition.
-;
-    _name.category_id             atom_analytical_source
-    _name.object_id               equipment_make
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'Bruker'
-         'ELEMISSION'
-         'Thermo Fisher Scientific'
-
-save_
-
-save_atom_analytical_source.id
-
-    _definition.id                '_atom_analytical_source.id'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Arbitrary label uniquely identifying the source of an elemental
-    composition value. This value is used by _atom_analytical.meas_id
-    to link individual composition values to their corresponding
-    technique of determination.
-;
-    _name.category_id             atom_analytical_source
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_analytical_source.special_details
-
-    _definition.id                '_atom_analytical_source.special_details'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Text describing the equipment or conditions under which the
-    data were collected that are not able to be captured using
-    _atom_analytical_source.equipment_make or
-    _atom_analytical_source.technique.
-;
-    _name.category_id             atom_analytical_source
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-;
-       XRF utilising a WDS detector system calibrated for the analysis
-       of iron ores.
-;
-;
-       Laser Induced Breakdown Spectroscopy. Measurements carried out
-       by commercial laboratory, report #P90.
-;
-;
-       Detector calibrated following Smith (2018).
-;
-
-save_
-
-save_atom_analytical_source.technique
-
-    _definition.id                '_atom_analytical_source.technique'
-    _definition.update            2022-11-18
-    _description.text
-;
-    Succinct text or acronym describing the experimental technique used
-    to find the elemental composition.
-
-    If further details are required to properly describe the experimental
-    technique, or the given acronym is not in common use, use
-    _atom_analytical_source.special_details.
-;
-    _name.category_id             atom_analytical_source
-    _name.object_id               technique
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         'XRF'
-         'LIBS'
-         'ICP OES'
-
-save_
-
-save_ATOM_SCAT_VERSUS_STOL
-
-    _definition.id                ATOM_SCAT_VERSUS_STOL
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2023-07-05
-    _description.text
-;
-    The CATEGORY of data items used to list atomic scattering factor values for
-    use in crystallographic structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_SCAT_VERSUS_STOL
-
-    loop_
-      _category_key.name
-         '_atom_scat_versus_stol.atom_type'
-         '_atom_scat_versus_stol.stol_value'
-
-    _description_example.case
-;
-        loop_
-        _atom_scat_versus_stol.atom_type
-        _atom_scat_versus_stol.stol_value
-        _atom_scat_versus_stol.scat_value
-        Ac  0.00  89.00000
-        Ac  0.01  88.91457
-        Ac  0.02  88.66288
-        #...
-        Ac  4.00   8.24987
-        Ac  5.00   5.98858
-        Ac  6.00   4.90623
-        O   0.00   8.00000
-        O   0.01   7.99171
-        O   0.02   7.96693
-        #...
-        O   4.00   0.13431
-        O   5.00   0.06740
-        O   6.00   0.03670
-;
-    _description_example.detail
-;
-        A listing of the scattering factors for Ac and O in the range
-        (0, 6.00) reciprocal angstroms.
-;
-save_
-
-save_atom_scat_versus_stol.atom_type
-
-    _definition.id                '_atom_scat_versus_stol.atom_type'
-    _definition.update            2023-07-05
-    _description.text
-;
-    The identity of the atom specie(s) representing this atom type.
-    See _atom_type.symbol for further details.
-;
-    _name.category_id             atom_scat_versus_stol
-    _name.object_id               atom_type
-    _name.linked_item_id          '_atom_type.symbol'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_scat_versus_stol.scat_value
-
-    _definition.id                '_atom_scat_versus_stol.scat_value'
-    _definition.update            2023-07-05
-    _description.text
-;
-    The value of the scattering factor of a particular atom type at a particular
-    stol value.
-;
-    _name.category_id             atom_scat_versus_stol
-    _name.object_id               scat_value
-    _type.purpose                 Measurand
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   electrons
-
-save_
-
-save_atom_scat_versus_stol.scat_value_su
-
-    _definition.id                '_atom_scat_versus_stol.scat_value_su'
-    _definition.update            2023-07-05
-    _description.text
-;
-    Standard uncertainty of _atom_scat_versus_stol.scat_value.
-;
-    _name.category_id             atom_scat_versus_stol
-    _name.object_id               scat_value_su
-    _name.linked_item_id          '_atom_scat_versus_stol.scat_value'
-    _units.code                   electrons
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_scat_versus_stol.stol_value
-
-    _definition.id                '_atom_scat_versus_stol.stol_value'
-    _definition.update            2023-07-05
-    _description.text
-;
-    The value of sin(θ)/λ (sin theta over lambda, stol) to which the
-    accompanying atom symbol and scattering factor value correspond to.
-
-    A regularly spaced grid is strongly recommended.
-;
-    _name.category_id             atom_scat_versus_stol
-    _name.object_id               stol_value
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_ATOM_SITE
-
-    _definition.id                ATOM_SITE
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2023-02-03
-    _description.text
-;
-    The CATEGORY of data items used to describe atom site information
-    used in crystallographic structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_SITE
-    loop_
-      _category_key.name
-         '_atom_site.label'
-         '_atom_site.structure_id'
-
-    loop_
-      _description_example.case
-      _description_example.detail
-;
-         loop_
-           _atom_site.label
-           _atom_site.occupancy
-           _atom_site.disorder_assembly
-           _atom_site.disorder_group
-            C1     1      .     .
-            H11A   .5     M     1
-            H12A   .5     M     1
-            H13A   .5     M     1
-            H11B   .5     M     2
-            H12B   .5     M     2
-            H13B   .5     M     2
-;
-;
-         A hypothetical example of a positional disorder description. Disorder
-         assembly 'M' describes a methyl group with two alternative
-         configurations '1' and '2':
-
-                            H11B    H11A      H13B
-                              .      |      .
-                                .    |    .
-                                  .  |  .
-                                     C1 --------C2---
-                                   / .  \
-                                 /   .    \
-                               /     .      \
-                            H12A    H12B    H13A
-;
-;
-         loop_
-           _atom_site.label
-           _atom_site.type_symbol
-           _atom_site.fract_x
-           _atom_site.fract_y
-           _atom_site.fract_z
-           _atom_site.occupancy
-           _atom_site.disorder_assembly
-           _atom_site.disorder_group
-            Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
-            Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
-            Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
-            O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
-            O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
-            # ...
-;
-;
-         An example of a compositional disorder description. Disorder assembly
-         'A' describes a site that is simultaneously occupied by Co and Mn
-         atoms which are assigned to disorder group '1' and disorder group '2'
-         respectively.
-
-         The example was created based on data from:
-             Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
-             https://doi.org/10.1039/d0dt03269g
-;
-
-save_
-
-save_atom_site.adp_type
-
-    _definition.id                '_atom_site.ADP_type'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_ADP_type'
-         '_atom_site_thermal_displace_type'
-         '_atom_site.thermal_displace_type'
-
-    _definition.update            2021-09-24
-    _description.text
-;
-    Code for type of atomic displacement parameters used for the site.
-;
-    _name.category_id             atom_site
-    _name.object_id               ADP_type
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         Uani                     'Anisotropic Uij.'
-         Uiso                     'Isotropic U.'
-         Uovl                     'Overall U.'
-         Umpe                     'Multipole expansion U.'
-         Bani                     'Anisotropic Bij.'
-         Biso                     'Isotropic B.'
-         Bovl                     'Overall B.'
-         betaani                  'Anisotropic betaij.'
-
-save_
-
-save_atom_site.attached_hydrogens
-
-    _definition.id                '_atom_site.attached_hydrogens'
-    _alias.definition_id          '_atom_site_attached_hydrogens'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Number of hydrogen atoms attached to the atom at this site
-    excluding any H atoms for which coordinates (measured or calculated)
-    are given.
-;
-    _name.category_id             atom_site
-    _name.object_id               attached_hydrogens
-    _type.purpose                 Number
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            0:8
-    _units.code                   none
-
-    loop_
-      _description_example.case
-      _description_example.detail
-         2                        'Water oxygen.'
-         1                        'Hydroxyl oxygen.'
-         4                        'Ammonium nitrogen.'
-
-save_
-
-save_atom_site.b_equiv_geom_mean
-
-    _definition.id                '_atom_site.B_equiv_geom_mean'
-    _alias.definition_id          '_atom_site_B_equiv_geom_mean'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Equivalent isotropic atomic displacement parameter, B(equiv),
-    in angstroms squared, calculated as the geometric mean of
-    the anisotropic atomic displacement parameters.
-
-                B(equiv) = (B~i~ B~j~ B~k~)^1/3^
-
-    B~n~  = the principal components of the orthogonalised B^ij^
-
-    The IUCr Commission on Nomenclature recommends against the use
-    of B for reporting atomic displacement parameters. U, being
-    directly proportional to B, is preferred.
-;
-    _name.category_id             atom_site
-    _name.object_id               B_equiv_geom_mean
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.b_equiv_geom_mean_su
-
-    _definition.id                '_atom_site.B_equiv_geom_mean_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_B_equiv_geom_mean_su'
-         '_atom_site.B_equiv_geom_mean_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the equivalent isotropic atomic displacement
-    parameter, B(equiv), in angstroms squared, calculated as the geometric
-    mean of the anisotropic atomic displacement parameters.
-;
-    _name.category_id             atom_site
-    _name.object_id               B_equiv_geom_mean_su
-    _name.linked_item_id          '_atom_site.B_equiv_geom_mean'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.b_iso_or_equiv
-
-    _definition.id                '_atom_site.B_iso_or_equiv'
-    _alias.definition_id          '_atom_site_B_iso_or_equiv'
-    _definition.update            2023-01-16
-    _description.text
-;
-    Isotropic atomic displacement parameter, or equivalent isotropic
-    atomic displacement parameter, B(equiv), in angstroms squared,
-    calculated from anisotropic atomic displacement parameters.
-
-        B(equiv) = (1/3) sum~i~[sum~j~(B^ij^ a*~i~ a*~j~ a~i~.a~j~)]
-
-    a     = the real-space cell vectors
-    a*    = the reciprocal-space cell lengths
-    B^ij^ = 8 π^2^ U^ij^
-    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
-
-    The IUCr Commission on Nomenclature recommends against the use
-    of B for reporting atomic displacement parameters. U, being
-    directly proportional to B, is preferred.
-;
-    _name.category_id             atom_site
-    _name.object_id               B_iso_or_equiv
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.b_iso_or_equiv_su
-
-    _definition.id                '_atom_site.B_iso_or_equiv_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_B_iso_or_equiv_su'
-         '_atom_site.B_iso_or_equiv_esd'
-
-    _definition.update            2023-01-16
-    _description.text
-;
-    Standard uncertainty of the isotropic atomic displacement parameter,
-    or equivalent isotropic atomic displacement parameter, B(equiv),
-    in angstroms squared, calculated from anisotropic atomic displacement
-    parameters.
-;
-    _name.category_id             atom_site
-    _name.object_id               B_iso_or_equiv_su
-    _name.linked_item_id          '_atom_site.B_iso_or_equiv'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.calc_attached_atom
-
-    _definition.id                '_atom_site.calc_attached_atom'
-    _alias.definition_id          '_atom_site_calc_attached_atom'
-    _definition.update            2023-01-13
-    _description.text
-;
-    The _atom_site.label of the atom site to which the 'geometry-calculated'
-    atom site is attached.
-;
-    _name.category_id             atom_site
-    _name.object_id               calc_attached_atom
-    _name.linked_item_id          '_atom_site.label'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_site.calc_flag
-
-    _definition.id                '_atom_site.calc_flag'
-    _alias.definition_id          '_atom_site_calc_flag'
-    _definition.update            2012-11-20
-    _description.text
-;
-    A standard code to signal if the site coordinates have been
-    determined from the intensities or calculated from the geometry
-    of surrounding sites, or have been assigned dummy coordinates.
-;
-    _name.category_id             atom_site
-    _name.object_id               calc_flag
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         d                        'Determined from diffraction measurements.'
-         calc                     'Calculated from molecular geometry.'
-         c                        'Abbreviation for "calc".'
-         dum                      'Dummy site with meaningless coordinates.'
-
-save_
-
-save_atom_site.cartn_x
-
-    _definition.id                '_atom_site.Cartn_x'
-    _alias.definition_id          '_atom_site_Cartn_x'
-    _name.category_id             atom_site
-    _name.object_id               Cartn_x
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
-
-save_
-
-save_atom_site.cartn_x_su
-
-    _definition.id                '_atom_site.Cartn_x_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_Cartn_x_su'
-         '_atom_site.Cartn_x_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               Cartn_x_su
-    _name.linked_item_id          '_atom_site.Cartn_x'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cartn_coord_su}]
-
-save_
-
-save_atom_site.cartn_xyz
-
-    _definition.id                '_atom_site.Cartn_xyz'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Vector of Cartesian (orthogonal angstrom) atom site coordinates.
-;
-    _name.category_id             atom_site
-    _name.object_id               Cartn_xyz
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a  as  atom_site
-
-    _atom_site.Cartn_xyz =   [a.Cartn_x, a.Cartn_y, a.Cartn_z]
-;
-
-save_
-
-save_atom_site.cartn_xyz_su
-
-    _definition.id                '_atom_site.Cartn_xyz_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_site.Cartn_xyz.
-;
-    _name.category_id             atom_site
-    _name.object_id               Cartn_xyz_su
-    _name.linked_item_id          '_atom_site.Cartn_xyz'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_atom_site.cartn_y
-
-    _definition.id                '_atom_site.Cartn_y'
-    _alias.definition_id          '_atom_site_Cartn_y'
-    _name.category_id             atom_site
-    _name.object_id               Cartn_y
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
-
-save_
-
-save_atom_site.cartn_y_su
-
-    _definition.id                '_atom_site.Cartn_y_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_Cartn_y_su'
-         '_atom_site.Cartn_y_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               Cartn_y_su
-    _name.linked_item_id          '_atom_site.Cartn_y'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cartn_coord_su}]
-
-save_
-
-save_atom_site.cartn_z
-
-    _definition.id                '_atom_site.Cartn_z'
-    _alias.definition_id          '_atom_site_Cartn_z'
-    _name.category_id             atom_site
-    _name.object_id               Cartn_z
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
-
-save_
-
-save_atom_site.cartn_z_su
-
-    _definition.id                '_atom_site.Cartn_z_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_Cartn_z_su'
-         '_atom_site.Cartn_z_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               Cartn_z_su
-    _name.linked_item_id          '_atom_site.Cartn_z'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':cartn_coord_su}]
-
-save_
-
-save_atom_site.chemical_conn_number
-
-    _definition.id                '_atom_site.chemical_conn_number'
-    _alias.definition_id          '_atom_site_chemical_conn_number'
-    _definition.update            2021-03-01
-    _description.text
-;
-    This number links an atom site to the chemical connectivity list.
-    It must match a number specified by _chemical_conn_atom.number.
-;
-    _name.category_id             atom_site
-    _name.object_id               chemical_conn_number
-    _name.linked_item_id          '_chemical_conn_atom.number'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _units.code                   none
-
-save_
-
-save_atom_site.constraints
-
-    _definition.id                '_atom_site.constraints'
-    _alias.definition_id          '_atom_site_constraints'
-    _definition.update            2012-11-20
-    _description.text
-;
-    A description of the constraints applied to parameters at this
-    site during refinement. See also _atom_site.refinement_flags_*
-    and _refine_ls.number_constraints.
-;
-    _name.category_id             atom_site
-    _name.object_id               constraints
-    _type.purpose                 Encode
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     pop=1.0-pop(Zn3)
-
-save_
-
-save_atom_site.description
-
-    _definition.id                '_atom_site.description'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_description'
-         '_atom_site.details'
-
-    _definition.update            2023-01-13
-    _description.text
-;
-    A description of special aspects of this site. See also
-    _atom_site.refinement_flags_*.
-;
-    _name.category_id             atom_site
-    _name.object_id               description
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'Ag/Si disordered'
-
-save_
-
-save_atom_site.disorder_assembly
-
-    _definition.id                '_atom_site.disorder_assembly'
-    _alias.definition_id          '_atom_site_disorder_assembly'
-    _definition.update            2023-01-29
-    _description.text
-;
-    A code which identifies a cluster of atoms that show long range disorder
-    but are locally ordered. Within each such cluster of atoms,
-    _atom_site.disorder_group is used to identify the sites that are
-    simultaneously occupied. This field is only needed if there is more than
-    one cluster of disordered atoms showing independent local order.
-;
-    _name.category_id             atom_site
-    _name.object_id               disorder_assembly
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-    loop_
-      _description_example.case
-      _description_example.detail
-         A
-;
-         Disordered methyl assembly with groups 1 and 2.
-;
-         B
-;
-         Disordered sites related by a mirror.
-;
-         C
-;
-         Assembly with groups that describe alternative compositions of a
-         compositionally disordered site.
-;
-         S
-;
-         Disordered sites independent of symmetry.
-;
-
-save_
-
-save_atom_site.disorder_group
-
-    _definition.id                '_atom_site.disorder_group'
-    _alias.definition_id          '_atom_site_disorder_group'
-    _definition.update            2023-01-29
-    _description.text
-;
-    A code that identifies a group of disordered atom sites that are locally
-    simultaneously occupied. Atoms that are positionally disordered over two or
-    more sites (e.g. the H atoms of a methyl group that exists in two
-    orientations) should be assigned to two or more groups. Similarly, atoms
-    that describe a specific alternative composition of a compositionally
-    disordered site should be assigned to a distinct disorder group (e.g. a site
-    that is partially occupied by Mg and Mn atoms should be described by
-    assigning the Mg atom to one group and the Mn atom to another group). Sites
-    belonging to the same group are simultaneously occupied, but those belonging
-    to different groups are not. A minus prefix (e.g. "-1") is used to indicate
-    sites disordered about a special position.
-;
-    _name.category_id             atom_site
-    _name.object_id               disorder_group
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-    loop_
-      _description_example.case
-      _description_example.detail
-         1
-;
-         Unique disordered site in group 1.
-;
-         2
-;
-         Unique disordered site in group 2.
-;
-         3
-;
-         Group describes a specific alternative composition of a compositionally
-         disordered site.
-;
-         -1
-;
-         Symmetry-independent disordered site.'
-;
-
-save_
-
-save_atom_site.fract_x
-
-    _definition.id                '_atom_site.fract_x'
-    _alias.definition_id          '_atom_site_fract_x'
-    _name.category_id             atom_site
-    _name.object_id               fract_x
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
-
-save_
-
-save_atom_site.fract_x_su
-
-    _definition.id                '_atom_site.fract_x_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_fract_x_su'
-         '_atom_site.fract_x_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               fract_x_su
-    _name.linked_item_id          '_atom_site.fract_x'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':fract_coord_su}]
-
-save_
-
-save_atom_site.fract_xyz
-
-    _definition.id                '_atom_site.fract_xyz'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Vector of atom site coordinates projected onto the crystal unit
-    cell as fractions of the cell lengths.
-;
-    _name.category_id             atom_site
-    _name.object_id               fract_xyz
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a  as  atom_site
-
-    _atom_site.fract_xyz =  [a.fract_x, a.fract_y, a.fract_z]
-;
-
-save_
-
-save_atom_site.fract_xyz_su
-
-    _definition.id                '_atom_site.fract_xyz_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_site.fract_xyz.
-;
-    _name.category_id             atom_site
-    _name.object_id               fract_xyz_su
-    _name.linked_item_id          '_atom_site.fract_xyz'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_atom_site.fract_y
-
-    _definition.id                '_atom_site.fract_y'
-    _alias.definition_id          '_atom_site_fract_y'
-    _name.category_id             atom_site
-    _name.object_id               fract_y
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
-
-save_
-
-save_atom_site.fract_y_su
-
-    _definition.id                '_atom_site.fract_y_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_fract_y_su'
-         '_atom_site.fract_y_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               fract_y_su
-    _name.linked_item_id          '_atom_site.fract_y'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':fract_coord_su}]
-
-save_
-
-save_atom_site.fract_z
-
-    _definition.id                '_atom_site.fract_z'
-    _alias.definition_id          '_atom_site_fract_z'
-    _name.category_id             atom_site
-    _name.object_id               fract_z
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
-
-save_
-
-save_atom_site.fract_z_su
-
-    _definition.id                '_atom_site.fract_z_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_fract_z_su'
-         '_atom_site.fract_z_esd'
-
-    _name.category_id             atom_site
-    _name.object_id               fract_z_su
-    _name.linked_item_id          '_atom_site.fract_z'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':fract_coord_su}]
-
-save_
-
-save_atom_site.label
-
-    _definition.id                '_atom_site.label'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_label'
-         '_atom_site.id'
-
-    _name.category_id             atom_site
-    _name.object_id               label
-
-    _import.get
-        [{'file':templ_attr.cif  'save':atom_site_label}]
-
-save_
-
-save_atom_site.label_component_0
-
-    _definition.id                '_atom_site.label_component_0'
-    _alias.definition_id          '_atom_site_label_component_0'
-    _name.category_id             atom_site
-    _name.object_id               label_component_0
-
-    _import.get
-        [{'file':templ_attr.cif  'save':label_component}]
-
-save_
-
-save_atom_site.label_component_1
-
-    _definition.id                '_atom_site.label_component_1'
-    _alias.definition_id          '_atom_site_label_component_1'
-    _name.category_id             atom_site
-    _name.object_id               label_component_1
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.label_component_2
-
-    _definition.id                '_atom_site.label_component_2'
-    _alias.definition_id          '_atom_site_label_component_2'
-    _name.category_id             atom_site
-    _name.object_id               label_component_2
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.label_component_3
-
-    _definition.id                '_atom_site.label_component_3'
-    _alias.definition_id          '_atom_site_label_component_3'
-    _name.category_id             atom_site
-    _name.object_id               label_component_3
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.label_component_4
-
-    _definition.id                '_atom_site.label_component_4'
-    _alias.definition_id          '_atom_site_label_component_4'
-    _name.category_id             atom_site
-    _name.object_id               label_component_4
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.label_component_5
-
-    _definition.id                '_atom_site.label_component_5'
-    _alias.definition_id          '_atom_site_label_component_5'
-    _name.category_id             atom_site
-    _name.object_id               label_component_5
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.label_component_6
-
-    _definition.id                '_atom_site.label_component_6'
-    _alias.definition_id          '_atom_site_label_component_6'
-    _name.category_id             atom_site
-    _name.object_id               label_component_6
-
-    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
-
-save_
-
-save_atom_site.occupancy
-
-    _definition.id                '_atom_site.occupancy'
-    _alias.definition_id          '_atom_site_occupancy'
-    _definition.update            2012-11-20
-    _description.text
-;
-    The fraction of the atom type present at this site.
-    The sum of the occupancies of all the atom types at this site
-    may not significantly exceed 1.0 unless it is a dummy site. The
-    value must lie in the 99.97% Gaussian confidence interval
-    -3u =< x =< 1 + 3u. The _enumeration.range of 0.0:1.0 is thus
-    correctly interpreted as meaning (0.0 - 3u) =< x =< (1.0 + 3u).
-;
-    _name.category_id             atom_site
-    _name.object_id               occupancy
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:1.0
-    _units.code                   none
-
-save_
-
-save_atom_site.occupancy_su
-
-    _definition.id                '_atom_site.occupancy_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_occupancy_su'
-         '_atom_site.occupancy_esd'
-
-    _definition.update            2021-03-03
-    _description.text
-;
-    Standard uncertainty of the fraction of the atom type
-    present at this site.
-;
-    _name.category_id             atom_site
-    _name.object_id               occupancy_su
-    _name.linked_item_id          '_atom_site.occupancy'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_atom_site.refinement_flags
-
-    _definition.id                '_atom_site.refinement_flags'
-
-    loop_
-      _definition_replaced.id
-      _definition_replaced.by
-         1                        '_atom_site.refinement_flags_posn'
-         2                        '_atom_site.refinement_flags_ADP'
-         3                        '_atom_site.refinement_flags_occupancy'
-
-    _alias.definition_id          '_atom_site_refinement_flags'
-    _definition.update            2021-09-24
-    _description.text
-;
-    A concatenated series of single-letter codes which indicate the
-    refinement restraints or constraints applied to this site. This
-    item should not be used. It has been replaced by
-    _atom_site.refinement_flags_posn, _ADP and _occupancy. It is
-    retained in this dictionary only to provide compatibility with
-    legacy CIFs.
-;
-    _name.category_id             atom_site
-    _name.object_id               refinement_flags
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         S                      'Special position constraint on site.'
-         G                      'Rigid group refinement of site.'
-         R                      'Riding-atom site attached to non-riding atom.'
-         D                      'Distance or angle restraint on site.'
-         T                      'Thermal displacement constraints.'
-         U                      'Uiso or Uij restraint (rigid bond).'
-         P                      'Partial occupancy constraint.'
-         .                      'No refinement constraints.'
-
-save_
-
-save_atom_site.refinement_flags_adp
-
-    _definition.id                '_atom_site.refinement_flags_ADP'
-    _alias.definition_id          '_atom_site_refinement_flags_ADP'
-    _definition.update            2021-09-24
-    _description.text
-;
-    A code which indicates the refinement restraints or constraints
-    applied to the atomic displacement parameters of this site.
-;
-    _name.category_id             atom_site
-    _name.object_id               refinement_flags_ADP
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         .    'No constraints on atomic displacement parameters.'
-         T    'Special-position constraints on atomic displacement parameters.'
-         U    'Uiso or Uij restraint (rigid bond).'
-         TU   'Both constraints applied.'
-
-save_
-
-save_atom_site.refinement_flags_occupancy
-
-    _definition.id                '_atom_site.refinement_flags_occupancy'
-    _alias.definition_id          '_atom_site_refinement_flags_occupancy'
-    _definition.update            2012-11-20
-    _description.text
-;
-    A code which indicates the refinement restraints or constraints
-    applied to the occupancy of this site.
-;
-    _name.category_id             atom_site
-    _name.object_id               refinement_flags_occupancy
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         .                       'No constraints on site-occupancy parameters.'
-         P                       'Site-occupancy constraint.'
-
-save_
-
-save_atom_site.refinement_flags_posn
-
-    _definition.id                '_atom_site.refinement_flags_posn'
-    _alias.definition_id          '_atom_site_refinement_flags_posn'
-    _definition.update            2012-11-20
-    _description.text
-;
-    A code which indicates the refinement restraints or constraints
-    applied to the positional coordinates of this site.
-;
-    _name.category_id             atom_site
-    _name.object_id               refinement_flags_posn
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         .             'No constraints on positional coordinates.'
-         D             'Distance or angle restraint on positional coordinates.'
-         G             'Rigid-group refinement of positional coordinates.'
-         R             'Riding-atom site attached to non-riding atom.'
-         S             'Special-position constraint on positional coordinates.'
-         DG            'Combination of the above constraints.'
-         DR            'Combination of the above constraints.'
-         DS            'Combination of the above constraints.'
-         GR            'Combination of the above constraints.'
-         GS            'Combination of the above constraints.'
-         RS            'Combination of the above constraints.'
-         DGR           'Combination of the above constraints.'
-         DGS           'Combination of the above constraints.'
-         DRS           'Combination of the above constraints.'
-         GRS           'Combination of the above constraints.'
-         DGRS          'Combination of the above constraints.'
-
-save_
-
-save_atom_site.restraints
-
-    _definition.id                '_atom_site.restraints'
-    _alias.definition_id          '_atom_site_restraints'
-    _definition.update            2023-01-13
-    _description.text
-;
-    A description of restraints applied to specific parameters at
-    this site during refinement. See also _atom_site.refinement_flags_*
-    and _refine_ls.number_restraints.
-;
-    _name.category_id             atom_site
-    _name.object_id               restraints
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'restrained to planar ring'
-
-save_
-
-save_atom_site.site_symmetry_multiplicity
-
-    _definition.id                '_atom_site.site_symmetry_multiplicity'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_site_symmetry_multiplicity'
-         '_atom_site_symmetry_multiplicity'
-         '_atom_site.symmetry_multiplicity'
-
-    _definition.update            2023-01-16
-    _description.text
-;
-    The number of different sites that are generated by the
-    application of the space-group symmetry to the coordinates
-    given for this site. It is equal to the multiplicity given
-    for this Wyckoff site in International Tables for Cryst.
-    Vol. A (2002). It is equal to the multiplicity of the general
-    position divided by the order of the site symmetry given in
-    _atom_site.site_symmetry_order.
-
-    The _atom_site_symmetry_multiplicity form of this data name is
-    deprecated because of historical inconsistencies in practice among
-    structure refinement software packages and should not be used.
-;
-    _name.category_id             atom_site
-    _name.object_id               site_symmetry_multiplicity
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:192
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With  a  as  atom_site
-
-        mul  =   0
-        xyz  =   a.fract_xyz
-
-          Loop  s  as  space_group_symop  {
-             sxyz  =   s.R * xyz + s.T
-             diff  =   Mod( 99.5 + xyz - sxyz, 1.0) - 0.5
-             If ( Norm ( diff ) < 0.1 ) mul +=  1
-       }
-    _atom_site.site_symmetry_multiplicity =  _space_group.multiplicity / mul
-;
-
-save_
-
-save_atom_site.site_symmetry_order
-
-    _definition.id                '_atom_site.site_symmetry_order'
-    _alias.definition_id          '_atom_site_site_symmetry_order'
-    _definition.update            2021-03-01
-    _description.text
-;
-    The number of times application of the crystallographic symmetry
-    to the coordinates for this site generates the same coordinates.
-    That is:
-            multiplicity of the general position
-            ------------------------------------
-            _atom_site.site_symmetry_multiplicity
-;
-    _name.category_id             atom_site
-    _name.object_id               site_symmetry_order
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:48
-    _units.code                   none
-
-save_
-
-save_atom_site.structure_id
-
-    _definition.id                '_atom_site.structure_id'
-    _definition.update            2023-07-10
-    _description.text
-;
-    Identifier for the structure to which the atom site belongs.
-;
-    _name.category_id             atom_site
-    _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_site.type_symbol
-
-    _definition.id                '_atom_site.type_symbol'
-    _alias.definition_id          '_atom_site_type_symbol'
-    _definition.update            2021-10-27
-    _description.text
-;
-    A code to identify the atom specie(s) occupying this site.
-    This code must match a corresponding _atom_type.symbol. The
-    specification of this code is optional if component_0 of the
-    _atom_site.label is used for this purpose. See _atom_type.symbol.
-;
-    _name.category_id             atom_site
-    _name.object_id               type_symbol
-    _name.linked_item_id          '_atom_type.symbol'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-    loop_
-      _description_example.case
-         Cu
-         Cu2+
-         S
-         O1-
-
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_site.type_symbol  =   AtomType ( _atom_site.label )
-;
-
-save_
-
-save_atom_site.u_equiv_geom_mean
-
-    _definition.id                '_atom_site.U_equiv_geom_mean'
-    _alias.definition_id          '_atom_site_U_equiv_geom_mean'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Equivalent isotropic atomic displacement parameter, U(equiv),
-    in angstroms squared, calculated as the geometric mean of
-    the anisotropic atomic displacement parameters.
-
-               U(equiv) = (U~i~ U~j~ U~k~)^1/3^
-
-    U~n~ = the principal components of the orthogonalised U^ij^
-;
-    _name.category_id             atom_site
-    _name.object_id               U_equiv_geom_mean
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.u_equiv_geom_mean_su
-
-    _definition.id                '_atom_site.U_equiv_geom_mean_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_U_equiv_geom_mean_su'
-         '_atom_site.U_equiv_geom_mean_esd'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    Standard uncertainty values (esds) of the U(equiv).
-;
-    _name.category_id             atom_site
-    _name.object_id               U_equiv_geom_mean_su
-    _name.linked_item_id          '_atom_site.U_equiv_geom_mean'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.u_iso_or_equiv
-
-    _definition.id                '_atom_site.U_iso_or_equiv'
-    _alias.definition_id          '_atom_site_U_iso_or_equiv'
-    _definition.update            2023-01-13
-    _description.text
-;
-    Isotropic atomic displacement parameter, or equivalent isotropic
-    atomic displacement parameter, U(equiv), in angstroms squared,
-    calculated from anisotropic atomic displacement parameters.
-
-       U(equiv) = (1/3) sum~i~[sum~j~(U^ij^ a*~i~ a*~j~ a~i~.a~j~)]
-
-    a  = the real-space cell vectors
-    a* = the reciprocal-space cell lengths
-    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
-;
-    _name.category_id             atom_site
-    _name.object_id               U_iso_or_equiv
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.u_iso_or_equiv_su
-
-    _definition.id                '_atom_site.U_iso_or_equiv_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_U_iso_or_equiv_su'
-         '_atom_site.U_iso_or_equiv_esd'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    Standard uncertainty values (esds) of the U(iso) or U(equiv).
-;
-    _name.category_id             atom_site
-    _name.object_id               U_iso_or_equiv_su
-    _name.linked_item_id          '_atom_site.U_iso_or_equiv'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site.wyckoff_symbol
-
-    _definition.id                '_atom_site.Wyckoff_symbol'
-    _alias.definition_id          '_atom_site_Wyckoff_symbol'
-    _definition.update            2021-09-23
-    _description.text
-;
-    The Wyckoff symbol (letter) as listed in the space-group section
-    of International Tables for Crystallography, Vol. A (1987).
-;
-    _name.category_id             atom_site
-    _name.object_id               Wyckoff_symbol
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    _import.get
-        [{'file':templ_enum.cif  'save':wyckoff_letter}]
-
-save_
-
-save_ATOM_SITE_ANISO
-
-    _definition.id                ATOM_SITE_ANISO
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2023-01-16
-    _description.text
-;
-    The CATEGORY of data items used to describe the anisotropic atomic
-    displacement parameters of the atomic sites in a crystal structure.
-;
-    _name.category_id             ATOM_SITE
-    _name.object_id               ATOM_SITE_ANISO
-
-    loop_
-      _category_key.name
-         '_atom_site_aniso.label'
-         '_atom_site_aniso.structure_id'
-
-save_
-
-save_atom_site_aniso.b_11
-
-    _definition.id                '_atom_site_aniso.B_11'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_11'
-         '_atom_site.aniso_B[1][1]'
-         '_atom_site_anisotrop.B[1][1]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_11
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_11_su
-
-    _definition.id                '_atom_site_aniso.B_11_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_11_su'
-         '_atom_site.aniso_B[1][1]_esd'
-         '_atom_site_anisotrop.B[1][1]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_11_su
-    _name.linked_item_id          '_atom_site_aniso.B_11'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.b_12
-
-    _definition.id                '_atom_site_aniso.B_12'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_12'
-         '_atom_site.aniso_B[1][2]'
-         '_atom_site_anisotrop.B[1][2]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_12
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_12_su
-
-    _definition.id                '_atom_site_aniso.B_12_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_12_su'
-         '_atom_site.aniso_B[1][2]_esd'
-         '_atom_site_anisotrop.B[1][2]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_12_su
-    _name.linked_item_id          '_atom_site_aniso.B_12'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.b_13
-
-    _definition.id                '_atom_site_aniso.B_13'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_13'
-         '_atom_site.aniso_B[1][3]'
-         '_atom_site_anisotrop.B[1][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_13
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_13_su
-
-    _definition.id                '_atom_site_aniso.B_13_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_13_su'
-         '_atom_site.aniso_B[1][3]_esd'
-         '_atom_site_anisotrop.B[1][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_13_su
-    _name.linked_item_id          '_atom_site_aniso.B_13'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.b_22
-
-    _definition.id                '_atom_site_aniso.B_22'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_22'
-         '_atom_site.aniso_B[2][2]'
-         '_atom_site_anisotrop.B[2][2]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_22
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_22_su
-
-    _definition.id                '_atom_site_aniso.B_22_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_22_su'
-         '_atom_site.aniso_B[2][2]_esd'
-         '_atom_site_anisotrop.B[2][2]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_22_su
-    _name.linked_item_id          '_atom_site_aniso.B_22'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.b_23
-
-    _definition.id                '_atom_site_aniso.B_23'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_23'
-         '_atom_site.aniso_B[2][3]'
-         '_atom_site_anisotrop.B[2][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_23
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_23_su
-
-    _definition.id                '_atom_site_aniso.B_23_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_23_su'
-         '_atom_site.aniso_B[2][3]_esd'
-         '_atom_site_anisotrop.B[2][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_23_su
-    _name.linked_item_id          '_atom_site_aniso.B_23'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.b_33
-
-    _definition.id                '_atom_site_aniso.B_33'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_33'
-         '_atom_site.aniso_B[3][3]'
-         '_atom_site_anisotrop.B[3][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_33
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
-
-save_
-
-save_atom_site_aniso.b_33_su
-
-    _definition.id                '_atom_site_aniso.B_33_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_B_33_su'
-         '_atom_site.aniso_B[3][3]_esd'
-         '_atom_site_anisotrop.B[3][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               B_33_su
-    _name.linked_item_id          '_atom_site_aniso.B_33'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
-
-save_
-
-save_atom_site_aniso.beta_11
-
-    _definition.id                '_atom_site_aniso.beta_11'
-    _alias.definition_id          '_atom_site_aniso_beta_11'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_11
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_11_su
-
-    _definition.id                '_atom_site_aniso.beta_11_su'
-    _alias.definition_id          '_atom_site_aniso_beta_11_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_11_su
-    _name.linked_item_id          '_atom_site_aniso.beta_11'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.beta_12
-
-    _definition.id                '_atom_site_aniso.beta_12'
-    _alias.definition_id          '_atom_site_aniso_beta_12'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_12
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_12_su
-
-    _definition.id                '_atom_site_aniso.beta_12_su'
-    _alias.definition_id          '_atom_site_aniso_beta_12_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_12_su
-    _name.linked_item_id          '_atom_site_aniso.beta_12'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.beta_13
-
-    _definition.id                '_atom_site_aniso.beta_13'
-    _alias.definition_id          '_atom_site_aniso_beta_13'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_13
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_13_su
-
-    _definition.id                '_atom_site_aniso.beta_13_su'
-    _alias.definition_id          '_atom_site_aniso_beta_13_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_13_su
-    _name.linked_item_id          '_atom_site_aniso.beta_13'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.beta_22
-
-    _definition.id                '_atom_site_aniso.beta_22'
-    _alias.definition_id          '_atom_site_aniso_beta_22'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_22
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_22_su
-
-    _definition.id                '_atom_site_aniso.beta_22_su'
-    _alias.definition_id          '_atom_site_aniso_beta_22_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_22_su
-    _name.linked_item_id          '_atom_site_aniso.beta_22'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.beta_23
-
-    _definition.id                '_atom_site_aniso.beta_23'
-    _alias.definition_id          '_atom_site_aniso_beta_23'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_23
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_23_su
-
-    _definition.id                '_atom_site_aniso.beta_23_su'
-    _alias.definition_id          '_atom_site_aniso_beta_23_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_23_su
-    _name.linked_item_id          '_atom_site_aniso.beta_23'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.beta_33
-
-    _definition.id                '_atom_site_aniso.beta_33'
-    _alias.definition_id          '_atom_site_aniso_beta_33'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_33
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
-
-save_
-
-save_atom_site_aniso.beta_33_su
-
-    _definition.id                '_atom_site_aniso.beta_33_su'
-    _alias.definition_id          '_atom_site_aniso_beta_33_su'
-    _name.category_id             atom_site_aniso
-    _name.object_id               beta_33_su
-    _name.linked_item_id          '_atom_site_aniso.beta_33'
-
-    _import.get
-        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
-
-save_
-
-save_atom_site_aniso.label
-
-    _definition.id                '_atom_site_aniso.label'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_label'
-         '_atom_site_anisotrop.id'
-
-    _definition.update            2019-04-03
-    _description.text
-;
-    Anisotropic atomic displacement parameters are usually looped in
-    a separate list. If this is the case, this code must match the
-    _atom_site.label of the associated atom in the atom coordinate
-    list and conform with the same rules described in _atom_site.label.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               label
-    _name.linked_item_id          '_atom_site.label'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_site_aniso.matrix_b
-
-    _definition.id                '_atom_site_aniso.matrix_B'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The symmetric anisotropic atomic displacement matrix B.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_B
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstrom_squared
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a as atom_site_aniso
-
-     a.matrix_B =  [[ a.B_11, a.B_12, a.B_13 ],
-                    [ a.B_12, a.B_22, a.B_23 ],
-                    [ a.B_13, a.B_23, a.B_33 ]]
-;
-
-save_
-
-save_atom_site_aniso.matrix_b_su
-
-    _definition.id                '_atom_site_aniso.matrix_B_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_site_aniso.matrix_B.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_B_su
-    _name.linked_item_id          '_atom_site_aniso.matrix_B'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site_aniso.matrix_beta
-
-    _definition.id                '_atom_site_aniso.matrix_beta'
-    _alias.definition_id          '_atom_site.tensor_beta'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The symmetric anisotropic atomic displacement parameter (ADP) matrix, β,
-    which appears in a structure factor expression.
-
-    The contribution of the ADPs to the calculation of the structure factor is
-    given as:
-
-        T = exp(-1 * Sum(Sum(β^ij^ * h~i~ * h~j~, j=1:3), i=1:3))
-
-    where β^ij^ are the matrix elements, and h~m~ are the Miller indices.
-
-    The ADP matrix β, is related to the ADP matrices U and B, as follows:
-
-                |a~1~*   0     0  |   |t^11^ t^12^ t^13^|   |a~1~*   0     0  |
-        β = C * |  0   a~2~*   0  | * |t^12^ t^22^ t^23^| * |  0   a~2~*   0  |
-                |  0     0   a~3~*|   |t^13^ t^23^ t^33^|   |  0     0   a~3~*|
-
-    where C is a constant (2 * π^2^ for U, and 0.25 for B), a~i~* is the
-    length of the respective reciprocal unit cell vector, and t represents
-    the individual anisotropic values, U^ij^ or B^ij^.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_beta
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a as atom_site_aniso
-
-        label = a.label
-
-        If (a.ADP_type == 'betaani')
-        {
-            a.matrix_beta =  [[ a.beta_11, a.beta_12, a.beta_13 ],
-                              [ a.beta_12, a.beta_22, a.beta_23 ],
-                              [ a.beta_13, a.beta_23, a.beta_33 ]]
-        }
-        Else
-        {
-            If (a.ADP_type == 'Uani')
-            {
-                UIJ = b.matrix_U
-            }
-            Else If (a.ADP_type == 'Bani')
-            {
-                UIJ = b.matrix_B / (8 * Pi**2)
-            }
-            Else {
-                If (a.ADP_type == 'Uiso')
-                {
-                    Loop b as atom_site
-                    {
-                        If(label == b.label)
-                        {
-                            U  =  b.U_iso_or_equiv
-                            Break
-                        }
-                    }
-                }
-                Else If (a.ADP_type == 'Biso')
-                {
-                    Loop b as atom_site
-                    {
-                        If(label == b.label)
-                        {
-                            U  = b.B_iso_or_equiv / (8 * Pi**2)
-                            Break
-                        }
-                    }
-                }
-                UIJ = U * _cell.convert_Uiso_to_Uij
-            }
-            CUB = _cell.convert_Uij_to_betaij
-            a.matrix_beta =  CUB * UIJ * CUB
-        }
-;
-
-save_
-
-save_atom_site_aniso.matrix_beta_su
-
-    _definition.id                '_atom_site_aniso.matrix_beta_su'
-    _alias.definition_id          '_atom_site.tensor_beta_su'
-    _definition.update            2023-02-15
-    _description.text
-;
-    Standard uncertainty of _atom_site_aniso.matrix_beta.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_beta_su
-    _name.linked_item_id          '_atom_site_aniso.matrix_beta'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_atom_site_aniso.matrix_u
-
-    _definition.id                '_atom_site_aniso.matrix_U'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The symmetric anisotropic atomic displacement matrix U.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_U
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstrom_squared
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a as atom_site_aniso
-
-       a.matrix_U =  [[ a.U_11, a.U_12, a.U_13 ],
-                      [ a.U_12, a.U_22, a.U_23 ],
-                      [ a.U_13, a.U_23, a.U_33 ]]
-;
-
-save_
-
-save_atom_site_aniso.matrix_u_su
-
-    _definition.id                '_atom_site_aniso.matrix_U_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_site_aniso.matrix_U.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               matrix_U_su
-    _name.linked_item_id          '_atom_site_aniso.matrix_U'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstrom_squared
-
-save_
-
-save_atom_site_aniso.ratio
-
-    _definition.id                '_atom_site_aniso.ratio'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_ratio'
-         '_atom_site_anisotrop.ratio'
-         '_atom_site.aniso_ratio'
-
-    _definition.update            2023-01-16
-    _description.text
-;
-    Ratio of the maximum to minimum eigenvalues of the atomic displacement
-    ellipsoids.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               ratio
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            1.0:
-    _units.code                   none
-
-save_
-
-save_atom_site_aniso.structure_id
-
-    _definition.id                '_atom_site_aniso.structure_id'
-    _definition.update            2023-07-06
-    _description.text
-;
-    Identifier for the structure to which the atom site belongs.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               structure_id
-    _name.linked_item_id          '_atom_site.structure_id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_site_aniso.type_symbol
-
-    _definition.id                '_atom_site_aniso.type_symbol'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_type_symbol'
-         '_atom_site_anisotrop.type_symbol'
-
-    _definition.update            2023-01-16
-    _description.text
-;
-    This _atom_type.symbol code links the anisotropic atomic displacement
-    parameters to the atom type data associated with this site and must match
-    one of the _atom_type.symbol codes in this list.
-;
-    _name.category_id             atom_site_aniso
-    _name.object_id               type_symbol
-    _name.linked_item_id          '_atom_type.symbol'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_site_aniso.type_symbol  =   AtomType ( _atom_site_aniso.label )
-;
-
-save_
-
-save_atom_site_aniso.u_11
-
-    _definition.id                '_atom_site_aniso.U_11'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_11'
-         '_atom_site.aniso_U[1][1]'
-         '_atom_site_anisotrop.U[1][1]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_11
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_11_su
-
-    _definition.id                '_atom_site_aniso.U_11_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_11_su'
-         '_atom_site.aniso_U[1][1]_esd'
-         '_atom_site_anisotrop.U[1][1]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_11_su
-    _name.linked_item_id          '_atom_site_aniso.U_11'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_atom_site_aniso.u_12
-
-    _definition.id                '_atom_site_aniso.U_12'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_12'
-         '_atom_site.aniso_U[1][2]'
-         '_atom_site_anisotrop.U[1][2]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_12
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_12_su
-
-    _definition.id                '_atom_site_aniso.U_12_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_12_su'
-         '_atom_site.aniso_U[1][2]_esd'
-         '_atom_site_anisotrop.U[1][2]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_12_su
-    _name.linked_item_id          '_atom_site_aniso.U_12'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_atom_site_aniso.u_13
-
-    _definition.id                '_atom_site_aniso.U_13'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_13'
-         '_atom_site.aniso_U[1][3]'
-         '_atom_site_anisotrop.U[1][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_13
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_13_su
-
-    _definition.id                '_atom_site_aniso.U_13_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_13_su'
-         '_atom_site.aniso_U[1][3]_esd'
-         '_atom_site_anisotrop.U[1][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_13_su
-    _name.linked_item_id          '_atom_site_aniso.U_13'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_atom_site_aniso.u_22
-
-    _definition.id                '_atom_site_aniso.U_22'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_22'
-         '_atom_site.aniso_U[2][2]'
-         '_atom_site_anisotrop.U[2][2]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_22
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_22_su
-
-    _definition.id                '_atom_site_aniso.U_22_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_22_su'
-         '_atom_site.aniso_U[2][2]_esd'
-         '_atom_site_anisotrop.U[2][2]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_22_su
-    _name.linked_item_id          '_atom_site_aniso.U_22'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_atom_site_aniso.u_23
-
-    _definition.id                '_atom_site_aniso.U_23'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_23'
-         '_atom_site.aniso_U[2][3]'
-         '_atom_site_anisotrop.U[2][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_23
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_23_su
-
-    _definition.id                '_atom_site_aniso.U_23_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_23_su'
-         '_atom_site.aniso_U[2][3]_esd'
-         '_atom_site_anisotrop.U[2][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_23_su
-    _name.linked_item_id          '_atom_site_aniso.U_23'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_atom_site_aniso.u_33
-
-    _definition.id                '_atom_site_aniso.U_33'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_33'
-         '_atom_site.aniso_U[3][3]'
-         '_atom_site_anisotrop.U[3][3]'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_33
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
-
-save_
-
-save_atom_site_aniso.u_33_su
-
-    _definition.id                '_atom_site_aniso.U_33_su'
-
-    loop_
-      _alias.definition_id
-         '_atom_site_aniso_U_33_su'
-         '_atom_site.aniso_U[3][3]_esd'
-         '_atom_site_anisotrop.U[3][3]_esd'
-
-    _name.category_id             atom_site_aniso
-    _name.object_id               U_33_su
-    _name.linked_item_id          '_atom_site_aniso.U_33'
-
-    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
-
-save_
-
-save_ATOM_SITES
-
-    _definition.id                ATOM_SITES
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2012-11-20
-    _description.text
-;
-    The CATEGORY of data items used to describe information which applies
-    to all atom sites in a crystal structure.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_SITES
-
-save_
-
-save_atom_sites.solution_hydrogens
-
-    _definition.id                '_atom_sites.solution_hydrogens'
-    _alias.definition_id          '_atom_sites_solution_hydrogens'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Codes which identify the methods used to locate the initial
-    atom sites. The *_primary code identifies how the first
-    atom sites were determined; the *_secondary code identifies
-    how the remaining non-hydrogen sites were located; and the
-    *_hydrogens code identifies how the hydrogen sites were located.
-
-    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
-         Miller, R. and Usón, I. (2001). Ab initio phasing.
-         In International Tables for Crystallography,
-         Vol. F. Crystallography of biological macromolecules,
-         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
-         Dordrecht: Kluwer Academic Publishers.
-;
-    _name.category_id             atom_sites
-    _name.object_id               solution_hydrogens
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         difmap
-;
-         Difference Fourier map.
-;
-         vecmap
-;
-         Real-space vector search.
-;
-         heavy
-;
-         Heavy-atom method.
-;
-         direct
-;
-         Structure-invariant direct methods.
-;
-         geom
-;
-         Inferred from neighbouring sites.
-;
-         disper
-;
-         Anomalous-dispersion techniques.
-;
-         isomor
-;
-         Isomorphous structure methods.
-;
-         mixed
-;
-         A mixture of "geom" and "difmap".
-;
-         notdet
-;
-         Coordinates were not determined.
-;
-         dual
-;
-         Dual-space method (Sheldrick et al., 2001).
-;
-         iterative
-;
-         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
-         Acta Cryst. A60, 134-141].
-;
-         other
-;
-         A method not included elsewhere in this list.
-;
-
-save_
-
-save_atom_sites.solution_primary
-
-    _definition.id                '_atom_sites.solution_primary'
-    _alias.definition_id          '_atom_sites_solution_primary'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Codes which identify the methods used to locate the initial
-    atom sites. The *_primary code identifies how the first
-    atom sites were determined; the *_secondary code identifies
-    how the remaining non-hydrogen sites were located; and the
-    *_hydrogens code identifies how the hydrogen sites were located.
-
-    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
-         Miller, R. and Usón, I. (2001). Ab initio phasing.
-         In International Tables for Crystallography,
-         Vol. F. Crystallography of biological macromolecules,
-         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
-         Dordrecht: Kluwer Academic Publishers.
-;
-    _name.category_id             atom_sites
-    _name.object_id               solution_primary
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         difmap
-;
-         Difference Fourier map.
-;
-         vecmap
-;
-         Real-space vector search.
-;
-         heavy
-;
-         Heavy-atom method.
-;
-         direct
-;
-         Structure-invariant direct methods.
-;
-         geom
-;
-         Inferred from neighbouring sites.
-;
-         disper
-;
-         Anomalous-dispersion techniques.
-;
-         isomor
-;
-         Isomorphous structure methods.
-;
-         notdet
-;
-         Coordinates were not determined.
-;
-         dual
-;
-         Dual-space method (Sheldrick et al., 2001).
-;
-         iterative
-;
-         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
-         Acta Cryst. A60, 134-141].
-;
-         other
-;
-         A method not included elsewhere in this list.
-;
-
-save_
-
-save_atom_sites.solution_secondary
-
-    _definition.id                '_atom_sites.solution_secondary'
-    _alias.definition_id          '_atom_sites_solution_secondary'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Codes which identify the methods used to locate the initial
-    atom sites. The *_primary code identifies how the first
-    atom sites were determined; the *_secondary code identifies
-    how the remaining non-hydrogen sites were located; and the
-    *_hydrogens code identifies how the hydrogen sites were located.
-
-    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
-         Miller, R. and Usón, I. (2001). Ab initio phasing.
-         In International Tables for Crystallography,
-         Vol. F. Crystallography of biological macromolecules,
-         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
-         Dordrecht: Kluwer Academic Publishers.
-;
-    _name.category_id             atom_sites
-    _name.object_id               solution_secondary
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _enumeration_set.state
-      _enumeration_set.detail
-         difmap
-;
-         Difference Fourier map.
-;
-         vecmap
-;
-         Real-space vector search.
-;
-         heavy
-;
-         Heavy-atom method.
-;
-         direct
-;
-         Structure-invariant direct methods.
-;
-         geom
-;
-         Inferred from neighbouring sites.
-;
-         disper
-;
-         Anomalous-dispersion techniques.
-;
-         isomor
-;
-         Isomorphous structure methods.
-;
-         notdet
-;
-         Coordinates were not determined.
-;
-         dual
-;
-         Dual-space method (Sheldrick et al., 2001).
-;
-         iterative
-;
-         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
-         Acta Cryst. A60, 134-141].
-;
-         other
-;
-         A method not included elsewhere in this list.
-;
-
-save_
-
-save_atom_sites.special_details
-
-    _definition.id                '_atom_sites.special_details'
-    _alias.definition_id          '_atom_sites_special_details'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Information about atomic coordinates not coded elsewhere in the CIF.
-;
-    _name.category_id             atom_sites
-    _name.object_id               special_details
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_ATOM_SITES_CARTN_TRANSFORM
-
-    _definition.id                ATOM_SITES_CARTN_TRANSFORM
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2021-03-03
-    _description.text
-;
-    The CATEGORY of data items used to describe the matrix elements
-    used to transform fractional coordinates into Cartesian coordinates
-    of all atom sites in a crystal structure.
-;
-    _name.category_id             ATOM_SITES
-    _name.object_id               ATOM_SITES_CARTN_TRANSFORM
-
-save_
-
-save_atom_sites_cartn_transform.axes
-
-    _definition.id                '_atom_sites_Cartn_transform.axes'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_transform_axes'
-         '_atom_sites.Cartn_transform_axes'
-
-    _definition.update            2012-12-11
-    _description.text
-;
-    Description of the relative alignment of the crystal cell axes to the
-    Cartesian orthogonal axes as applied in the transformation matrix
-    _atom_sites_Cartn_transform.matrix.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               axes
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'a parallel to x; b in the plane of x & y'
-
-save_
-
-save_atom_sites_cartn_transform.mat_11
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_11'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_11'
-         '_atom_sites.Cartn_transf_matrix[1][1]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_11
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-     With c as cell
-
-    _enumeration.default =
-    c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma)
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_11_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_11_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_11.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_11_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_11'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_12
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_12'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_12'
-         '_atom_sites.Cartn_transf_matrix[1][2]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_12
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default =  0.
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_12_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_12_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_12.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_12_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_12'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_13
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_13'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_13'
-         '_atom_sites.Cartn_transf_matrix[1][3]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_13
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default =  0.
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_13_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_13_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_13.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_13_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_13'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_21
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_21'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_21'
-         '_atom_sites.Cartn_transf_matrix[2][1]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_21
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-     with c as cell
-
-    _enumeration.default =
-    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma)
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_21_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_21_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_21.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_21_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_21'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_22
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_22'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_22'
-         '_atom_sites.Cartn_transf_matrix[2][2]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_22
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-     With c  as  cell
-
-    _enumeration.default =  c.length_b * Sind(c.angle_alpha)
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_22_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_22_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_22.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_22_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_22'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_23
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_23'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_23'
-         '_atom_sites.Cartn_transf_matrix[2][3]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_23
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default =  0.
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_23_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_23_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_23.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_23_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_23'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_31
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_31'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_31'
-         '_atom_sites.Cartn_transf_matrix[3][1]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_31
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-     With c  as  cell
-
-    _enumeration.default =  c.length_a * Cosd(c.angle_beta)
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_31_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_31_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_31.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_31_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_31'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_32
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_32'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_32'
-         '_atom_sites.Cartn_transf_matrix[3][2]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_32
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-     With c  as  cell
-
-    _enumeration.default =  c.length_b * Cosd(c.angle_alpha)
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_32_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_32_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_32.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_32_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_32'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.mat_33
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_33'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_matrix_33'
-         '_atom_sites.Cartn_transf_matrix[3][3]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_33
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
-
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default =  _cell.length_c
-;
-
-save_
-
-save_atom_sites_cartn_transform.mat_33_su
-
-    _definition.id                '_atom_sites_Cartn_transform.mat_33_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.mat_33.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               mat_33_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_33'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.matrix
-
-    _definition.id                '_atom_sites_Cartn_transform.matrix'
-    _definition.update            2021-07-07
-    _description.text
-;
-    Matrix used to transform fractional coordinates in the ATOM_SITE
-    category to Cartesian coordinates. The axial alignments of this
-    transformation are described in _atom_sites_Cartn_transform.axes.
-    The 3 x 1 translation is defined in _atom_sites_Cartn_transform.vector.
-
-      x'                   |11 12 13|     x                  | 1 |
-    ( y' ) Cartesian   =   |21 22 23| * ( y ) fractional  + v| 2 |
-      z'                   |31 32 33|     z                  | 3 |
-
-    The default transformation matrix uses Rollet's axial
-    assignments with cell vectors a,b,c aligned with orthogonal
-    axes X,Y,Z so that c||Z and b in plane YZ.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               matrix
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a as atom_sites_Cartn_transform
-
-    _atom_sites_Cartn_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
-                                          [a.mat_21, a.mat_22, a.mat_23],
-                                          [a.mat_31, a.mat_32, a.mat_33]]
-;
-
-save_
-
-save_atom_sites_cartn_transform.matrix_su
-
-    _definition.id                '_atom_sites_Cartn_transform.matrix_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.matrix.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               matrix_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.matrix'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_atom_sites_cartn_transform.vec_1
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_1'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_vector_1'
-         '_atom_sites.Cartn_transf_vector[1]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_1
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
-
-save_
-
-save_atom_sites_cartn_transform.vec_1_su
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_1_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.vec_1.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_1_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_1'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.vec_2
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_2'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_vector_2'
-         '_atom_sites.Cartn_transf_vector[2]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_2
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
-
-save_
-
-save_atom_sites_cartn_transform.vec_2_su
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_2_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.vec_2.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_2_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_2'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.vec_3
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_3'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_Cartn_tran_vector_3'
-         '_atom_sites.Cartn_transf_vector[3]'
-
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_3
-
-    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
-
-save_
-
-save_atom_sites_cartn_transform.vec_3_su
-
-    _definition.id                '_atom_sites_Cartn_transform.vec_3_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.vec_3.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vec_3_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_3'
-    _units.code                   angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_cartn_transform.vector
-
-    _definition.id                '_atom_sites_Cartn_transform.vector'
-    _definition.update            2021-07-07
-    _description.text
-;
-    The 3x1 translation is used with _atom_sites_Cartn_transform.matrix
-    used to transform fractional coordinates to Cartesian coordinates.
-    The axial alignments of this transformation are described in
-    _atom_sites_Cartn_transform.axes.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vector
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With t as atom_sites_Cartn_transform
-
-    _atom_sites_Cartn_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
-;
-
-save_
-
-save_atom_sites_cartn_transform.vector_su
-
-    _definition.id                '_atom_sites_Cartn_transform.vector_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_Cartn_transform.vector.
-;
-    _name.category_id             atom_sites_Cartn_transform
-    _name.object_id               vector_su
-    _name.linked_item_id          '_atom_sites_Cartn_transform.vector'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   angstroms
-
-save_
-
-save_ATOM_SITES_FRACT_TRANSFORM
-
-    _definition.id                ATOM_SITES_FRACT_TRANSFORM
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2021-03-03
-    _description.text
-;
-    The CATEGORY of data items used to describe the matrix elements
-    used to transform Cartesian coordinates into fractional coordinates
-    of all atom sites in a crystal structure.
-;
-    _name.category_id             ATOM_SITES
-    _name.object_id               ATOM_SITES_FRACT_TRANSFORM
-
-save_
-
-save_atom_sites_fract_transform.axes
-
-    _definition.id                '_atom_sites_fract_transform.axes'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_transform_axes'
-         '_atom_sites.fract_transform_axes'
-
-    _definition.update            2012-12-11
-    _description.text
-;
-    Description of the relative alignment of the crystal cell axes to the
-    Cartesian orthogonal axes as applied in the transformation matrix
-    _atom_sites_fract_transform.matrix.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               axes
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'a parallel to x; b in the plane of x & y'
-
-save_
-
-save_atom_sites_fract_transform.mat_11
-
-    _definition.id                '_atom_sites_fract_transform.mat_11'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_11'
-         '_atom_sites.fract_transf_matrix[1][1]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_11
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_11_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_11_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_11.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_11_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_11'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_12
-
-    _definition.id                '_atom_sites_fract_transform.mat_12'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_12'
-         '_atom_sites.fract_transf_matrix[1][2]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_12
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_12_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_12_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_12.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_12_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_12'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_13
-
-    _definition.id                '_atom_sites_fract_transform.mat_13'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_13'
-         '_atom_sites.fract_transf_matrix[1][3]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_13
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_13_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_13_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_13.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_13_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_13'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_21
-
-    _definition.id                '_atom_sites_fract_transform.mat_21'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_21'
-         '_atom_sites.fract_transf_matrix[2][1]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_21
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_21_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_21_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_21.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_21_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_21'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_22
-
-    _definition.id                '_atom_sites_fract_transform.mat_22'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_22'
-         '_atom_sites.fract_transf_matrix[2][2]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_22
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_22_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_22_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_22.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_22_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_22'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_23
-
-    _definition.id                '_atom_sites_fract_transform.mat_23'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_23'
-         '_atom_sites.fract_transf_matrix[2][3]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_23
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_23_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_23_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_23.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_23_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_23'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_31
-
-    _definition.id                '_atom_sites_fract_transform.mat_31'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_31'
-         '_atom_sites.fract_transf_matrix[3][1]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_31
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_31_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_31_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_31.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_31_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_31'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_32
-
-    _definition.id                '_atom_sites_fract_transform.mat_32'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_32'
-         '_atom_sites.fract_transf_matrix[3][2]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_32
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_32_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_32_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_32.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_32_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_32'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.mat_33
-
-    _definition.id                '_atom_sites_fract_transform.mat_33'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_matrix_33'
-         '_atom_sites.fract_transf_matrix[3][3]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_33
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
-
-save_
-
-save_atom_sites_fract_transform.mat_33_su
-
-    _definition.id                '_atom_sites_fract_transform.mat_33_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.mat_33.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               mat_33_su
-    _name.linked_item_id          '_atom_sites_fract_transform.mat_33'
-    _units.code                   reciprocal_angstroms
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.matrix
-
-    _definition.id                '_atom_sites_fract_transform.matrix'
-    _definition.update            2021-07-21
-    _description.text
-;
-    Matrix used to transform Cartesian coordinates in the ATOM_SITE
-    category to fractional coordinates. The axial alignments of this
-    transformation are described in _atom_sites_fract_transform.axes.
-    The 3 x 1 translation is defined in _atom_sites_fract_transform.vector.
-
-      x'                   |11 12 13|     x                  | 1 |
-    ( y' )fractional = mat |21 22 23| * ( y ) Cartesian + vec| 2 |
-      z'                   |31 32 33|     z                  | 3 |
-
-    The default transformation matrix uses Rollet's axial
-    assignments with cell vectors a,b,c aligned with orthogonal
-    axes X,Y,Z so that c||Z and b in plane YZ.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               matrix
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With a as atom_sites_fract_transform
-
-    _atom_sites_fract_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
-                                          [a.mat_21, a.mat_22, a.mat_23],
-                                          [a.mat_31, a.mat_32, a.mat_33]]
-;
-
-save_
-
-save_atom_sites_fract_transform.matrix_su
-
-    _definition.id                '_atom_sites_fract_transform.matrix_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.matrix.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               matrix_su
-    _name.linked_item_id          '_atom_sites_fract_transform.matrix'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3,3]'
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_sites_fract_transform.vec_1
-
-    _definition.id                '_atom_sites_fract_transform.vec_1'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_vector_1'
-         '_atom_sites.fract_transf_vector[1]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_1
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
-
-save_
-
-save_atom_sites_fract_transform.vec_1_su
-
-    _definition.id                '_atom_sites_fract_transform.vec_1_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.vec_1.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_1_su
-    _name.linked_item_id          '_atom_sites_fract_transform.vec_1'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.vec_2
-
-    _definition.id                '_atom_sites_fract_transform.vec_2'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_vector_2'
-         '_atom_sites.fract_transf_vector[2]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_2
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
-
-save_
-
-save_atom_sites_fract_transform.vec_2_su
-
-    _definition.id                '_atom_sites_fract_transform.vec_2_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.vec_2.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_2_su
-    _name.linked_item_id          '_atom_sites_fract_transform.vec_2'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.vec_3
-
-    _definition.id                '_atom_sites_fract_transform.vec_3'
-
-    loop_
-      _alias.definition_id
-         '_atom_sites_fract_tran_vector_3'
-         '_atom_sites.fract_transf_vector[3]'
-
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_3
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
-
-save_
-
-save_atom_sites_fract_transform.vec_3_su
-
-    _definition.id                '_atom_sites_fract_transform.vec_3_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.vec_3.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vec_3_su
-    _name.linked_item_id          '_atom_sites_fract_transform.vec_3'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_sites_fract_transform.vector
-
-    _definition.id                '_atom_sites_fract_transform.vector'
-    _definition.update            2021-03-01
-    _description.text
-;
-    The 3x1 translation is used with _atom_sites_fract_transform.matrix
-    used to transform Cartesian coordinates to fractional coordinates.
-    The axial alignments of this transformation are described in
-    _atom_sites_fract_transform.axes.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vector
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With t as atom_sites_fract_transform
-
-    _atom_sites_fract_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
-;
-
-save_
-
-save_atom_sites_fract_transform.vector_su
-
-    _definition.id                '_atom_sites_fract_transform.vector_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_sites_fract_transform.vector.
-;
-    _name.category_id             atom_sites_fract_transform
-    _name.object_id               vector_su
-    _name.linked_item_id          '_atom_sites_fract_transform.vector'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               Matrix
-    _type.dimension               '[3]'
-    _type.contents                Real
-    _units.code                   none
-
-save_
-
-save_ATOM_TYPE
-
-    _definition.id                ATOM_TYPE
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2021-06-29
-    _description.text
-;
-    The CATEGORY of data items used to describe atomic type information
-    used in crystallographic structure studies.
-;
-    _name.category_id             ATOM
-    _name.object_id               ATOM_TYPE
-    _category_key.name            '_atom_type.symbol'
-    _method.purpose               Evaluation
-    _method.expression
-;
-    typelist  = List()
-
-    Loop  a  as  atom_site  {
-       type = AtomType ( a.label )
-       If( type not in typelist )  typelist ++= type
-     }
-     For type in typelist {
-                             atom_type(.symbol         = type,
-                                       .number_in_cell = '?'   )
-     }
-;
-
-save_
-
-save_atom_type.analytical_mass_percent
-
-    _definition.id                '_atom_type.analytical_mass_percent'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_analytical_mass_%'
-         '_atom_type.analytical_mass_%'
-
-    _definition.update            2013-04-11
-    _description.text
-;
-    Mass percentage of this atom type derived from chemical analysis.
-;
-    _name.category_id             atom_type
-    _name.object_id               analytical_mass_percent
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:100.0
-    _units.code                   none
-
-save_
-
-save_atom_type.analytical_mass_percent_su
-
-    _definition.id                '_atom_type.analytical_mass_percent_su'
-    _definition.update            2021-09-23
-    _description.text
-;
-    Standard uncertainty of _atom_type.analytical_mass_percent.
-;
-    _name.category_id             atom_type
-    _name.object_id               analytical_mass_percent_su
-    _name.linked_item_id          '_atom_type.analytical_mass_percent'
-    _units.code                   none
-
-    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
-
-save_
-
-save_atom_type.atomic_mass
-
-    _definition.id                '_atom_type.atomic_mass'
-    _definition.update            2012-11-20
-    _description.text
-;
-    Mass of this atom type.
-;
-    _name.category_id             atom_type
-    _name.object_id               atomic_mass
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.def_index_id     '_atom_type.symbol'
-
-    _import.get                   [{'file':templ_enum.cif  'save':atomic_mass}]
-
-save_
-
-save_atom_type.atomic_number
-
-    _definition.id                '_atom_type.atomic_number'
-    _definition.update            2023-06-01
-    _description.text
-;
-    Atomic number of this atom type.
-;
-    _name.category_id             atom_type
-    _name.object_id               atomic_number
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _enumeration.def_index_id     '_atom_type.element_symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':atomic_number}]
-
-save_
-
-save_atom_type.description
-
-    _definition.id                '_atom_type.description'
-    _alias.definition_id          '_atom_type_description'
-    _definition.update            2023-01-13
-    _description.text
-;
-    A description of the atom(s) designated by this atom type. In
-    most cases this will be the element name and oxidation state of
-    a single atom species. For disordered or nonstoichiometric
-    structures it will describe a combination of atom species.
-;
-    _name.category_id             atom_type
-    _name.object_id               description
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-    loop_
-      _description_example.case
-         deuterium
-         0.34Fe+0.66Ni
-
-save_
-
-save_atom_type.display_colour
-
-    _definition.id                '_atom_type.display_colour'
-    _definition.update            2023-02-06
-    _description.text
-;
-    The display colour assigned to this atom type. Note that the
-    possible colours are enumerated in the DISPLAY_COLOUR list
-    category of items.
-;
-    _name.category_id             atom_type
-    _name.object_id               display_colour
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.def_index_id     '_atom_type.symbol'
-
-    _import.get                   [
-                                   {'file':templ_enum.cif  'save':colour_rgb}
-                                   {'file':templ_enum.cif  'save':colour_hue}
-                                  ]
-
-save_
-
-save_atom_type.electron_count
-
-    _definition.id                '_atom_type.electron_count'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Number of electrons in this atom type.
-;
-    _name.category_id             atom_type
-    _name.object_id               electron_count
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _enumeration.def_index_id     '_atom_type.symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':electron_count}]
-
-save_
-
-save_atom_type.element_symbol
-
-    _definition.id                '_atom_type.element_symbol'
-    _definition.update            2021-10-27
-    _description.text
-;
-    Element symbol for of this atom type. The default value is extracted
-    from the ion-to-element enumeration_default list using the index
-    value of _atom_type.symbol.
-;
-    _name.category_id             atom_type
-    _name.object_id               element_symbol
-    _type.purpose                 State
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-    _enumeration.def_index_id     '_atom_type.symbol'
-
-    _import.get
-        [
-         {'file':templ_enum.cif  'save':element_symbol}
-         {'file':templ_enum.cif  'save':ion_to_element}
-        ]
-
-save_
-
-save_atom_type.key
-
-    _definition.id                '_atom_type.key'
-    _definition.update            2021-10-27
-    _description.text
-;
-    Value is a unique key to a set of ATOM_TYPE items
-    in a looped list.
-;
-    _name.category_id             atom_type
-    _name.object_id               key
-    _type.purpose                 Key
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-    _method.purpose               Evaluation
-    _method.expression
-;
-    _atom_type.key = _atom_type.symbol
-;
-
-save_
-
-save_atom_type.mass_number
-
-    _definition.id                '_atom_type.mass_number'
-    _definition.update            2023-05-22
-    _description.text
-;
-    Mass number of this atom type.
-
-    Used to denote a specific isotope. Special value '.' indicates
-    that the element is present in natural isotopic abundance.
-;
-    _name.category_id             atom_type
-    _name.object_id               mass_number
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _units.code                   none
-
-save_
-
-save_atom_type.number_in_cell
-
-    _definition.id                '_atom_type.number_in_cell'
-    _alias.definition_id          '_atom_type_number_in_cell'
-    _definition.update            2013-01-28
-    _description.text
-;
-    Total number of atoms of this atom type in the unit cell.
-;
-    _name.category_id             atom_type
-    _name.object_id               number_in_cell
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With t as atom_type
-
-    cnt =  0.
-
-    Loop a  as  atom_site  {
-
-       if ( a.type_symbol == t.symbol ) {
-
-          cnt +=  a.occupancy * a.site_symmetry_multiplicity
-    }  }
-    _atom_type.number_in_cell =  cnt
-;
-
-save_
-
-save_atom_type.oxidation_number
-
-    _definition.id                '_atom_type.oxidation_number'
-    _alias.definition_id          '_atom_type_oxidation_number'
-    _definition.update            2021-03-01
-    _description.text
-;
-    Formal oxidation state of this atom type in the structure.
-;
-    _name.category_id             atom_type
-    _name.object_id               oxidation_number
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            -8:8
-    _units.code                   none
-
-save_
-
-save_atom_type.radius_bond
-
-    _definition.id                '_atom_type.radius_bond'
-    _alias.definition_id          '_atom_type_radius_bond'
-    _definition.update            2012-11-20
-    _description.text
-;
-    The effective intra-molecular bonding radius of this atom type.
-;
-    _name.category_id             atom_type
-    _name.object_id               radius_bond
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:5.0
-    _enumeration.def_index_id     '_atom_type.symbol'
-
-    _import.get                   [{'file':templ_enum.cif  'save':radius_bond}]
-
-save_
-
-save_atom_type.radius_contact
-
-    _definition.id                '_atom_type.radius_contact'
-    _alias.definition_id          '_atom_type_radius_contact'
-    _definition.update            2012-11-20
-    _description.text
-;
-    The effective inter-molecular bonding radius of this atom type.
-;
-    _name.category_id             atom_type
-    _name.object_id               radius_contact
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.range            0.0:5.0
-    _units.code                   angstroms
-    _method.purpose               Definition
-    _method.expression
-;
-    _enumeration.default = _atom_type.radius_bond + 1.25
-;
-
-save_
-
-save_atom_type.symbol
-
-    _definition.id                '_atom_type.symbol'
-    _alias.definition_id          '_atom_type_symbol'
-    _definition.update            2021-10-27
-    _description.text
-;
-    The identity of the atom specie(s) representing this atom type.
-    Normally this code is the element symbol followed by the charge
-    if there is one. The symbol may be composed of any character except
-    an underline or a blank, with the proviso that digits designate an
-    oxidation state and must be followed by a + or - character.
-;
-    _name.category_id             atom_type
-    _name.object_id               symbol
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-    loop_
-      _description_example.case
-         Mg
-         Cu2+
-         dummy
-         FeNi
-
-save_
-
-save_ATOM_TYPE_SCAT
-
-    _definition.id                ATOM_TYPE_SCAT
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2021-06-29
-    _description.text
-;
-    The CATEGORY of data items used to describe atomic scattering
-    information used in crystallographic structure studies.
-;
-    _name.category_id             ATOM_TYPE
-    _name.object_id               ATOM_TYPE_SCAT
-    _category_key.name            '_atom_type_scat.symbol'
-
-save_
-
-save_atom_type_scat.cromer_mann_a1
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_a1'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_a1'
-         '_atom_type.scat_Cromer_Mann_a1'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_a1
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_a1}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_a2
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_a2'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_a2'
-         '_atom_type.scat_Cromer_Mann_a2'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_a2
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_a2}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_a3
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_a3'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_a3'
-         '_atom_type.scat_Cromer_Mann_a3'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_a3
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_a3}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_a4
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_a4'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_a4'
-         '_atom_type.scat_Cromer_Mann_a4'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_a4
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_a4}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_b1
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_b1'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_b1'
-         '_atom_type.scat_Cromer_Mann_b1'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_b1
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_b1}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_b2
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_b2'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_b2'
-         '_atom_type.scat_Cromer_Mann_b2'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_b2
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_b2}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_b3
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_b3'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_b3'
-         '_atom_type.scat_Cromer_Mann_b3'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_b3
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_b3}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_b4
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_b4'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_b4'
-         '_atom_type.scat_Cromer_Mann_b4'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_b4
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_b4}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_c
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_c'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_Cromer_Mann_c'
-         '_atom_type.scat_Cromer_Mann_c'
-
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_c
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':cromer_mann_coeff}
-         {'file':templ_enum.cif  'save':cromer_mann_c}
-        ]
-
-save_
-
-save_atom_type_scat.cromer_mann_coeffs
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_coeffs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Cromer-Mann coefficients for generating X-ray scattering
-    factors. [ c, a1, b1, a2, b2, a3, b3, a4, b4 ]
-    Ref: International Tables for Crystallography, Vol. C
-            (1991) Table 6.1.1.4
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_coeffs
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[9]'
-    _type.contents                Real
-    _units.code                   unspecified
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With t  as  atom_type_scat
-
-     _atom_type_scat.Cromer_Mann_coeffs  =          [ t.Cromer_Mann_c,
-                                    t.Cromer_Mann_a1, t.Cromer_Mann_b1,
-                                    t.Cromer_Mann_a2, t.Cromer_Mann_b2,
-                                    t.Cromer_Mann_a3, t.Cromer_Mann_b3,
-                                    t.Cromer_Mann_a4, t.Cromer_Mann_b4 ]
-;
-
-save_
-
-save_atom_type_scat.dispersion
-
-    _definition.id                '_atom_type_scat.dispersion'
-    _definition.update            2013-04-28
-    _description.text
-;
-    The anomalous dispersion scattering factor in its complex form
-    for this atom type and radiation by _diffrn_radiation_wavelength.value
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Complex
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With s as atom_type_scat
-
-            d = Complex( s.dispersion_real, s.dispersion_imag )
-
-       if(_reflns.apply_dispersion_to_Fcalc == 'no')   d = 0.
-
-                _atom_type_scat.dispersion = d
-;
-
-save_
-
-save_atom_type_scat.dispersion_imag
-
-    _definition.id                '_atom_type_scat.dispersion_imag'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_dispersion_imag'
-         '_atom_type.scat_dispersion_imag'
-
-    _definition.update            2021-09-24
-    _description.text
-;
-    The imaginary component of the anomalous dispersion scattering factors
-    for this atom type and radiation by _diffrn_radiation_wavelength.value
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_imag
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With q as atom_type_scat
-
-     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_imag_Cu
-     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_imag_Mo
-
-             _atom_type_scat.dispersion_imag = a
-;
-
-save_
-
-save_atom_type_scat.dispersion_imag_cu
-
-    _definition.id                '_atom_type_scat.dispersion_imag_Cu'
-    _definition.update            2023-06-01
-    _description.text
-;
-    The imaginary component of the anomalous dispersion scattering factors
-    for this atom type and Cu Kα radiation.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_imag_Cu
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.def_index_id     '_atom_type.element_symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':dispersion_imag_cu}]
-
-save_
-
-save_atom_type_scat.dispersion_imag_mo
-
-    _definition.id                '_atom_type_scat.dispersion_imag_Mo'
-    _definition.update            2023-06-01
-    _description.text
-;
-    The imaginary component of the anomalous dispersion scattering factors
-    for this atom type and Mo Kα radiation.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_imag_Mo
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.def_index_id     '_atom_type.element_symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':dispersion_imag_mo}]
-
-save_
-
-save_atom_type_scat.dispersion_real
-
-    _definition.id                '_atom_type_scat.dispersion_real'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_dispersion_real'
-         '_atom_type.scat_dispersion_real'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    The real component of the anomalous dispersion scattering factors
-    for this atom type and radiation by _diffrn_radiation_wavelength.value
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_real
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   none
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With q as atom_type_scat
-
-     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_real_Cu
-     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_real_Mo
-
-             _atom_type_scat.dispersion_real = a
-;
-
-save_
-
-save_atom_type_scat.dispersion_real_cu
-
-    _definition.id                '_atom_type_scat.dispersion_real_Cu'
-    _definition.update            2023-06-01
-    _description.text
-;
-    The real component of the anomalous dispersion scattering factors
-    for this atom type and Cu Kα radiation.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_real_Cu
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.def_index_id     '_atom_type.element_symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':dispersion_real_cu}]
-
-save_
-
-save_atom_type_scat.dispersion_real_mo
-
-    _definition.id                '_atom_type_scat.dispersion_real_Mo'
-    _definition.update            2023-06-01
-    _description.text
-;
-    The real component of the anomalous dispersion scattering factors
-    for this atom type and Mo Kα radiation.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_real_Mo
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _enumeration.def_index_id     '_atom_type.element_symbol'
-
-    _import.get
-        [{'file':templ_enum.cif  'save':dispersion_real_mo}]
-
-save_
-
-save_atom_type_scat.dispersion_source
-
-    _definition.id                '_atom_type_scat.dispersion_source'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_dispersion_source'
-         '_atom_type.scat_dispersion_source'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    Reference to source of real and imaginary dispersion
-    corrections for scattering factors used for this atom type.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               dispersion_source
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'International Tables Vol. IV Table 2.3.1'
-
-save_
-
-save_atom_type_scat.exponential_polynomial_coefs
-
-    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of polynomial coefficients for generating X-ray scattering factors:
-    [ a_0, a_1, ... , a_N ].
-
-    f(s; Z) = exp(Sum(a~i~ * s^i^), i=0:N)
-
-    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
-    of the incident radiation in angstroms.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.exponential_polynomial_coefs_su
-
-    _definition.id
-        '_atom_type_scat.exponential_polynomial_coefs_su'
-    _definition.update            2023-06-16
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coefs_su
-    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.exponential_polynomial_lower_limit
-
-    _definition.id
-        '_atom_type_scat.exponential_polynomial_lower_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The inclusive lower limit of s for which the corresponding exponential
-    polynomial coefficients are valid.
-
-    See _atom_type_scat.exponential_polynomial_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_lower_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.exponential_polynomial_upper_limit
-
-    _definition.id
-        '_atom_type_scat.exponential_polynomial_upper_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The exclusive upper limit of s for which the corresponding exponential
-    polynomial coefficients are valid.
-
-    See _atom_type_scat.exponential_polynomial_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_upper_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.gaussian_coefs
-
-    _definition.id                '_atom_type_scat.Gaussian_coefs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Gaussian coefficients for generating X-ray scattering factors:
-    [ c, a_1, b_1, a_2, b_2, ... , a_N, b_N ].
-
-    f(s; Z) = c + Sum(a~i~ * exp(-b~i~ * s^2^), i=1:N)
-
-    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
-    of the incident radiation in angstroms.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.gaussian_coefs_su
-
-    _definition.id                '_atom_type_scat.Gaussian_coefs_su'
-    _definition.update            2023-06-16
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.Gaussian_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_coefs_su
-    _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.gaussian_lower_limit
-
-    _definition.id                '_atom_type_scat.Gaussian_lower_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The inclusive lower limit of s for which the corresponding Gaussian
-    coefficients are valid.
-
-    See _atom_type_scat.Gaussian_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_lower_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.gaussian_upper_limit
-
-    _definition.id                '_atom_type_scat.Gaussian_upper_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The exclusive upper limit of s for which the corresponding Gaussian
-    coefficients are valid.
-
-    See _atom_type_scat.Gaussian_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_upper_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.hi_ang_fox_c0
-
-    _definition.id                '_atom_type_scat.hi_ang_Fox_c0'
-    _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_c0
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
-         {'file':templ_enum.cif  'save':hi_ang_fox_c0}
-        ]
-
-save_
-
-save_atom_type_scat.hi_ang_fox_c1
-
-    _definition.id                '_atom_type_scat.hi_ang_Fox_c1'
-    _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_c1
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
-         {'file':templ_enum.cif  'save':hi_ang_fox_c1}
-        ]
-
-save_
-
-save_atom_type_scat.hi_ang_fox_c2
-
-    _definition.id                '_atom_type_scat.hi_ang_Fox_c2'
-    _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_c2
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
-         {'file':templ_enum.cif  'save':hi_ang_fox_c2}
-        ]
-
-save_
-
-save_atom_type_scat.hi_ang_fox_c3
-
-    _definition.id                '_atom_type_scat.hi_ang_Fox_c3'
-    _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_c3
-
-    _import.get
-        [
-         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
-         {'file':templ_enum.cif  'save':hi_ang_fox_c3}
-        ]
-
-save_
-
-save_atom_type_scat.hi_ang_fox_coeffs
-
-    _definition.id                '_atom_type_scat.hi_ang_Fox_coeffs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Fox et al. coefficients for generating high angle
-    X-ray scattering factors. [ c0, c1, c2, c3 ]
-    Ref: International Tables for Crystallography, Vol. C
-         (1991) Table 6.1.1.5
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_coeffs
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[4]'
-    _type.contents                Real
-    _units.code                   unspecified
-    _method.purpose               Evaluation
-    _method.expression
-;
-     With t  as  atom_type_scat
-
-    _atom_type_scat.hi_ang_Fox_coeffs  =
-    [t.hi_ang_Fox_c0,t.hi_ang_Fox_c1,t.hi_ang_Fox_c2,t.hi_ang_Fox_c3]
-;
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_coefs
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Gaussian coefficients for use in the inverse Mott-Bethe
-    relationship for generating X-ray scattering factors:
-    [ e, c_1, d_1, c_2, d_2, ... , c_N, d_N ].
-
-    f(s; Z) =
-    Z - 8π * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))
-
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z is the atomic number.
-    θ is the diffraction angle and λ is the wavelength of the incident
-    radiation in angstroms.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_coefs_su
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs_su'
-    _definition.update            2023-06-16
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_coefs_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
-    _type.purpose                 SU
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_lower_limit
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The inclusive lower limit of s for which the corresponding Gaussian
-    coefficients are valid.
-
-    See _atom_type_scat.inv_Mott_Bethe_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_lower_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_upper_limit
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_upper_limit'
-    _definition.update            2023-04-09
-    _description.text
-;
-    The exclusive upper limit of s for which the corresponding Gaussian
-    coefficients are valid.
-
-    See _atom_type_scat.inv_Mott_Bethe_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_upper_limit
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   reciprocal_angstroms
-
-save_
-
-save_atom_type_scat.length_neutron
-
-    _definition.id                '_atom_type_scat.length_neutron'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_length_neutron'
-         '_atom_type.scat_length_neutron'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    The bound coherent scattering length for the atom type at the
-    isotopic composition used for the diffraction experiment.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               length_neutron
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   femtometres
-
-save_
-
-save_atom_type_scat.source
-
-    _definition.id                '_atom_type_scat.source'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_source'
-         '_atom_type.scat_source'
-
-    _definition.update            2012-11-20
-    _description.text
-;
-    Reference to source of scattering factors used for this atom type.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               source
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'International Tables Vol. IV Table 2.4.6B'
-
-save_
-
-save_atom_type_scat.symbol
-
-    _definition.id                '_atom_type_scat.symbol'
-    _alias.definition_id          '_atom_type_scat_symbol'
-    _definition.update            2021-10-27
-    _description.text
-;
-    The identity of the atom specie(s) representing this atom type.
-    See _atom_type.symbol for further details.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               symbol
-    _name.linked_item_id          '_atom_type.symbol'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_atom_type_scat.versus_stol_list
-
-    _definition.id                '_atom_type_scat.versus_stol_list'
-
-    loop_
-      _definition_replaced.id
-      _definition_replaced.by
-         1                        '_atom_scat_versus_stol.atom_type'
-         2                        '_atom_scat_versus_stol.stol_value'
-         3                        '_atom_scat_versus_stol.scat_value'
-
-    loop_
-      _alias.definition_id
-         '_atom_type_scat_versus_stol_list'
-         '_atom_type.scat_versus_stol_list'
-
-    _definition.update            2023-07-05
-    _description.text
-;
-    Deprecated. Data items from the ATOM_SCAT_VERSUS_STOL category should be
-    used instead of this item.
-
-    A table of scattering factors as a function of sin(θ)/λ (sin theta over
-    lambda, stol). This table should be well-commented to indicate the items
-    present. Regularly formatted lists are strongly recommended.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               versus_stol_list
-    _type.purpose                 Describe
-    _type.source                  Recorded
-    _type.container               Single
-    _type.contents                Text
-
-save_
 
 save_REFINE
 
@@ -28043,7 +28043,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2023-07-05
+         3.3.0                    2023-07-10
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -28089,4 +28089,6 @@ save_
        Added ATOM_SCAT_VERSUS_STOL to allow for the explicit listing of
        scattering factor values with respect to sin theta over lambda.
        Deprecated the _atom_type_scat.versus_stol_list data item.
+
+       Add identifier for space group and structure.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -510,7 +510,7 @@ save_CELL
 ;
     _name.category_id             DIFFRN
     _name.object_id               CELL
-    _category_key.name            '_cell.diffrn_id'
+    _category_key.name            '_cell.structure_id'
 
 save_
 
@@ -748,29 +748,6 @@ save_cell.convert_uiso_to_uij_su
     _type.dimension               '[3,3]'
     _type.contents                Real
     _units.code                   none
-
-save_
-
-save_cell.diffrn_id
-
-    _definition.id                '_cell.diffrn_id'
-    _definition.update            2023-02-01
-    _description.text
-;
-    A pointer to the diffraction conditions to which this cell has been applied,
-    for example, to locate and extract diffraction peaks. These will normally be
-    the same conditions as those under which the cell was measured, but some
-    legacy data sets may have used a cell measured under differing conditions,
-    in which case those conditions should be indicated using the
-    _cell_measurement.condition_id data item.
-;
-    _name.category_id             cell
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -1536,6 +1513,23 @@ save_cell.special_details
 
 save_
 
+save_cell.structure_id
+
+    _definition.id                '_cell.structure_id'
+    _definition.update            2023-07-06
+    _description.text
+;
+    Identifier for the structure to which the cell belongs.
+;
+    _name.category_id             cell
+    _name.object_id               structure_id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_cell.vector_a
 
     _definition.id                '_cell.vector_a'
@@ -1733,7 +1727,7 @@ save_CELL_MEASUREMENT
 ;
     _name.category_id             CELL
     _name.object_id               CELL_MEASUREMENT
-    _category_key.name            '_cell_measurement.diffrn_id'
+    _category_key.name            '_cell_measurement.structure_id'
 
 save_
 
@@ -1759,25 +1753,6 @@ save_cell_measurement.condition_id
 ;
     _enumeration.default = _cell_measurement.diffrn_id
 ;
-
-save_
-
-save_cell_measurement.diffrn_id
-
-    _definition.id                '_cell_measurement.diffrn_id'
-    _definition.update            2023-02-01
-    _description.text
-;
-    A pointer to the diffraction experiment to which the measured cell
-    has been applied.
-;
-    _name.category_id             cell_measurement
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -1885,6 +1860,24 @@ save_cell_measurement.reflns_used
     _type.contents                Integer
     _enumeration.range            3:
     _units.code                   none
+
+save_
+
+save_cell_measurement.structure_id
+
+    _definition.id                '_cell_measurement.structure_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    The structure that the measured cell relates to.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -2037,6 +2030,7 @@ save_CELL_MEASUREMENT_REFLN
          '_cell_measurement_refln.index_h'
          '_cell_measurement_refln.index_k'
          '_cell_measurement_refln.index_l'
+         '_cell_measurement_refln.structure_id'
 
 save_
 
@@ -2096,6 +2090,24 @@ save_cell_measurement_refln.index_l
     _name.object_id               index_l
 
     _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_cell_measurement_refln.structure_id
+
+    _definition.id                '_cell_measurement_refln.structure_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    The structure for which the reflections were measured.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -11115,7 +11127,7 @@ save_SPACE_GROUP
     _definition.id                SPACE_GROUP
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-01-13
+    _definition.update            2023-07-10
     _description.text
 ;
     The CATEGORY of data items used to specify space group
@@ -11142,7 +11154,8 @@ save_SPACE_GROUP
 ;
     _name.category_id             EXPTL
     _name.object_id               SPACE_GROUP
-
+    _category_key.name            '_space_group.id'
+        
 save_
 
 save_space_group.bravais_type
@@ -11732,6 +11745,23 @@ save_space_group.point_group_h-m
 
 save_
 
+save_space_group.id
+
+    _definition.id                '_space_group.id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    An arbitrary identifier for this space group description.
+;
+    _name.category_id             space_group
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_symmetry.cell_setting
 
     _definition.id                '_symmetry.cell_setting'
@@ -11773,7 +11803,7 @@ save_SPACE_GROUP_GENERATOR
     _definition.id                SPACE_GROUP_GENERATOR
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2021-06-29
+    _definition.update            2023-07-10
     _description.text
 ;
     The CATEGORY of data items used to list generators for
@@ -11781,7 +11811,10 @@ save_SPACE_GROUP_GENERATOR
 ;
     _name.category_id             SPACE_GROUP
     _name.object_id               SPACE_GROUP_GENERATOR
-    _category_key.name            '_space_group_generator.key'
+    loop_
+      _category_key.name
+        '_space_group_generator.key'
+        '_space_group_generator.space_group_id'
 
 save_
 
@@ -11796,6 +11829,24 @@ save_space_group_generator.key
     _name.category_id             space_group_generator
     _name.object_id               key
     _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_space_group_generator.space_group_id
+
+    _definition.id                '_space_group_generator.space_group_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    Identifier for the space group to which the generator relates.
+;
+    _name.category_id             space_group_generator
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
@@ -11855,7 +11906,7 @@ save_SPACE_GROUP_SYMOP
     _definition.id                SPACE_GROUP_SYMOP
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2021-06-29
+    _definition.update            2023-07-10
     _description.text
 ;
     The CATEGORY of data items used to describe symmetry equivalent sites
@@ -11863,7 +11914,10 @@ save_SPACE_GROUP_SYMOP
 ;
     _name.category_id             SPACE_GROUP
     _name.object_id               SPACE_GROUP_SYMOP
-    _category_key.name            '_space_group_symop.id'
+    loop_
+      _category_key.name
+        '_space_group_symop.id'
+        '_space_group_symop.space_group_id'
 
 save_
 
@@ -12063,6 +12117,24 @@ save_space_group_symop.seitz_matrix
 
 save_
 
+save_space_group_symop.space_group_id
+
+    _definition.id                '_space_group_symop.space_group_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    Identifier for the space group to which the symop belongs.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_space_group_symop.t
 
     _definition.id                '_space_group_symop.T'
@@ -12094,7 +12166,7 @@ save_SPACE_GROUP_WYCKOFF
     _definition.id                SPACE_GROUP_WYCKOFF
     _definition.scope             Category
     _definition.class             Loop
-    _definition.update            2023-01-13
+    _definition.update            2023-07-10
     _description.text
 ;
     Contains information about Wyckoff positions of a space group.
@@ -12104,7 +12176,10 @@ save_SPACE_GROUP_WYCKOFF
 ;
     _name.category_id             SPACE_GROUP
     _name.object_id               SPACE_GROUP_WYCKOFF
-    _category_key.name            '_space_group_Wyckoff.id'
+    loop_
+      _category_key.name
+        '_space_group_Wyckoff.id'
+        '_space_group_Wyckoff.space_group_id'
 
 save_
 
@@ -12243,6 +12318,24 @@ save_space_group_wyckoff.site_symmetry
          the point group 2 with the twofold axis along one of the {100}
          directions.
 ;
+
+save_
+
+save_space_group_wyckoff.space_group_id
+
+    _definition.id                '_space_group_Wyckoff.space_group_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    Identifier for the space group that has these Wyckoff positions.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 
@@ -19853,17 +19946,76 @@ save_STRUCTURE
     _definition.id                STRUCTURE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2012-11-20
+    _definition.update            2023-07-06
     _description.text
 ;
-    The DICTIONARY group encompassing the CORE STRUCTURE data items defined
-    and used within the Crystallographic Information Framework (CIF).
+    A category for collecting information relating to the atomic-level
+    structure.
 ;
     _name.category_id             CIF_CORE
     _name.object_id               STRUCTURE
+    _category_key.name            _structure.id
 
 save_
 
+save_structure.diffrn_id
+
+    _definition.id                '_structure.diffrn_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    A pointer to the diffraction conditions to which this structure has been
+    applied, for example, to locate and extract diffraction peaks. These will
+    normally be the same conditions as those under which the cell was measured,
+    but some legacy data sets may have used a cell measured under differing
+    conditions, in which case those conditions should be indicated using the
+    _cell_measurement.condition_id data item.
+;
+    _name.category_id             structure
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.id
+
+    _definition.id                '_structure.id'
+    _definition.update            2023-06-06
+    _description.text
+;
+    Unique identifier for a structure description.
+;
+    _name.category_id             structure
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.space_group_id
+
+    _definition.id                '_structure.space_group_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    The space group of the structure.
+;
+    _name.category_id             structure
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+    
 save_ATOM
 
     _definition.id                ATOM
@@ -19875,7 +20027,7 @@ save_ATOM
     The CATEGORY of data items used to describe atomic information
     used in crystallographic structure studies.
 ;
-    _name.category_id             STRUCTURE
+    _name.category_id             CIF_CORE
     _name.object_id               ATOM
 
 save_
@@ -20574,7 +20726,10 @@ save_ATOM_SITE
 ;
     _name.category_id             ATOM
     _name.object_id               ATOM_SITE
-    _category_key.name            '_atom_site.label'
+    loop_
+      _category_key.name
+         '_atom_site.label'
+         '_atom_site.structure_id'
 
     loop_
       _description_example.case
@@ -21673,6 +21828,24 @@ save_atom_site.site_symmetry_order
 
 save_
 
+save_atom_site.structure_id
+
+    _definition.id                '_atom_site.structure_id'
+    _definition.update            2023-07-10
+    _description.text
+;
+    Identifier for the structure to which the atom site belongs.
+;
+    _name.category_id             atom_site
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_atom_site.type_symbol
 
     _definition.id                '_atom_site.type_symbol'
@@ -21847,7 +22020,11 @@ save_ATOM_SITE_ANISO
 ;
     _name.category_id             ATOM_SITE
     _name.object_id               ATOM_SITE_ANISO
-    _category_key.name            '_atom_site_aniso.label'
+
+    loop_
+      _category_key.name
+         '_atom_site_aniso.label'
+         '_atom_site_aniso.structure_id'
 
 save_
 
@@ -22463,6 +22640,24 @@ save_atom_site_aniso.ratio
     _type.contents                Real
     _enumeration.range            1.0:
     _units.code                   none
+
+save_
+
+save_atom_site_aniso.structure_id
+
+    _definition.id                '_atom_site_aniso.structure_id'
+    _definition.update            2023-07-06
+    _description.text
+;
+    Identifier for the structure to which the atom site belongs.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               structure_id
+    _name.linked_item_id          '_atom_site.structure_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -19954,7 +19954,7 @@ save_STRUCTURE
 ;
     _name.category_id             CIF_CORE
     _name.object_id               STRUCTURE
-    _category_key.name            _structure.id
+    _category_key.name            '_structure.id'
 
 save_
 


### PR DESCRIPTION
Closes #442 

Repurpose STRUCTURE category to make it possible to reference a structure, and to describe the components of a structure.
    
This pull request makes it possible to reference a "structure" in the following steps:
    
1. All categories describing the space group are assigned a "_space_group.id" key data name or pointer. This makes explicit the fact that they all relate to the same space group.
    
 2. The STRUCTURE category now holds a description of structure, which consists of a pointer to the space group and to the diffraction conditions that it relates to.
    
3. The ATOM_SITE and CELL categories now include a key data name pointer to `_structure.id`, identifying which structure an atom or cell relates to.
    
4. More controversially, `_cell.diffrn_id` has been replaced by `_structure.diffrn_id`. To strictly follow our rules, it should be deprecated, but it is unlikely to have been used since the release.

As re-ordering was necessary, the first commit in the series is the easiest one to read in order to understand the changes.
