### PR TITLE
Add an instrument DOI identifier

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -5894,7 +5894,9 @@ save_diffrn_source.instrument_doi
     _definition.update            2026-04-09
     _description.text
 ;
-    A DOI for the instrument used to measure the data.
+    A DOI for the instrument used to measure the data. This DOI
+    typically refers to a facility beamline or a laboratory instrument,
+    rather than to a specific component.
 ;
     _name.category_id             diffrn_source
     _name.object_id               instrument_DOI

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -5888,6 +5888,31 @@ save_diffrn_source.facility
 
 save_
 
+save_diffrn_source.instrument_doi
+
+    _definition.id                '_diffrn_source.instrument_DOI'
+    _definition.update            2026-04-09
+    _description.text
+;
+    A DOI for the instrument used to measure the data.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               instrument_DOI
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    _description_example.case     10.5442/ni000019
+    _description_example.detail
+;
+        Data were collected at the hard X-ray EMIL beamline at the BESSY
+        synchrotron. Metadata for this DOI conform to the RDA recommended
+        schema at https://doi.org/10.15497/RDA00070.
+;
+
+save_
+
 save_diffrn_source.make
 
     _definition.id                '_diffrn_source.make'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2026-02-26
+    _dictionary.date              2026-04-09
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -29034,7 +29034,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2026-02-26
+         3.3.0                    2026-04-09
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -29205,4 +29205,6 @@ save_
        Add data item for PaNET experimental method identifier.
 
        Added the _dictionary.licensing_SPDX dictionary attribute.
+
+       Add data item for instrument DOI.
 ;


### PR DESCRIPTION
This fixes #589.

Note the definition text attempts to address the scope of the DOI, as components of instruments may also be assigned instrument DOIs (e.g. detectors), but the intention of this dataname is to encompass the entire instrument. There's probably a precise way to express how far up the component hierarchy you go: maybe as far as possible without including any "instruments" that would introduce ambiguity as to the source of the data, so at a lab you could include an integrated X-ray source as part of the instrument but at a facility you would not include the synchrotron ring (as that includes all instruments on the ring), only the monochromator. Is that explanation worth including?

I've also left scope for future DOI schemes beyond the RDA recommendations, by not specifying that the DOIs should conform to the DataCite/RDA schema.