### PR TITLE
Updated the description of the 'Symop' content type

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -10,7 +10,7 @@ data_DDL_DIC
     _dictionary.title             DDL_DIC
     _dictionary.class             Reference
     _dictionary.version           4.2.0
-    _dictionary.date              2023-11-07
+    _dictionary.date              2023-11-14
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
     _dictionary.ddl_conformance   4.2.0
@@ -2123,8 +2123,8 @@ save_type.contents
 ;
          Symop
 ;
-         A string composed of an integer optionally followed by an underscore
-         or space and three or more digits.
+         A string composed of a positive integer optionally followed by an
+         underscore or space and three or more digits.
 ;
          Implied
 ;
@@ -2287,7 +2287,7 @@ save_type.purpose
 
     _definition.id                '_type.purpose'
     _definition.class             Attribute
-    _definition.update            2023-07-11
+    _definition.update            2023-11-14
     _description.text
 ;
     The primary purpose or function the defined data item serves in a
@@ -3039,7 +3039,7 @@ save_
        by explicitly specifying that it adheres to the formal grammar
        provided in SemVer version 2.0.0.
 ;
-         4.2.0                    2023-11-07
+         4.2.0                    2023-11-14
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -3077,4 +3077,6 @@ save_
 
        Explicitly specified that the _type.contents attribute value 'Implied'
        can only be applied in the DDLm Reference dictionary.
+
+       Updated the description of the 'Symop' content type.
 ;


### PR DESCRIPTION
This PR explicitly specifies that the first part of a `Symop` values (e.g. `2` in `2_555`) must be a positive integer as opposed to any integer. This limitation is imposed since the `_space_group_symop.id` attribute can only have integer values in the range of [1, 230]. Even if the same content type is later on reused to represent magnetic or modulated structures, the symop id will most likely still not be negative or 0. 