### PR TITLE
Corrected the definition of a* in _atom_site.B_iso_or_equiv and similar

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -10,7 +10,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2025-09-18
+    _dictionary.date              2025-09-21
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -21363,7 +21363,7 @@ save_atom_site.b_iso_or_equiv
 
     _definition.id                '_atom_site.B_iso_or_equiv'
     _alias.definition_id          '_atom_site_B_iso_or_equiv'
-    _definition.update            2023-01-16
+    _definition.update            2025-09-21
     _description.text
 ;
     Isotropic atomic displacement parameter, or equivalent isotropic
@@ -21373,7 +21373,7 @@ save_atom_site.b_iso_or_equiv
         B(equiv) = (1/3) sum~i~[sum~j~(B^ij^ a*~i~ a*~j~ a~i~.a~j~)]
 
     a     = the real-space cell vectors
-    a*    = the reciprocal-space cell lengths
+    a*    = the reciprocals of the direct-space cell lengths
     B^ij^ = 8 π^2^ U^ij^
     Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
 
@@ -22388,7 +22388,7 @@ save_atom_site.u_iso_or_equiv
 
     _definition.id                '_atom_site.U_iso_or_equiv'
     _alias.definition_id          '_atom_site_U_iso_or_equiv'
-    _definition.update            2023-01-13
+    _definition.update            2025-09-21
     _description.text
 ;
     Isotropic atomic displacement parameter, or equivalent isotropic
@@ -22398,7 +22398,7 @@ save_atom_site.u_iso_or_equiv
        U(equiv) = (1/3) sum~i~[sum~j~(U^ij^ a*~i~ a*~j~ a~i~.a~j~)]
 
     a  = the real-space cell vectors
-    a* = the reciprocal-space cell lengths
+    a* = the reciprocals of the direct-space cell lengths
     Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
 ;
     _name.category_id             atom_site
@@ -28774,7 +28774,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2025-09-18
+         3.3.0                    2025-09-21
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -28918,4 +28918,8 @@ save_
        and added _cell.formula_units_Z_details. (bm)
 
        Removed the _cell_angle.beta_su and _cell_angle.gamma_su aliases.
+
+       Corrected the definition of a* in _atom_site.B_iso_or_equiv and
+       _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
+       J. Appl. Cryst. 57, 1733-1746]
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -10,7 +10,7 @@ data_TEMPL_ATTR
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.11
-    _dictionary.date             2025-05-19
+    _dictionary.date             2025-09-21
     _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_attr.cif
     _dictionary.ddl_conformance  4.2.0
     _description.text
@@ -570,7 +570,7 @@ save_aniso_bij
          T = exp{-1/4 sum~i~ [ sum~j~ (B^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
-     a* = the reciprocal-space cell lengths
+     a* = the reciprocals of the direct-space cell lengths
 
      The unique elements of the real symmetric matrix are entered by row.
 
@@ -668,7 +668,7 @@ save_aniso_uij
         T = exp{ -2π^2^ sum~i~ [ sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
-     a* = the reciprocal-space cell lengths
+     a* = the reciprocals of the direct-space cell lengths
 
      The unique elements of the real symmetric matrix are entered by row.
 
@@ -1033,7 +1033,7 @@ save_display_colour
 
        Updated description of _site_symmetry.
 ;
-         1.4.11                   2025-05-19
+         1.4.11                   2025-09-21
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -1064,4 +1064,7 @@ save_display_colour
        Updated description of _site_symmetry.
 
        Added reference to cartn_matrix and fract_matrix.
+
+       Corrected the definition of a* in save_aniso_bij and save_aniso_uij.
+       [bm, after Nespolo, M. (2024). J. Appl. Cryst. 57, 1733-1746]
 ;


### PR DESCRIPTION
Following correspondence with Massimo Nespolo (18-09-2025); He also provided a link to his paper  [Nespolo, M. (2024). _J. Appl. Cryst._ **57**, 1733-1746] for more detailed explanation:

> Dear Brian,
> 
> Sorry for the late answer, semester has started here.
> The problematic sentence is indeed the one where a*, b* and c*  are called ‘reciprocal-space cell lengths’. They are the 'reciprocal of the direct-space cell lengths', which do not coincided with the  ‘reciprocal-space cell lengths' unless the unit cell is primitive. The fact that the reciprocal of a unit cell is not a unit cell (unless the latter is primitive) has gone unnoticed for so long time that I was really surprised when I "discovered" it. But now that it has been pointed out, the imprecise sentences require correction.
> 
> Best wishes.
> 
> Massimo
