### PR TITLE
added dictionary author info for D.N. Rainer (#622)

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -29088,6 +29088,8 @@ save_
          .
          8               'Bollinger, John C.'               .
          .
+         9               'Rainer, Daniel N.'                0000-0002-3272-3161
+         d.n.rainer@soton.ac.uk
 
     loop_
       _dictionary_audit.version


### PR DESCRIPTION
* added dictionary author info for D.N. Rainer

(cherry picked from commit 2a00a03156d3fa88451d79152e186bcadf1c30da)