### PR TITLE
Redefine cell measurement wavelength as measurand

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2024-05-17
+    _dictionary.date              2024-07-17
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -1970,7 +1970,7 @@ save_cell_measurement.wavelength
     _definition_replaced.id       1
     _definition_replaced.by       '_diffrn_radiation_wavelength.value'
     _alias.definition_id          '_cell_measurement_wavelength'
-    _definition.update            2022-05-25
+    _definition.update            2024-07-17
     _description.text
 ;
     ** DEPRECATED **
@@ -1981,12 +1981,33 @@ save_cell_measurement.wavelength
 ;
     _name.category_id             cell_measurement
     _name.object_id               wavelength
-    _type.purpose                 Number
+    _type.purpose                 Measurand
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   angstroms
+
+save_
+
+save_cell_measurement.wavelength_su
+
+    _definition.id                '_cell_measurement.wavelength_su'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn_radiation_wavelength.value_su'
+    _definition.update            2024-07-17
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of _cell_measurement.wavelength.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               wavelength_su
+    _name.linked_item_id          '_cell_measurement.wavelength'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
 
 save_
 
@@ -27861,7 +27882,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2024-05-17
+         3.3.0                    2024-07-17
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -27938,4 +27959,8 @@ save_
        Renamed the Head category from 'CIF_CORE' to 'CIF_CORE_HEAD'.
 
        Updated the dictionary description.
+
+       Redefined the _cell_measurement.wavelength data item as a measurand.
+       Added and immediately deprecated the _cell_measurement.wavelength_su
+       data item.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,15 +10,16 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2024-05-15
+    _dictionary.date              2024-05-17
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
     _dictionary.namespace         CifCore
     _description.text
 ;
-    The CIF_CORE dictionary records all the CORE data items defined
-    and used within the Crystallographic Information Framework (CIF).
+    The CIF_CORE dictionary defines data items that are common to all domains
+    of crystallographic studies. These definitions are mostly used within the
+    Crystallographic Information Framework (CIF).
 ;
 
 save_CIF_CORE_HEAD
@@ -27860,7 +27861,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2024-05-15
+         3.3.0                    2024-05-17
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -27935,4 +27936,6 @@ save_
        Changed the title of the dictionary to 'CIF_CORE'.
 
        Renamed the Head category from 'CIF_CORE' to 'CIF_CORE_HEAD'.
+
+       Updated the dictionary description.
 ;


### PR DESCRIPTION
This PR redefines the `_cell_measurement.wavelength` data item as a measurand and adds the corresponding SU item. While this data item is already deprecated, it makes sense to still correct this issue for consistency (`_cell_measurement.temperature`, `_cell_measurement.pressure` and the `_diffrn_radiation_wavelength.value` data item that superseded `_cell_measurement.wavelength` all allows SU values).

Note, that the definition of this data item in the DDL1 dictionary also did not allow SU value, but I have opened a separate PR in the DDL1 legacy dictionary repository to fix this (https://github.com/COMCIFS/DDL1-legacy-dictionaries/pull/9) that can be merged once/if this PR is approved. 