### PR TITLE
Remove incorrect alias for diffrn_radiation_wavelength.id

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3701,7 +3701,6 @@ save_diffrn_radiation_wavelength.id
     loop_
       _alias.definition_id
          '_diffrn_radiation_wavelength_id'
-         '_diffrn_radiation.wavelength_id'
 
     _definition.update            2023-04-04
     _description.text


### PR DESCRIPTION
`_diffrn_radiation_wavelength.id` is not an alias of `_diffrn_radiation.wavelength_id`, instead the latter is a pointer to the former.