### PR TITLE
Add dictionary URIs for deprecated data names

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -2642,11 +2642,15 @@ save_diffrn_detector.description
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_radiation_detector'                                1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
          '_diffrn_detector'                                          .
+         ?
          '_diffrn_detector.detector'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Description of the type of diffraction radiation detector.
@@ -2692,11 +2696,15 @@ save_diffrn_detector.dtime
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_detector_dtime'                                    .
+         ?
          '_diffrn_radiation.detector_dtime'                          .
+         ?
          '_diffrn_radiation_detector_dtime'                          1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The maximum time between two detector signals that cannot be resolved.
@@ -4575,12 +4583,17 @@ save_diffrn_refln.intensity_net_su
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_refln_intensity_u'                                 .
+         ?
          '_diffrn_refln_intensity_sigma'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_refln.intensity_sigma'                             .
+         ?
          '_diffrn_refln.intensity_u'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Standard uncertainty of _diffrn_refln.intensity_net.
@@ -4941,12 +4954,17 @@ save_diffrn_reflns.av_suneti_over_neti
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_reflns_av_sigmaI/netI'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_reflns.av_unetI/netI'                              .
+         ?
          '_diffrn_reflns_av_unetI/netI'                              .
+         ?
          '_diffrn_reflns.av_sigmaI_over_netI'                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Recorded [sum |su(netI)| / sum |netI|] for all measured reflections.
@@ -5382,13 +5400,19 @@ save_diffrn_reflns_class.av_sui_over_i
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_reflns_class_av_uI_over_I'                         .
+         ?
          '_diffrn_reflns_class.av_uI/I'                              .
+         ?
          '_diffrn_reflns_class_av_uI/I'                              .
+         ?
          '_diffrn_reflns_class.av_sgI/I'                             .
+         ?
          '_diffrn_reflns_class_av_sgI/I'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Recorded [sum|su(net I)|/sum|net I|] in a reflection class.
@@ -5886,9 +5910,13 @@ save_diffrn_source.description
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_source'                                            .
+         ?
          '_diffrn_radiation_source'                                  1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
          '_diffrn_source.source'                                     .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -6282,12 +6310,17 @@ save_diffrn_standards.scale_su_average
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_standards_scale_sigma'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_standards.scale_sigma'                             .
+         ?
          '_diffrn_standards.scale_u'                                 .
+         ?
          '_diffrn_standards_scale_u'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The average standard uncertainty of the individual standard scales
@@ -7161,12 +7194,17 @@ save_refln.include_status
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refln_include_status'                                     .
+         ?
          '_refln_observed_status'                                    1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refln.observed_status'                                    .
+         ?
          '_refln.status'                                             .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Code indicating how the reflection was included in the refinement
@@ -7925,11 +7963,15 @@ save_reflns.number_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_number_gt'                                         .
+         ?
          '_reflns_number_observed'                                   1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns.number_obs'                                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
@@ -8010,11 +8052,15 @@ save_reflns.threshold_expression
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_threshold_expression'                              .
+         ?
          '_reflns_observed_criterion'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns.observed_criterion'                                .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Description of the criterion used to classify a reflection as having a
@@ -8587,12 +8633,17 @@ save_reflns_shell.meani_over_sui_all
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_meanI_over_uI_all'                           .
+         ?
          '_reflns_shell_meanI_over_sigI_all'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.meanI_over_sigI_all'                         .
+         ?
          '_reflns_shell.meanI_over_uI_all'                           .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Ratio of the mean intensity in a shell to the mean standard uncertainty
@@ -8616,14 +8667,21 @@ save_reflns_shell.meani_over_sui_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_meanI_over_sigI_obs'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.meanI_over_sigI_obs'                         .
+         ?
          '_reflns_shell.meanI_over_sigI_gt'                          .
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell_meanI_over_sigI_gt'                          1999-03-24
+         ?
          '_reflns_shell.meanI_over_uI_gt'                            .
