### PR TITLE
Change the usage _audit_support.funding_organization_doi

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-05-05
+    _dictionary.date              2026-06-10
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -16417,19 +16417,19 @@ save_AUDIT_SUPPORT
     _audit_support.award_recipient
 
     1 'Engineering and Physical Sciences Research Council'
-    'https://doi.org/10.13039/501100000266'
+    10.13039/501100000266
     studentship 'EP-M506515-1' 'E. T. Broadhurst'
     2 'Swedish Funding Council'
     ?
     grant '2017-05333' 'M. Lightowler'
     3 'Wellcome Trust'
-    'https://doi.org/10.13039/100004440'
+    10.13039/100004440
     grant 'WT087658' 'University of Edinburgh EM facility'
     4 'Scottish Universities Life Sciences Alliance (SULSA)'
     ?
     other ? 'University of Edinburgh EM facility'
     5 'Harvard Medical School'
-    'https://doi.org/10.13039/100006691'
+    10.13039/100006691
     ? ? ?
 ;
     _description_example.detail
@@ -16554,27 +16554,24 @@ save_
 save_audit_support.funding_organization_doi
 
     _definition.id                '_audit_support.funding_organization_DOI'
-    _definition.update            2025-12-10
+    _definition.update            2026-06-10
     _description.text
 ;
     The Digital Object Identifier (DOI) associated with the
     Organization providing funding support for
-    the data collected and analysed in the data block. In
-    accordance with Crossref guidelines, the full URI of
-    the resolved page describing the funding organization
-    should be given (i.e. including the https://doi.org/
-    DOI resolver prefix). Note that it may be necessary to
-    URL-encode certain special characters in the DOI suffix
-    for the URI to resolve correctly through Crossref
-    (e.g. the number sign '#' must be encoded as '%23').
+    the data collected and analysed in the data block.
+
+    The display form of the DOI may differ from the
+    DOI itself; see, for example, the Crossref guidelines
+    (https://www.crossref.org/display-guidelines/).
 ;
     _name.category_id             audit_support
     _name.object_id               funding_organization_DOI
     _type.purpose                 Encode
     _type.source                  Recorded
     _type.container               Single
-    _type.contents                Word
-    _description_example.case     https://doi.org/10.13039/100000064
+    _type.contents                Text
+    _description_example.case     10.13039/100000064
 
 save_
 
@@ -29190,8 +29187,11 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-05-05
+         3.4.0                    2026-06-10
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
+
+       Specified that _audit_support.funding_organization_doi should
+       record pure DOIs without the resolver part.
 ;


### PR DESCRIPTION
This PR was created following the discussion in https://github.com/COMCIFS/cif_core/issues/572.

The updated definition explicitly states that the `_audit_support.funding_organization_doi` data item should record pure DOIs without the resolver part.

Also, I chose to remove the details about URL encoding since this it deals more with how the resolving rather than the representation of the DOI.