### PR TITLE
Add explicit definition class to items in the reference dictionary.

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.2.0
-    _dictionary.date              2023-07-11
+    _dictionary.date              2023-07-13
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.2.0
@@ -753,7 +753,8 @@ save_
 save_dictionary_author.email
 
     _definition.id                '_dictionary_author.email'
-    _definition.update            2023-06-02
+    _definition.class             Attribute
+    _definition.update            2023-07-13
     _description.text
 ;
     The electronic mail address of an author of the dictionary, in a form
@@ -778,7 +779,8 @@ save_
 save_dictionary_author.id
 
     _definition.id                '_dictionary_author.id'
-    _definition.update            2023-06-02
+    _definition.class             Attribute
+    _definition.update            2023-07-13
     _description.text
 ;
     Arbitrary identifier for this author.
@@ -795,7 +797,8 @@ save_
 save_dictionary_author.id_orcid
 
     _definition.id                '_dictionary_author.id_ORCID'
-    _definition.update            2023-06-02
+    _definition.class             Attribute
+    _definition.update            2023-07-13
     _description.text
 ;
     Identifier in the ORCID Registry of a publication
@@ -816,7 +819,8 @@ save_
 save_dictionary_author.name
 
     _definition.id                '_dictionary_author.name'
-    _definition.update            2023-06-28
+    _definition.class             Attribute
+    _definition.update            2023-07-13
     _description.text
 ;
     The name of an author of this dictionary. The family name(s), followed
@@ -1240,7 +1244,8 @@ save_
 save_enumeration_defaults.source_id
 
     _definition.id                '_enumeration_defaults.source_id'
-    _definition.update            2023-06-23
+    _definition.class             Attribute
+    _definition.update            2023-07-13
     _description.text
 ;
     An identifier which corresponds to an entry in the ENUMERATION_SOURCE
@@ -3031,7 +3036,7 @@ save_
        by explicitly specifying that it adheres to the formal grammar
        provided in SemVer version 2.0.0.
 ;
-         4.2.0                    2023-07-11
+         4.2.0                    2023-07-13
 ;
        # Please update the date above and describe the change below until
        # ready for the next release


### PR DESCRIPTION
The default class of 'Datum' is not allowed in definitions of the Reference dictionary.