### PR TITLE
added new units - electron volts per angstrom

### DIFF
--- a/templ_enum.cif
+++ b/templ_enum.cif
@@ -883,6 +883,8 @@ save_units_code
    'microseconds_per_angstrom_squared' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-2))'"
    'microseconds_per_angstrom_cubed' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-3))'"
    'angstroms_per_microsecond'       "TOF coefficient '(metres * 10^(-10)) * (seconds * 10^(-6)^(-1))'"
+
+   'electron_volts_per_angstrom' "force 'electron volts per angstrom (eV * (metres * 10^(-10)^(-1)))'"
     save_
 
 


### PR DESCRIPTION
The new measurement unit electron volts per angstrom was added. These units are needed in Nudged Elastic Band (NEB) experiment to describe residual forces. These units are currently used in the development version of the CIF_TCOD_NEB dictionary (https://www.crystallography.net/tcod/cif/dictionaries/ddlm/cif_tcod_neb/cif_tcod_neb_0.1.0.dic , see definitions _tcod_neb_image.residual_forces, _tcod_neb_image.residual_forces_su).