### PR TITLE
Update julia cache key to force new cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         id: cache
         with:
           path: ~/.julia
-          key: ${{ runner.os }}-julia-v2
+          key: ${{ runner.os }}-julia-v3
 
       - name: Install Julia
         uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
Changing Julia version without forcing a new cache key meant that the old cache was used leading to a failure to find the packages as the packages in the old cache were associated with the old Julia version.