### PR TITLE
Refold some dREL code for readability

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2025-05-19
+    _dictionary.date              2025-06-22
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -6518,7 +6518,7 @@ save_refln.f_complex
 
     _definition.id                '_refln.F_complex'
     _alias.definition_id          '_refln_F_complex'
-    _definition.update            2016-05-13
+    _definition.update            2025-06-22
     _description.text
 ;
     The structure factor vector for the reflection calculated from
@@ -6536,10 +6536,11 @@ save_refln.f_complex
       _method.expression
          Definition
 ;
-              If (_diffrn_radiation.probe == "neutron")  _units.code =
-         "femtometres" Else If (_diffrn_radiation.probe == "electron")
-         _units.code =  "volts" Else
-         _units.code =  "electrons"
+              If (_diffrn_radiation.probe == "neutron")
+                                              _units.code = "femtometres"
+         Else If (_diffrn_radiation.probe == "electron")
+                                              _units.code =  "volts"
+         Else                                 _units.code =  "electrons"
 ;
          Evaluation
 ;
@@ -6568,7 +6569,7 @@ save_
 save_refln.f_complex_su
 
     _definition.id                '_refln.F_complex_su'
-    _definition.update            2023-07-01
+    _definition.update            2025-06-22
     _description.text
 ;
     Standard uncertainty of _refln.F_complex.
@@ -6583,10 +6584,11 @@ save_refln.f_complex_su
     _method.purpose               Definition
     _method.expression
 ;
-         If (_diffrn_radiation.probe == "neutron")  _units.code =
-    "femtometres" Else If (_diffrn_radiation.probe == "electron")
-    _units.code =  "volts" Else
-    _units.code =  "electrons"
+              If (_diffrn_radiation.probe == "neutron")
+                                              _units.code = "femtometres"
+         Else If (_diffrn_radiation.probe == "electron")
+                                              _units.code =  "volts"
+         Else                                 _units.code =  "electrons"
 ;
 
 save_
@@ -28725,8 +28727,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-
-         3.3.0                    2025-05-19
+         3.3.0                    2025-06-22
 ;
        # Please update the date above and describe the change below until
        # ready for the next release


### PR DESCRIPTION
A systematic refolding of the dREL code for readability is probably best made by automated means, however, I ran into these particular fragments while comparing definitions which are defined in coreCIF and then redefined in pdCIF.