+         ?
          '_reflns_shell_meanI_over_uI_gt'                            .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Ratio of the mean intensity of significantly intense reflections (see
@@ -8668,11 +8726,15 @@ save_reflns_shell.number_measured_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_number_measured_obs'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.number_measured_obs'                         .
+         ?
          '_reflns_shell_number_measured_gt'                          .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Number of reflections measured for this resolution shell which are
@@ -8741,11 +8803,15 @@ save_reflns_shell.number_unique_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_number_unique_gt'                            .
+         ?
          '_reflns_shell_number_unique_obs'                           1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.number_unique_obs'                           .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Number of symmetry-unique reflections present in this reflection shell
@@ -8789,11 +8855,15 @@ save_reflns_shell.percent_possible_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_percent_possible_gt'                         .
+         ?
          '_reflns_shell_percent_possible_obs'                        1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.percent_possible_obs'                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Percentage of reflections present in this shell which are significantly
@@ -8848,11 +8918,15 @@ save_reflns_shell.rmerge_f_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_Rmerge_F_obs'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.Rmerge_F_obs'                                .
+         ?
          '_reflns_shell_Rmerge_F_gt'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Rmerge(F) for reflections in a shell which are significantly intense
@@ -8908,11 +8982,15 @@ save_reflns_shell.rmerge_i_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_Rmerge_I_obs'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.Rmerge_I_obs'                                .
+         ?
          '_reflns_shell_Rmerge_I_gt'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Rmerge(I) for reflections in a shell which are significantly intense
@@ -12075,11 +12153,15 @@ save_space_group.it_number
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_IT_number'                                    .
+         ?
          '_symmetry.Int_Tables_number'                               .
+         ?
          '_symmetry_Int_Tables_number'                               2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The number as assigned in International Tables for Crystallography
@@ -12232,8 +12314,11 @@ save_space_group.name_h-m_full
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_symmetry.space_group_name_H-M'                            .
+         ?
          '_symmetry_space_group_name_H-M'                            2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2025-06-18
     _description.text
@@ -12331,9 +12416,13 @@ save_space_group.name_hall
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_name_Hall'                                    .
+         ?
          '_symmetry_space_group_name_Hall'                           2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
          '_symmetry.space_group_name_Hall'                           .
+         ?
 
     _definition.update            2023-02-13
     _description.text
@@ -12485,6 +12574,8 @@ save_symmetry.cell_setting
     _definition_replaced.by       '_space_group.crystal_system'
     _alias.definition_id          '_symmetry_cell_setting'
     _alias.deprecation_date       2003-10-04
+    _alias.dictionary_uri
+        https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
     _definition.update            2024-02-14
     _description.text
 ;
@@ -12621,9 +12712,13 @@ save_space_group_symop.id
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_symop_id'                                     .
+         ?
          '_symmetry_equiv.pos_site_id'                               .
+         ?
          '_symmetry_equiv_pos_site_id'                               2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2024-02-14
     _description.text
@@ -12676,9 +12771,13 @@ save_space_group_symop.operation_xyz
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_symop_operation_xyz'                          .
+         ?
          '_symmetry_equiv.pos_as_xyz'                                .
+         ?
          '_symmetry_equiv_pos_as_xyz'                                2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2024-02-14
     _description.text
@@ -21569,11 +21668,15 @@ save_atom_site.adp_type
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_atom_site_ADP_type'                                       .
+         ?
          '_atom_site_thermal_displace_type'                          1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_atom_site.thermal_displace_type'                          .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Code for type of atomic displacement parameters used for the site.
@@ -22552,9 +22655,13 @@ save_atom_site.site_symmetry_multiplicity
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_atom_site_site_symmetry_multiplicity'                     .
+         ?
          '_atom_site_symmetry_multiplicity'                          2014-05-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.4.4.dic
          '_atom_site.symmetry_multiplicity'                          .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -27367,12 +27474,17 @@ save_refine_ls.goodness_of_fit_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_goodness_of_fit_gt'                             .
+         ?
          '_refine_ls_goodness_of_fit_obs'                            1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine.ls_goodness_of_fit_obs'                            .
+         ?
          '_refine.ls_goodness_of_fit_gt'                             .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Least-squares goodness-of-fit parameter S for significantly
@@ -27811,10 +27923,15 @@ save_refine_ls.r_factor_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_R_factor_obs'                                   1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine_ls_R_factor_gt'                                    .
+         ?
          '_refine.ls_R_factor_obs'                                   .
+         ?
          '_refine.ls_R_factor_gt'                                    .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -27996,9 +28113,13 @@ save_refine_ls.restrained_s_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_restrained_S_obs'                               1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine_ls_restrained_S_gt'                                .
+         ?
          '_refine.ls_restrained_S_obs'                               .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28161,13 +28282,19 @@ save_refine_ls.shift_over_su_max
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_shift_over_su_max'                              .
+         ?
          '_refine.ls_shift_over_esd_max'                             .
+         ?
          '_refine.ls_shift_over_su_max'                              .
+         ?
          '_refine_ls_shift/su_max'                                   .
+         ?
          '_refine_ls_shift/esd_max'                                  1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The largest ratio of the final least-squares parameter shift
@@ -28220,13 +28347,19 @@ save_refine_ls.shift_over_su_mean
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_shift_over_su_mean'                             .
+         ?
          '_refine.ls_shift_over_esd_mean'                            .
+         ?
          '_refine.ls_shift_over_su_mean'                             .
+         ?
          '_refine_ls_shift/su_mean'                                  .
+         ?
          '_refine_ls_shift/esd_mean'                                 1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The average ratio of the final least-squares parameter shift
@@ -28408,11 +28541,15 @@ save_refine_ls.wr_factor_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_wR_factor_obs'                                  1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine.ls_wR_factor_obs'                                  .
+         ?
          '_refine_ls_wR_factor_gt'                                   .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Weighted residual factors for significantly intense reflections
@@ -29186,6 +29323,7 @@ save_
        equipment.
 
        Added the _dictionary.licensing_SPDX dictionary attribute.
+
        Renamed the Head category from 'CIF_CORE' to 'CIF_CORE_HEAD'.
 
        Corrected the definition of a* in _atom_site.B_iso_or_equiv and
@@ -29196,4 +29334,6 @@ save_
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
+
+       Added dictionary URIs for deprecated data names.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-05-04
+    _dictionary.date              2026-05-05
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -2643,14 +2643,16 @@ save_diffrn_detector.description
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_radiation_detector'                                1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
          '_diffrn_detector'                                          .
-         ?
+         ? ?
          '_diffrn_detector.detector'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Description of the type of diffraction radiation detector.
@@ -2697,14 +2699,16 @@ save_diffrn_detector.dtime
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_detector_dtime'                                    .
-         ?
+         ? ?
          '_diffrn_radiation.detector_dtime'                          .
-         ?
+         ? ?
          '_diffrn_radiation_detector_dtime'                          1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The maximum time between two detector signals that cannot be resolved.
@@ -4584,16 +4588,18 @@ save_diffrn_refln.intensity_net_su
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_refln_intensity_u'                                 .
-         ?
+         ? ?
          '_diffrn_refln_intensity_sigma'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_refln.intensity_sigma'                             .
-         ?
+         ? ?
          '_diffrn_refln.intensity_u'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Standard uncertainty of _diffrn_refln.intensity_net.
@@ -4955,16 +4961,18 @@ save_diffrn_reflns.av_suneti_over_neti
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_reflns_av_sigmaI/netI'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_reflns.av_unetI/netI'                              .
-         ?
+         ? ?
          '_diffrn_reflns_av_unetI/netI'                              .
-         ?
+         ? ?
          '_diffrn_reflns.av_sigmaI_over_netI'                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Recorded [sum |su(netI)| / sum |netI|] for all measured reflections.
@@ -5401,18 +5409,20 @@ save_diffrn_reflns_class.av_sui_over_i
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_reflns_class_av_uI_over_I'                         .
-         ?
+         ? ?
          '_diffrn_reflns_class.av_uI/I'                              .
-         ?
+         ? ?
          '_diffrn_reflns_class_av_uI/I'                              .
-         ?
+         ? ?
          '_diffrn_reflns_class.av_sgI/I'                             .
-         ?
+         ? ?
          '_diffrn_reflns_class_av_sgI/I'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Recorded [sum|su(net I)|/sum|net I|] in a reflection class.
@@ -5911,12 +5921,14 @@ save_diffrn_source.description
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_source'                                            .
-         ?
+         ? ?
          '_diffrn_radiation_source'                                  1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
          '_diffrn_source.source'                                     .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -6311,16 +6323,18 @@ save_diffrn_standards.scale_su_average
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_standards_scale_sigma'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_standards.scale_sigma'                             .
-         ?
+         ? ?
          '_diffrn_standards.scale_u'                                 .
-         ?
+         ? ?
          '_diffrn_standards_scale_u'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The average standard uncertainty of the individual standard scales
@@ -7195,16 +7209,18 @@ save_refln.include_status
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refln_include_status'                                     .
-         ?
+         ? ?
          '_refln_observed_status'                                    1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refln.observed_status'                                    .
-         ?
+         ? ?
          '_refln.status'                                             .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Code indicating how the reflection was included in the refinement
@@ -7964,14 +7980,16 @@ save_reflns.number_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_number_gt'                                         .
-         ?
+         ? ?
          '_reflns_number_observed'                                   1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns.number_obs'                                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
@@ -8053,14 +8071,16 @@ save_reflns.threshold_expression
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_threshold_expression'                              .
-         ?
+         ? ?
          '_reflns_observed_criterion'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns.observed_criterion'                                .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Description of the criterion used to classify a reflection as having a
@@ -8634,16 +8654,18 @@ save_reflns_shell.meani_over_sui_all
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_meanI_over_uI_all'                           .
-         ?
+         ? ?
          '_reflns_shell_meanI_over_sigI_all'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.meanI_over_sigI_all'                         .
-         ?
+         ? ?
          '_reflns_shell.meanI_over_uI_all'                           .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Ratio of the mean intensity in a shell to the mean standard uncertainty
@@ -8668,20 +8690,23 @@ save_reflns_shell.meani_over_sui_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_meanI_over_sigI_obs'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.meanI_over_sigI_obs'                         .
-         ?
+         ? ?
          '_reflns_shell.meanI_over_sigI_gt'                          .
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell_meanI_over_sigI_gt'                          1999-03-24
-         ?
+         ? ?
          '_reflns_shell.meanI_over_uI_gt'                            .
-         ?
+         ? ?
          '_reflns_shell_meanI_over_uI_gt'                            .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Ratio of the mean intensity of significantly intense reflections (see
@@ -8727,14 +8752,16 @@ save_reflns_shell.number_measured_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_number_measured_obs'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.number_measured_obs'                         .
-         ?
+         ? ?
          '_reflns_shell_number_measured_gt'                          .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Number of reflections measured for this resolution shell which are
@@ -8804,14 +8831,16 @@ save_reflns_shell.number_unique_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_number_unique_gt'                            .
-         ?
+         ? ?
          '_reflns_shell_number_unique_obs'                           1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.number_unique_obs'                           .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Number of symmetry-unique reflections present in this reflection shell
@@ -8856,14 +8885,16 @@ save_reflns_shell.percent_possible_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_percent_possible_gt'                         .
-         ?
+         ? ?
          '_reflns_shell_percent_possible_obs'                        1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.percent_possible_obs'                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Percentage of reflections present in this shell which are significantly
@@ -8919,14 +8950,16 @@ save_reflns_shell.rmerge_f_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_Rmerge_F_obs'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.Rmerge_F_obs'                                .
-         ?
+         ? ?
          '_reflns_shell_Rmerge_F_gt'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Rmerge(F) for reflections in a shell which are significantly intense
@@ -8983,14 +9016,16 @@ save_reflns_shell.rmerge_i_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_Rmerge_I_obs'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.Rmerge_I_obs'                                .
-         ?
+         ? ?
          '_reflns_shell_Rmerge_I_gt'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Rmerge(I) for reflections in a shell which are significantly intense
@@ -12154,14 +12189,16 @@ save_space_group.it_number
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_IT_number'                                    .
-         ?
+         ? ?
          '_symmetry.Int_Tables_number'                               .
-         ?
+         ? ?
          '_symmetry_Int_Tables_number'                               2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The number as assigned in International Tables for Crystallography
@@ -12315,10 +12352,12 @@ save_space_group.name_h-m_full
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_symmetry.space_group_name_H-M'                            .
-         ?
+         ? ?
          '_symmetry_space_group_name_H-M'                            2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2025-06-18
     _description.text
@@ -12417,12 +12456,14 @@ save_space_group.name_hall
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_name_Hall'                                    .
-         ?
+         ? ?
          '_symmetry_space_group_name_Hall'                           2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
          '_symmetry.space_group_name_Hall'                           .
-         ?
+         ? ?
 
     _definition.update            2023-02-13
     _description.text
@@ -12576,6 +12617,7 @@ save_symmetry.cell_setting
     _alias.deprecation_date       2003-10-04
     _alias.dictionary_uri
         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+    _alias.dictionary_version     2.3
     _definition.update            2024-02-14
     _description.text
 ;
@@ -12713,12 +12755,14 @@ save_space_group_symop.id
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_symop_id'                                     .
-         ?
+         ? ?
          '_symmetry_equiv.pos_site_id'                               .
-         ?
+         ? ?
          '_symmetry_equiv_pos_site_id'                               2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2024-02-14
     _description.text
@@ -12772,12 +12816,14 @@ save_space_group_symop.operation_xyz
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_symop_operation_xyz'                          .
-         ?
+         ? ?
          '_symmetry_equiv.pos_as_xyz'                                .
-         ?
+         ? ?
          '_symmetry_equiv_pos_as_xyz'                                2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2024-02-14
     _description.text
@@ -21669,14 +21715,16 @@ save_atom_site.adp_type
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_atom_site_ADP_type'                                       .
-         ?
+         ? ?
          '_atom_site_thermal_displace_type'                          1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_atom_site.thermal_displace_type'                          .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Code for type of atomic displacement parameters used for the site.
@@ -22656,12 +22704,14 @@ save_atom_site.site_symmetry_multiplicity
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_atom_site_site_symmetry_multiplicity'                     .
-         ?
+         ? ?
          '_atom_site_symmetry_multiplicity'                          2014-05-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.4.4.dic
+         2.4.4
          '_atom_site.symmetry_multiplicity'                          .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -27475,16 +27525,18 @@ save_refine_ls.goodness_of_fit_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_goodness_of_fit_gt'                             .
-         ?
+         ? ?
          '_refine_ls_goodness_of_fit_obs'                            1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine.ls_goodness_of_fit_obs'                            .
-         ?
+         ? ?
          '_refine.ls_goodness_of_fit_gt'                             .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Least-squares goodness-of-fit parameter S for significantly
@@ -27924,14 +27976,16 @@ save_refine_ls.r_factor_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_R_factor_obs'                                   1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine_ls_R_factor_gt'                                    .
-         ?
+         ? ?
          '_refine.ls_R_factor_obs'                                   .
-         ?
+         ? ?
          '_refine.ls_R_factor_gt'                                    .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28114,12 +28168,14 @@ save_refine_ls.restrained_s_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_restrained_S_obs'                               1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine_ls_restrained_S_gt'                                .
-         ?
+         ? ?
          '_refine.ls_restrained_S_obs'                               .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28283,18 +28339,20 @@ save_refine_ls.shift_over_su_max
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_shift_over_su_max'                              .
-         ?
+         ? ?
          '_refine.ls_shift_over_esd_max'                             .
-         ?
+         ? ?
          '_refine.ls_shift_over_su_max'                              .
-         ?
+         ? ?
          '_refine_ls_shift/su_max'                                   .
-         ?
+         ? ?
          '_refine_ls_shift/esd_max'                                  1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The largest ratio of the final least-squares parameter shift
@@ -28348,18 +28406,20 @@ save_refine_ls.shift_over_su_mean
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_shift_over_su_mean'                             .
-         ?
+         ? ?
          '_refine.ls_shift_over_esd_mean'                            .
-         ?
+         ? ?
          '_refine.ls_shift_over_su_mean'                             .
-         ?
+         ? ?
          '_refine_ls_shift/su_mean'                                  .
-         ?
+         ? ?
          '_refine_ls_shift/esd_mean'                                 1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The average ratio of the final least-squares parameter shift
@@ -28542,14 +28602,16 @@ save_refine_ls.wr_factor_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_wR_factor_obs'                                  1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine.ls_wR_factor_obs'                                  .
-         ?
+         ? ?
          '_refine_ls_wR_factor_gt'                                   .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Weighted residual factors for significantly intense reflections
@@ -29330,10 +29392,13 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-05-04
+         3.4.0                    2026-05-05
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
 
        Added dictionary URIs for deprecated data names.
+
+       Added dictionary URIs and dictionary version numbers for deprecated
+       data names.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -2643,14 +2643,16 @@ save_diffrn_detector.description
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_radiation_detector'                                1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
          '_diffrn_detector'                                          .
-         ?
+         ? ?
          '_diffrn_detector.detector'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Description of the type of diffraction radiation detector.
@@ -2697,14 +2699,16 @@ save_diffrn_detector.dtime
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_detector_dtime'                                    .
-         ?
+         ? ?
          '_diffrn_radiation.detector_dtime'                          .
-         ?
+         ? ?
          '_diffrn_radiation_detector_dtime'                          1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The maximum time between two detector signals that cannot be resolved.
@@ -4584,16 +4588,18 @@ save_diffrn_refln.intensity_net_su
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_refln_intensity_u'                                 .
-         ?
+         ? ?
          '_diffrn_refln_intensity_sigma'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_refln.intensity_sigma'                             .
-         ?
+         ? ?
          '_diffrn_refln.intensity_u'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Standard uncertainty of _diffrn_refln.intensity_net.
@@ -4955,16 +4961,18 @@ save_diffrn_reflns.av_suneti_over_neti
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_reflns_av_sigmaI/netI'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_reflns.av_unetI/netI'                              .
-         ?
+         ? ?
          '_diffrn_reflns_av_unetI/netI'                              .
-         ?
+         ? ?
          '_diffrn_reflns.av_sigmaI_over_netI'                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Recorded [sum |su(netI)| / sum |netI|] for all measured reflections.
@@ -5401,18 +5409,20 @@ save_diffrn_reflns_class.av_sui_over_i
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_reflns_class_av_uI_over_I'                         .
-         ?
+         ? ?
          '_diffrn_reflns_class.av_uI/I'                              .
-         ?
+         ? ?
          '_diffrn_reflns_class_av_uI/I'                              .
-         ?
+         ? ?
          '_diffrn_reflns_class.av_sgI/I'                             .
-         ?
+         ? ?
          '_diffrn_reflns_class_av_sgI/I'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Recorded [sum|su(net I)|/sum|net I|] in a reflection class.
@@ -5911,12 +5921,14 @@ save_diffrn_source.description
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_source'                                            .
-         ?
+         ? ?
          '_diffrn_radiation_source'                                  1997-01-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
+         2.0.1
          '_diffrn_source.source'                                     .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -6311,16 +6323,18 @@ save_diffrn_standards.scale_su_average
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_diffrn_standards_scale_sigma'                             1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_diffrn_standards.scale_sigma'                             .
-         ?
+         ? ?
          '_diffrn_standards.scale_u'                                 .
-         ?
+         ? ?
          '_diffrn_standards_scale_u'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The average standard uncertainty of the individual standard scales
@@ -7195,16 +7209,18 @@ save_refln.include_status
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refln_include_status'                                     .
-         ?
+         ? ?
          '_refln_observed_status'                                    1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refln.observed_status'                                    .
-         ?
+         ? ?
          '_refln.status'                                             .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Code indicating how the reflection was included in the refinement
@@ -7964,14 +7980,16 @@ save_reflns.number_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_number_gt'                                         .
-         ?
+         ? ?
          '_reflns_number_observed'                                   1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns.number_obs'                                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
@@ -8053,14 +8071,16 @@ save_reflns.threshold_expression
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_threshold_expression'                              .
-         ?
+         ? ?
          '_reflns_observed_criterion'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns.observed_criterion'                                .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Description of the criterion used to classify a reflection as having a
@@ -8634,16 +8654,18 @@ save_reflns_shell.meani_over_sui_all
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_meanI_over_uI_all'                           .
-         ?
+         ? ?
          '_reflns_shell_meanI_over_sigI_all'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.meanI_over_sigI_all'                         .
-         ?
+         ? ?
          '_reflns_shell.meanI_over_uI_all'                           .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Ratio of the mean intensity in a shell to the mean standard uncertainty
@@ -8668,20 +8690,23 @@ save_reflns_shell.meani_over_sui_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_meanI_over_sigI_obs'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.meanI_over_sigI_obs'                         .
-         ?
+         ? ?
          '_reflns_shell.meanI_over_sigI_gt'                          .
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell_meanI_over_sigI_gt'                          1999-03-24
-         ?
+         ? ?
          '_reflns_shell.meanI_over_uI_gt'                            .
-         ?
+         ? ?
          '_reflns_shell_meanI_over_uI_gt'                            .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Ratio of the mean intensity of significantly intense reflections (see
@@ -8727,14 +8752,16 @@ save_reflns_shell.number_measured_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_number_measured_obs'                         1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.number_measured_obs'                         .
-         ?
+         ? ?
          '_reflns_shell_number_measured_gt'                          .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Number of reflections measured for this resolution shell which are
@@ -8804,14 +8831,16 @@ save_reflns_shell.number_unique_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_number_unique_gt'                            .
-         ?
+         ? ?
          '_reflns_shell_number_unique_obs'                           1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.number_unique_obs'                           .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Number of symmetry-unique reflections present in this reflection shell
@@ -8856,14 +8885,16 @@ save_reflns_shell.percent_possible_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_percent_possible_gt'                         .
-         ?
+         ? ?
          '_reflns_shell_percent_possible_obs'                        1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.percent_possible_obs'                        .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Percentage of reflections present in this shell which are significantly
@@ -8919,14 +8950,16 @@ save_reflns_shell.rmerge_f_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_Rmerge_F_obs'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.Rmerge_F_obs'                                .
-         ?
+         ? ?
          '_reflns_shell_Rmerge_F_gt'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Rmerge(F) for reflections in a shell which are significantly intense
@@ -8983,14 +9016,16 @@ save_reflns_shell.rmerge_i_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_reflns_shell_Rmerge_I_obs'                                1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_reflns_shell.Rmerge_I_obs'                                .
-         ?
+         ? ?
          '_reflns_shell_Rmerge_I_gt'                                 .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Rmerge(I) for reflections in a shell which are significantly intense
@@ -12152,14 +12187,16 @@ save_space_group.it_number
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_IT_number'                                    .
-         ?
+         ? ?
          '_symmetry.Int_Tables_number'                               .
-         ?
+         ? ?
          '_symmetry_Int_Tables_number'                               2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The number as assigned in International Tables for Crystallography
@@ -12313,10 +12350,12 @@ save_space_group.name_h-m_full
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_symmetry.space_group_name_H-M'                            .
-         ?
+         ? ?
          '_symmetry_space_group_name_H-M'                            2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2025-06-18
     _description.text
@@ -12415,12 +12454,14 @@ save_space_group.name_hall
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_name_Hall'                                    .
-         ?
+         ? ?
          '_symmetry_space_group_name_Hall'                           2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
          '_symmetry.space_group_name_Hall'                           .
-         ?
+         ? ?
 
     _definition.update            2023-02-13
     _description.text
@@ -12574,6 +12615,7 @@ save_symmetry.cell_setting
     _alias.deprecation_date       2003-10-04
     _alias.dictionary_uri
         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+    _alias.dictionary_version     2.3
     _definition.update            2024-02-14
     _description.text
 ;
@@ -12711,12 +12753,14 @@ save_space_group_symop.id
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_symop_id'                                     .
-         ?
+         ? ?
          '_symmetry_equiv.pos_site_id'                               .
-         ?
+         ? ?
          '_symmetry_equiv_pos_site_id'                               2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2024-02-14
     _description.text
@@ -12770,12 +12814,14 @@ save_space_group_symop.operation_xyz
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_space_group_symop_operation_xyz'                          .
-         ?
+         ? ?
          '_symmetry_equiv.pos_as_xyz'                                .
-         ?
+         ? ?
          '_symmetry_equiv_pos_as_xyz'                                2003-10-04
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
+         2.3
 
     _definition.update            2024-02-14
     _description.text
@@ -21744,14 +21790,16 @@ save_atom_site.adp_type
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_atom_site_ADP_type'                                       .
-         ?
+         ? ?
          '_atom_site_thermal_displace_type'                          1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_atom_site.thermal_displace_type'                          .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Code for type of atomic displacement parameters used for the site.
@@ -22731,12 +22779,14 @@ save_atom_site.site_symmetry_multiplicity
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_atom_site_site_symmetry_multiplicity'                     .
-         ?
+         ? ?
          '_atom_site_symmetry_multiplicity'                          2014-05-20
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.4.4.dic
+         2.4.4
          '_atom_site.symmetry_multiplicity'                          .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -27556,16 +27606,18 @@ save_refine_ls.goodness_of_fit_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_goodness_of_fit_gt'                             .
-         ?
+         ? ?
          '_refine_ls_goodness_of_fit_obs'                            1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine.ls_goodness_of_fit_obs'                            .
-         ?
+         ? ?
          '_refine.ls_goodness_of_fit_gt'                             .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Least-squares goodness-of-fit parameter S for significantly
@@ -28005,14 +28057,16 @@ save_refine_ls.r_factor_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_R_factor_obs'                                   1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine_ls_R_factor_gt'                                    .
-         ?
+         ? ?
          '_refine.ls_R_factor_obs'                                   .
-         ?
+         ? ?
          '_refine.ls_R_factor_gt'                                    .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28195,12 +28249,14 @@ save_refine_ls.restrained_s_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_restrained_S_obs'                               1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine_ls_restrained_S_gt'                                .
-         ?
+         ? ?
          '_refine.ls_restrained_S_obs'                               .
-         ?
+         ? ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28364,18 +28420,20 @@ save_refine_ls.shift_over_su_max
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_shift_over_su_max'                              .
-         ?
+         ? ?
          '_refine.ls_shift_over_esd_max'                             .
-         ?
+         ? ?
          '_refine.ls_shift_over_su_max'                              .
-         ?
+         ? ?
          '_refine_ls_shift/su_max'                                   .
-         ?
+         ? ?
          '_refine_ls_shift/esd_max'                                  1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The largest ratio of the final least-squares parameter shift
@@ -28429,18 +28487,20 @@ save_refine_ls.shift_over_su_mean
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_shift_over_su_mean'                             .
-         ?
+         ? ?
          '_refine.ls_shift_over_esd_mean'                            .
-         ?
+         ? ?
          '_refine.ls_shift_over_su_mean'                             .
-         ?
+         ? ?
          '_refine_ls_shift/su_mean'                                  .
-         ?
+         ? ?
          '_refine_ls_shift/esd_mean'                                 1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     The average ratio of the final least-squares parameter shift
@@ -28623,14 +28683,16 @@ save_refine_ls.wr_factor_gt
       _alias.definition_id
       _alias.deprecation_date
       _alias.dictionary_uri
+      _alias.dictionary_version
          '_refine_ls_wR_factor_obs'                                  1999-03-24
          https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
+         2.1
          '_refine.ls_wR_factor_obs'                                  .
-         ?
+         ? ?
          '_refine_ls_wR_factor_gt'                                   .
-         ?
+         ? ?
 
-    _definition.update            2024-02-20
+    _definition.update            2026-05-05
     _description.text
 ;
     Weighted residual factors for significantly intense reflections
@@ -29437,4 +29499,7 @@ save_
        from 'rot_anode' to 'rot-anode'.
 
        Added dictionary URIs for deprecated data names.
+
+       Added dictionary URIs and dictionary version numbers for deprecated
+       data names.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -2642,11 +2642,15 @@ save_diffrn_detector.description
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_radiation_detector'                                1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
          '_diffrn_detector'                                          .
+         ?
          '_diffrn_detector.detector'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Description of the type of diffraction radiation detector.
@@ -2692,11 +2696,15 @@ save_diffrn_detector.dtime
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_detector_dtime'                                    .
+         ?
          '_diffrn_radiation.detector_dtime'                          .
+         ?
          '_diffrn_radiation_detector_dtime'                          1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The maximum time between two detector signals that cannot be resolved.
@@ -4575,12 +4583,17 @@ save_diffrn_refln.intensity_net_su
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_refln_intensity_u'                                 .
+         ?
          '_diffrn_refln_intensity_sigma'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_refln.intensity_sigma'                             .
+         ?
          '_diffrn_refln.intensity_u'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Standard uncertainty of _diffrn_refln.intensity_net.
@@ -4941,12 +4954,17 @@ save_diffrn_reflns.av_suneti_over_neti
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_reflns_av_sigmaI/netI'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_reflns.av_unetI/netI'                              .
+         ?
          '_diffrn_reflns_av_unetI/netI'                              .
+         ?
          '_diffrn_reflns.av_sigmaI_over_netI'                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Recorded [sum |su(netI)| / sum |netI|] for all measured reflections.
@@ -5382,13 +5400,19 @@ save_diffrn_reflns_class.av_sui_over_i
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_reflns_class_av_uI_over_I'                         .
+         ?
          '_diffrn_reflns_class.av_uI/I'                              .
+         ?
          '_diffrn_reflns_class_av_uI/I'                              .
+         ?
          '_diffrn_reflns_class.av_sgI/I'                             .
+         ?
          '_diffrn_reflns_class_av_sgI/I'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Recorded [sum|su(net I)|/sum|net I|] in a reflection class.
@@ -5886,9 +5910,13 @@ save_diffrn_source.description
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_source'                                            .
+         ?
          '_diffrn_radiation_source'                                  1997-01-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.0.1.dic
          '_diffrn_source.source'                                     .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -6282,12 +6310,17 @@ save_diffrn_standards.scale_su_average
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_diffrn_standards_scale_sigma'                             1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_diffrn_standards.scale_sigma'                             .
+         ?
          '_diffrn_standards.scale_u'                                 .
+         ?
          '_diffrn_standards_scale_u'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The average standard uncertainty of the individual standard scales
@@ -7161,12 +7194,17 @@ save_refln.include_status
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refln_include_status'                                     .
+         ?
          '_refln_observed_status'                                    1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refln.observed_status'                                    .
+         ?
          '_refln.status'                                             .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Code indicating how the reflection was included in the refinement
@@ -7925,11 +7963,15 @@ save_reflns.number_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_number_gt'                                         .
+         ?
          '_reflns_number_observed'                                   1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns.number_obs'                                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
@@ -8010,11 +8052,15 @@ save_reflns.threshold_expression
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_threshold_expression'                              .
+         ?
          '_reflns_observed_criterion'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns.observed_criterion'                                .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Description of the criterion used to classify a reflection as having a
@@ -8587,12 +8633,17 @@ save_reflns_shell.meani_over_sui_all
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_meanI_over_uI_all'                           .
+         ?
          '_reflns_shell_meanI_over_sigI_all'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.meanI_over_sigI_all'                         .
+         ?
          '_reflns_shell.meanI_over_uI_all'                           .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Ratio of the mean intensity in a shell to the mean standard uncertainty
@@ -8616,14 +8667,21 @@ save_reflns_shell.meani_over_sui_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_meanI_over_sigI_obs'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.meanI_over_sigI_obs'                         .
+         ?
          '_reflns_shell.meanI_over_sigI_gt'                          .
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell_meanI_over_sigI_gt'                          1999-03-24
+         ?
          '_reflns_shell.meanI_over_uI_gt'                            .
+         ?
          '_reflns_shell_meanI_over_uI_gt'                            .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Ratio of the mean intensity of significantly intense reflections (see
@@ -8668,11 +8726,15 @@ save_reflns_shell.number_measured_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_number_measured_obs'                         1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.number_measured_obs'                         .
+         ?
          '_reflns_shell_number_measured_gt'                          .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Number of reflections measured for this resolution shell which are
@@ -8741,11 +8803,15 @@ save_reflns_shell.number_unique_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_number_unique_gt'                            .
+         ?
          '_reflns_shell_number_unique_obs'                           1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.number_unique_obs'                           .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Number of symmetry-unique reflections present in this reflection shell
@@ -8789,11 +8855,15 @@ save_reflns_shell.percent_possible_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_percent_possible_gt'                         .
+         ?
          '_reflns_shell_percent_possible_obs'                        1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.percent_possible_obs'                        .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Percentage of reflections present in this shell which are significantly
@@ -8848,11 +8918,15 @@ save_reflns_shell.rmerge_f_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_Rmerge_F_obs'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.Rmerge_F_obs'                                .
+         ?
          '_reflns_shell_Rmerge_F_gt'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Rmerge(F) for reflections in a shell which are significantly intense
@@ -8908,11 +8982,15 @@ save_reflns_shell.rmerge_i_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_reflns_shell_Rmerge_I_obs'                                1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_reflns_shell.Rmerge_I_obs'                                .
+         ?
          '_reflns_shell_Rmerge_I_gt'                                 .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Rmerge(I) for reflections in a shell which are significantly intense
@@ -12073,11 +12151,15 @@ save_space_group.it_number
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_IT_number'                                    .
+         ?
          '_symmetry.Int_Tables_number'                               .
+         ?
          '_symmetry_Int_Tables_number'                               2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The number as assigned in International Tables for Crystallography
@@ -12230,8 +12312,11 @@ save_space_group.name_h-m_full
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_symmetry.space_group_name_H-M'                            .
+         ?
          '_symmetry_space_group_name_H-M'                            2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2025-06-18
     _description.text
@@ -12329,9 +12414,13 @@ save_space_group.name_hall
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_name_Hall'                                    .
+         ?
          '_symmetry_space_group_name_Hall'                           2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
          '_symmetry.space_group_name_Hall'                           .
+         ?
 
     _definition.update            2023-02-13
     _description.text
@@ -12483,6 +12572,8 @@ save_symmetry.cell_setting
     _definition_replaced.by       '_space_group.crystal_system'
     _alias.definition_id          '_symmetry_cell_setting'
     _alias.deprecation_date       2003-10-04
+    _alias.dictionary_uri
+        https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
     _definition.update            2024-02-14
     _description.text
 ;
@@ -12619,9 +12710,13 @@ save_space_group_symop.id
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_symop_id'                                     .
+         ?
          '_symmetry_equiv.pos_site_id'                               .
+         ?
          '_symmetry_equiv_pos_site_id'                               2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2024-02-14
     _description.text
@@ -12674,9 +12769,13 @@ save_space_group_symop.operation_xyz
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_space_group_symop_operation_xyz'                          .
+         ?
          '_symmetry_equiv.pos_as_xyz'                                .
+         ?
          '_symmetry_equiv_pos_as_xyz'                                2003-10-04
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.3.dic
 
     _definition.update            2024-02-14
     _description.text
@@ -21644,11 +21743,15 @@ save_atom_site.adp_type
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_atom_site_ADP_type'                                       .
+         ?
          '_atom_site_thermal_displace_type'                          1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_atom_site.thermal_displace_type'                          .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Code for type of atomic displacement parameters used for the site.
@@ -22627,9 +22730,13 @@ save_atom_site.site_symmetry_multiplicity
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_atom_site_site_symmetry_multiplicity'                     .
+         ?
          '_atom_site_symmetry_multiplicity'                          2014-05-20
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.4.4.dic
          '_atom_site.symmetry_multiplicity'                          .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -27448,12 +27555,17 @@ save_refine_ls.goodness_of_fit_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_goodness_of_fit_gt'                             .
+         ?
          '_refine_ls_goodness_of_fit_obs'                            1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine.ls_goodness_of_fit_obs'                            .
+         ?
          '_refine.ls_goodness_of_fit_gt'                             .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Least-squares goodness-of-fit parameter S for significantly
@@ -27892,10 +28004,15 @@ save_refine_ls.r_factor_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_R_factor_obs'                                   1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine_ls_R_factor_gt'                                    .
+         ?
          '_refine.ls_R_factor_obs'                                   .
+         ?
          '_refine.ls_R_factor_gt'                                    .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28077,9 +28194,13 @@ save_refine_ls.restrained_s_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_restrained_S_obs'                               1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine_ls_restrained_S_gt'                                .
+         ?
          '_refine.ls_restrained_S_obs'                               .
+         ?
 
     _definition.update            2024-02-14
     _description.text
@@ -28242,13 +28363,19 @@ save_refine_ls.shift_over_su_max
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_shift_over_su_max'                              .
+         ?
          '_refine.ls_shift_over_esd_max'                             .
+         ?
          '_refine.ls_shift_over_su_max'                              .
+         ?
          '_refine_ls_shift/su_max'                                   .
+         ?
          '_refine_ls_shift/esd_max'                                  1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The largest ratio of the final least-squares parameter shift
@@ -28301,13 +28428,19 @@ save_refine_ls.shift_over_su_mean
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_shift_over_su_mean'                             .
+         ?
          '_refine.ls_shift_over_esd_mean'                            .
+         ?
          '_refine.ls_shift_over_su_mean'                             .
+         ?
          '_refine_ls_shift/su_mean'                                  .
+         ?
          '_refine_ls_shift/esd_mean'                                 1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     The average ratio of the final least-squares parameter shift
@@ -28489,11 +28622,15 @@ save_refine_ls.wr_factor_gt
     loop_
       _alias.definition_id
       _alias.deprecation_date
+      _alias.dictionary_uri
          '_refine_ls_wR_factor_obs'                                  1999-03-24
+         https://www.iucr.org/__data/iucr/cif/dictionaries/cif_core_2.1.dic
          '_refine.ls_wR_factor_obs'                                  .
+         ?
          '_refine_ls_wR_factor_gt'                                   .
+         ?
 
-    _definition.update            2024-02-14
+    _definition.update            2024-02-20
     _description.text
 ;
     Weighted residual factors for significantly intense reflections
@@ -29267,6 +29404,7 @@ save_
        equipment.
 
        Added the _dictionary.licensing_SPDX dictionary attribute.
+
        Renamed the Head category from 'CIF_CORE' to 'CIF_CORE_HEAD'.
 
        Corrected the definition of a* in _atom_site.B_iso_or_equiv and
@@ -29297,4 +29435,6 @@ save_
 
        Changed the _diffrn_source.device data item enumeration value
        from 'rot_anode' to 'rot-anode'.
+
+       Added dictionary URIs for deprecated data names.
 ;


### PR DESCRIPTION
This PR adds dictionary URI for the deprecated aliases.

The URIs were chosen to refer to the versions of the dictionary in which those specific aliases were deprecated. These URIs might need to be changed if the definition of the `_alias.dictionary_uri` attribute get reworded (see issue #481).