### PR TITLE
Apply minor rewording

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.3.0
-    _dictionary.date              2026-06-25
+    _dictionary.date              2026-06-30
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -3885,11 +3885,11 @@ save_diffrn_radiation_wavelength.details
          '_diffrn_radiation_wavelength_details'
          '_diffrn_radiation.wavelength_details'
 
-    _definition.update            2012-11-26
+    _definition.update            2026-06-30
     _description.text
 ;
     Information about the determination of the radiation
-    diffrn_radiation_wavelength that is not conveyed completely by an
+    _diffrn_radiation_wavelength.value that is not conveyed completely by an
     enumerated value of _diffrn_radiation_wavelength.determination.
 ;
     _name.category_id             diffrn_radiation_wavelength
@@ -29232,7 +29232,7 @@ save_
        Changed the purpose of the _diffrn_radiation_wavelength.id data item
        from 'Encode' to 'Key'.
 ;
-         3.3.0                    2026-06-25
+         3.3.0                    2026-06-30
 ;
        Expanded available form factor parameterisations, added support for
        isotopes and symmforms for atom sites. More details can be added

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -3567,13 +3567,13 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-10-15
+    _definition.update            2026-06-30
     _description.text
 ;
-    The category of data items which specify the wavelength of the
-    radiation used in measuring diffraction intensities. To identify
-    and assign weights to distinct wavelength components from a
-    polychromatic beam, see DIFFRN_RADIATION_WAVELENGTH.
+    The category of data items which describe the radiation used
+    in measuring diffraction intensities. To identify and assign
+    weights to distinct wavelength components from a beam,
+    see DIFFRN_RADIATION_WAVELENGTH.
 ;
     _name.category_id             DIFFRN
     _name.object_id               DIFFRN_RADIATION


### PR DESCRIPTION
Sorry for the late PR, I only now rediscovered these minor issues in my notes. If it is too late to include them in this release, I will reissue the PR on the main branch.

Main issues in definition descriptions addressed by this PR:
- In the latest version of the dictionary, the diffraction radiation wavelength is described by the `DIFFRN_RADIATION_WAVELENGTH` category while the `DIFFRN_RADIATION` category describes the general properties of the radiation beam. Furthermore, items in the `DIFFRN_RADIATION_WAVELENGTH` category are not exclusively used for non-polychromatic beams, thus I have removed this specific word from the `DIFFRN_RADIATION` description (it remains in the `DIFFRN_RADIATION_WAVELENGTH` description).
- The term '`diffrn_radiation_wavelength`' referred neither to a category nor a specific data item thus I have changed it to `_diffrn_radiation_wavelength.value`.