### PR TITLE
Rename the 'photons per second' unit to 'photons_per_second'

### DIFF
--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -10,7 +10,7 @@ data_COM_VAL
     _dictionary.title            COM_VAL
     _dictionary.class            Template
     _dictionary.version          1.4.9
-    _dictionary.date             2023-11-13
+    _dictionary.date             2023-11-27
     _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_enum.cif
     _dictionary.ddl_conformance  4.2.0
     _description.text
@@ -859,7 +859,7 @@ save_units_code
    'counts_per_photon' "measure of gain used in array detectors"
    'counts'            "counts from a detector"
    'counts_per_second' "counts from a detector per second of count time"
-   'photons per second'  "photons registered in one second"
+   'photons_per_second'  "photons registered in one second"
 
    'microseconds_per_angstrom' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-1))'"
    'microseconds_per_angstrom_squared' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-2))'"
@@ -2350,7 +2350,7 @@ save_
        'electrons_per_angstrom_cubed', 'electrons_per_picometre_cubed' and
        'femtometre_squared' enumeration states in the 'units_code' save frame.
 ;
-         1.4.9                    2023-11-13
+         1.4.9                    2023-11-27
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -2376,4 +2376,6 @@ save_
        the Greek letter 'alpha'.
 
        Added hertz and counts_per_second to units_code.
+
+       Renamed the 'photons per second' unit to 'photons_per_second'.
 ;


### PR DESCRIPTION
Closes #303.

The 'photons per second' units were renamed to 'photons_per_second' in the upcoming version 1.8.8 of the `cif_img.dic` dictionary [1] so the same change can be reflected in DDLm as well.

Although it is unlikely that the units will change again, we might want to wait until the release of version 1.8.8 just to be safe before merging this PR.

[1] https://github.com/yayahjb/cbf_imgcif_dictionary/tree/main