### PR TITLE
add _enumeration_set.detail values to _space_group.bravais_type

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11917,20 +11917,20 @@ save_space_group.bravais_type
     loop_
       _enumeration_set.state
       _enumeration_set.detail
-         aP        'Triclinic primitive'
-         mP        'Monoclinic primitive'
-         mS        'Monoclinic centred'
-         oP        'Orthorhombic primitive'
-         oS        'Orthorhombic single-face centred'
-         oI        'Orthorhombic body-centred'
-         oF        'Orthorhombic all faces centred'
-         tP        'Tetragonal primitive'
-         tI        'Tetragonal body-centred'
-         hP        'Hexagonal primitive'
-         hR        'Rhombohedral'
-         cP        'Cubic primitive'
-         cI        'Cubic body-centred'
-         cF        'Cubic face-centred'
+         aP                       'Triclinic primitive'
+         mP                       'Monoclinic primitive'
+         mS                       'Monoclinic centred'
+         oP                       'Orthorhombic primitive'
+         oS                       'Orthorhombic single-face centred'
+         oI                       'Orthorhombic body-centred'
+         oF                       'Orthorhombic all faces centred'
+         tP                       'Tetragonal primitive'
+         tI                       'Tetragonal body-centred'
+         hP                       'Hexagonal primitive'
+         hR                       'Rhombohedral'
+         cP                       'Cubic primitive'
+         cI                       'Cubic body-centred'
+         cF                       'Cubic face-centred'
 
 save_
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11918,7 +11918,7 @@ save_space_group.bravais_type
       _enumeration_set.state
       _enumeration_set.detail
          aP        'Triclinic primitive'
-         mP        'Monoclinice primitive'
+         mP        'Monoclinic primitive'
          mS        'Monoclinic centred'
          oP        'Orthorhombic primitive'
          oS        'Orthorhombic single-face centred'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11916,23 +11916,21 @@ save_space_group.bravais_type
 
     loop_
       _enumeration_set.state
-         aP
-         mP
-         mS
-         oP
-         oS
-         oI
-         oF
-         tP
-         tI
-         hP
-         hR
-         cP
-         cI
-         cF
-
-    _description_example.case     aP
-    _description_example.detail   'Triclinic (anorthic) primitive lattice.'
+      _enumeration_set.detail
+         aP        'Triclinic primitive'
+         mP        'Monoclinice primitive'
+         mS        'Monoclinic centred'
+         oP        'Orthorhombic primitive'
+         oS        'Orthorhombic single-face centred'
+         oI        'Orthorhombic body-centred'
+         oF        'Orthorhombic all faces centred'
+         tP        'Tetragonal primitive'
+         tI        'Tetragonal body-centred'
+         hP        'Hexagonal primitive'
+         hR        'Rhombohedral'
+         cP        'Cubic primitive'
+         cI        'Cubic body-centred'
+         cF        'Cubic face-centred'
 
 save_
 


### PR DESCRIPTION
_enumeration_set.state for _space_group.bravais_type didn't have any description.

Added _enumeration_set.detail values to _space_group.bravais_type as described in https://journals.iucr.org/a/issues/1985/03/00/a24271/a24271.pdf (de Wolff et al. (1985)), as referenced in ITA.

Removed _description_example.case and .detail as it was just explaining one of the enumeration states.

Didn't update dates, as I didn't change any of the definitions.