### PR TITLE
Add authors for core dictionary

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -967,7 +967,8 @@ save_cell.formula_units_z_details
     _type.container               Single
     _type.contents                Text
     _description_example.case
-;         The fractional value of Z=2/3 allows integral coefficients in
+;
+         The fractional value of Z=2/3 allows integral coefficients in
          the chemical formula, emphasizing that the compound is
          stoichiometric in spite of the multiple orderings within
          these molecular perovskites A~x~{Ni[Bi(SCN)~6~]}.
@@ -17776,7 +17777,8 @@ save_DATABASE_RELATED
     _name.object_id               DATABASE_RELATED
     _category_key.name            '_database_related.id'
     _description_example.case
-;    loop_
+;
+    loop_
       _database_related.id
       _database_related.database_id
       _database_related.entry_code
@@ -17787,7 +17789,8 @@ save_DATABASE_RELATED
        3 CSD BAPLOT01 Identical .
 ;
     _description_example.detail
-;    The loop relates a specific instance of a theophylline crystal structure
+;
+    The loop relates a specific instance of a theophylline crystal structure
     to corresponding entries in the COD and CSD crystallographic databases
     as well as to the general description of the theophyline compound in the
     CAS registry.
@@ -20567,7 +20570,8 @@ save_ATOM_ANALYTICAL
     _name.object_id               ATOM_ANALYTICAL
     _category_key.name            '_atom_analytical.id'
     _description_example.case
-;    loop_
+;
+    loop_
     _atom_analytical.id
     _atom_analytical.analyte
     _atom_analytical.meas_id
@@ -21128,7 +21132,8 @@ save_ATOM_SCAT_VERSUS_STOL
          '_atom_scat_versus_stol.stol_value'
 
     _description_example.case
-;        loop_
+;
+        loop_
         _atom_scat_versus_stol.atom_type
         _atom_scat_versus_stol.stol_value
         _atom_scat_versus_stol.scat_value
@@ -21148,7 +21153,8 @@ save_ATOM_SCAT_VERSUS_STOL
         O   6.00   0.03670
 ;
     _description_example.detail
-;        A listing of the scattering factors for Ac and O in the range
+;
+        A listing of the scattering factors for Ac and O in the range
         (0, 6.00) reciprocal angstroms.
 ;
 
@@ -28072,7 +28078,8 @@ save_refine_ls.weighting_details
     _type.container               Single
     _type.contents                Text
     _description_example.case
-;    Sigdel model of Konnert-Hendrickson:
+;
+    Sigdel model of Konnert-Hendrickson:
       Sigdel = Afsig +  Bfsig*(sin(θ)/λ - 1/6)
       Afsig  = 22.0, Bfsig = 150.0 at the beginning of refinement.
       Afsig  = 16.0, Bfsig =  60.0 at the end of refinement.
@@ -28704,23 +28711,23 @@ save_
     loop_
       _dictionary_author.id
       _dictionary_author.name
-      _dictionary_author.email
       _dictionary_author.id_orcid
-         1            'Hall, Sydney R.'               .
+      _dictionary_author.email
+         1               'Hall, Sydney R.'                  .
          .
-         2            'McMahon, Brian'                .
-         0000-0003-0391-0002
-         3            'Brown, I. D.'                  .
+         2               'McMahon, Brian'                   0000-0003-0391-0002
          .
-         4            'Toby, Brian'                   .
+         3               'Brown, I. D.'                     .
          .
-         5            'Hester, James R.'              jxh@ansto.gov.au
-         0000-0002-2004-8672
-         6            'Vaitkus, Antanas'              antanas.vaitkus@bti.vu.lt
-         0000-0002-5944-1391
-         7            'Rowles, Matthew'               .
+         4               'Toby, Brian'                      .
          .
-         8            'Bollinger, John C.'            .
+         5               'Hester, James R.'                 0000-0002-2004-8672
+         jxh@ansto.gov.au
+         6               'Vaitkus, Antanas'                 0000-0002-5944-1391
+         antanas.vaitkus@bti.vu.lt
+         7               'Rowles, Matthew'                  .
+         .
+         8               'Bollinger, John C.'               .
          .
 
     loop_


### PR DESCRIPTION
This addresses #560 . The present list was created from those with >10 lines changed in the git repository, plus those who contributed definitions to the DDL1 version. I am not proposing to add Orcid IDs or emails for retired authors or those active only on the DDL1 dictionary.

Obviously not ready for merging until we've resolved which authors want what information included.

@rowlesmr @vaitkus @jcbollinger please edit PR or comment below regarding inclusion of email and/or Orcid identifier.