### PR TITLE
diversify `_atom_type_scat.inv_mott_bethe_*` and `_ats.gaussian_*` to better deliniate coefs

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26172,6 +26172,150 @@ save_atom_type_scat.exponential_polynomial_upper_limit
 
 save_
 
+save_atom_type_scat.gaussian_as
+
+    _definition.id                '_atom_type_scat.Gaussian_as'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian scalar coefficients for generating X-ray scattering
+    factors:
+    [ a_1, a_2, ... , a_N ].
+
+    f(s; Z) = c + Sum[a~i~ * exp(-b~i~ * s^2^), i=1:N]
+
+    where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.gaussian_bs
+              _atom_type_scat.gaussian_c
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_as
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.gaussian_as_su
+
+    _definition.id                '_atom_type_scat.Gaussian_as_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_as.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_as_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_as'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.gaussian_bs
+
+    _definition.id                '_atom_type_scat.Gaussian_bs'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian exponent coefficients for generating X-ray scattering
+    factors:
+    [ b_1, b_2, ... , b_N ].
+
+    f(s; Z) = c + Sum[a~i~ * exp(-b~i~ * s^2^), i=1:N]
+
+    where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.gaussian_as
+              _atom_type_scat.gaussian_c
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_bs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_type_scat.gaussian_bs_su
+
+    _definition.id                '_atom_type_scat.Gaussian_bs_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_bs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_bs_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_bs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_type_scat.gaussian_c
+
+    _definition.id                '_atom_type_scat.Gaussian_c'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The Gaussian constant coefficient for generating X-ray scattering factors:
+    c.
+
+    f(s; Z) = c + Sum[a~i~ * exp(-b~i~ * s^2^), i=1:N]
+
+    where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.gaussian_as
+              _atom_type_scat.gaussian_bs
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_type_scat.gaussian_c_su
+
+    _definition.id                '_atom_type_scat.Gaussian_c_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_c.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_c_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_c'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
 save_atom_type_scat.gaussian_coefs
 
     _definition.id                '_atom_type_scat.Gaussian_coefs'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26458,7 +26458,9 @@ save_atom_type_scat.gaussian_lower_limit
     The inclusive lower limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.Gaussian_coefs.
+    See also: _atom_type_scat.Gaussian_as
+              _atom_type_scat.Gaussian_bs
+              _atom_type_scat.Gaussian_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               Gaussian_lower_limit
@@ -26479,7 +26481,9 @@ save_atom_type_scat.gaussian_upper_limit
     The exclusive upper limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.Gaussian_coefs.
+    See also: _atom_type_scat.Gaussian_as
+              _atom_type_scat.Gaussian_bs
+              _atom_type_scat.Gaussian_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               Gaussian_upper_limit

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26320,8 +26320,8 @@ save_atom_type_scat.gaussian_as
     where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
     of the incident radiation in angstroms.
 
-    See also: _atom_type_scat.gaussian_bs
-              _atom_type_scat.gaussian_c
+    See also: _atom_type_scat.Gaussian_bs
+              _atom_type_scat.Gaussian_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               Gaussian_as
@@ -26369,8 +26369,8 @@ save_atom_type_scat.gaussian_bs
     where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
     of the incident radiation in angstroms.
 
-    See also: _atom_type_scat.gaussian_as
-              _atom_type_scat.gaussian_c
+    See also: _atom_type_scat.Gaussian_as
+              _atom_type_scat.Gaussian_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               Gaussian_bs

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -29686,4 +29686,12 @@ save_
        from 'rot_anode' to 'rot-anode'.
 
        Enhanced form factor parameterisations through reprovision of
+       _atom_type_scat.inv_mott_bethe_as
+       _atom_type_scat.inv_mott_bethe_bs
+       _atom_type_scat.inv_mott_bethe_c
+       _atom_type_scat.gaussian_as
+       _atom_type_scat.gaussian_bs
+       _atom_type_scat.gaussian_c
+       _atom_type_scat.cromer_mann_as
+       _atom_type_scat.cromer_mann_bs
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26760,7 +26760,9 @@ save_atom_type_scat.inv_mott_bethe_lower_limit
     The inclusive lower limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.inv_Mott_Bethe_coefs.
+    See also: _atom_type_scat.inv_mott_bethe_as
+              _atom_type_scat.inv_mott_bethe_bs
+              _atom_type_scat.inv_mott_bethe_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               inv_Mott_Bethe_lower_limit
@@ -26781,7 +26783,9 @@ save_atom_type_scat.inv_mott_bethe_upper_limit
     The exclusive upper limit of s for which the corresponding Gaussian
     coefficients are valid.
 
-    See _atom_type_scat.inv_Mott_Bethe_coefs.
+    See also: _atom_type_scat.inv_mott_bethe_as
+              _atom_type_scat.inv_mott_bethe_bs
+              _atom_type_scat.inv_mott_bethe_c
 ;
     _name.category_id             atom_type_scat
     _name.object_id               inv_Mott_Bethe_upper_limit

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -7087,12 +7087,14 @@ save_refln.form_factor_table
 
              } Else If (s < 2.0 ) {
 
-               c  =   t.Cromer_Mann_coeffs
+               cmc  =   t.Cromer_Mann_c
+               cma  =   t.Cromer_Mann_as
+               cmb  =   t.Cromer_Mann_bs
 
-               f  =  (c[0] + c[1] * Exp (-c[2] * s*s)
-                           + c[3] * Exp (-c[4] * s*s)
-                           + c[5] * Exp (-c[6] * s*s)
-                           + c[7] * Exp (-c[8] * s*s))
+               f  =  (cmc + cma[0] * Exp (-cmb[0] * s*s)
+                          + cma[1] * Exp (-cmb[1] * s*s)
+                          + cma[2] * Exp (-cmb[2] * s*s)
+                          + cma[3] * Exp (-cmb[3] * s*s))
              } Else {
 
                c  =   t.hi_ang_Fox_coeffs

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26219,8 +26219,7 @@ save_
 
 save_atom_type_scat.exponential_polynomial_coefs
 
-    _definition.id
-        '_atom_type_scat.exponential_polynomial_coef'
+    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
     _definition.update            2023-06-16
     _description.text
 ;
@@ -26254,8 +26253,7 @@ save_atom_type_scat.exponential_polynomial_coefs_su
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_coefs_su
-    _name.linked_item_id
-        '_atom_type_scat.exponential_polynomial_coefs'
+    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26593,9 +26593,9 @@ save_atom_type_scat.inv_mott_bethe_as
     [ a_1, a_2, ... , a_N ].
 
     f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
+    Z~0~ - 8π * r~B~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
 
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    where s = sin(θ)/λ, r~B~ is the Bohr radius, and Z~0~ is the number of
     electrons for the atom or ion. θ is the diffraction angle and λ is the
     wavelength of the incident radiation in angstroms.
 
@@ -26650,9 +26650,9 @@ save_atom_type_scat.inv_mott_bethe_bs
     [ b_1, b_2, ... , b_N ].
 
     f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
+    Z~0~ - 8π * r~B~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
 
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    where s = sin(θ)/λ, r~B~ is the Bohr radius, and Z~0~ is the number of
     electrons for the atom or ion. θ is the diffraction angle and λ is the
     wavelength of the incident radiation in angstroms.
 
@@ -26707,9 +26707,9 @@ save_atom_type_scat.inv_mott_bethe_c
     c.
 
     f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
+    Z~0~ - 8π * r~B~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
 
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    where s = sin(θ)/λ, r~B~ is the Bohr radius, and Z~0~ is the number of
     electrons for the atom or ion. θ is the diffraction angle and λ is the
     wavelength of the incident radiation in angstroms.
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26215,9 +26215,9 @@ save_atom_type_scat.dispersion_source
 
 save_
 
-save_atom_type_scat.exponential_polynomial_coefs
+save_atom_type_scat.exponential_polynomial_coeffs
 
-    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
+    _definition.id                '_atom_type_scat.exponential_polynomial_coeffs'
     _definition.update            2023-06-16
     _description.text
 ;
@@ -26230,7 +26230,7 @@ save_atom_type_scat.exponential_polynomial_coefs
     of the incident radiation in angstroms.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coefs
+    _name.object_id               exponential_polynomial_coeffs
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               List
@@ -26240,18 +26240,18 @@ save_atom_type_scat.exponential_polynomial_coefs
 
 save_
 
-save_atom_type_scat.exponential_polynomial_coefs_su
+save_atom_type_scat.exponential_polynomial_coeffs_su
 
     _definition.id
-        '_atom_type_scat.exponential_polynomial_coefs_su'
+        '_atom_type_scat.exponential_polynomial_coeffs_su'
     _definition.update            2023-07-01
     _description.text
 ;
-    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
+    Standard uncertainty of _atom_type_scat.exponential_polynomial_coeffs.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coefs_su
-    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
+    _name.object_id               exponential_polynomial_coeffs_su
+    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coeffs'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List
@@ -26271,7 +26271,7 @@ save_atom_type_scat.exponential_polynomial_lower_limit
     The inclusive lower limit of s for which the corresponding exponential
     polynomial coefficients are valid.
 
-    See _atom_type_scat.exponential_polynomial_coefs.
+    See _atom_type_scat.exponential_polynomial_coeffs.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_lower_limit
@@ -26293,7 +26293,7 @@ save_atom_type_scat.exponential_polynomial_upper_limit
     The exclusive upper limit of s for which the corresponding exponential
     polynomial coefficients are valid.
 
-    See _atom_type_scat.exponential_polynomial_coefs.
+    See _atom_type_scat.exponential_polynomial_coeffs.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_upper_limit

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26751,59 +26751,6 @@ save_atom_type_scat.inv_mott_bethe_c_su
 
 save_
 
-save_atom_type_scat.inv_mott_bethe_coefs
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
-    _definition.update            2025-05-16
-    _description.text
-;
-    The set of Gaussian coefficients for use in the inverse Mott-Bethe
-    relationship for generating X-ray scattering factors:
-    [ e, c_1, d_1, c_2, d_2, ... , c_N, d_N ].
-
-    f(s; Z) =
-    Z - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
-
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z is the atomic number.
-    θ is the diffraction angle and λ is the wavelength of the incident
-    radiation in angstroms.
-
-    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318–330.
-         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
-         127, 658–665.
-         Bethe, H. (1930). Ann. Phys. 397, 325–400.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_coefs_su
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs_su'
-    _definition.update            2023-07-01
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_coefs_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
 save_atom_type_scat.inv_mott_bethe_lower_limit
 
     _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25780,6 +25780,42 @@ save_atom_type_scat.cromer_mann_b4
 
 save_
 
+save_atom_type_scat.cromer_mann_bs
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_bs'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Cromer-Mann 'b' coefficients for generating X-ray scattering
+    factors:
+    [ b1, b2, b3, b4 ].
+
+    See also: _atom_type_scat.cromer_mann_as
+              _atom_type_scat.cromer_mann_c
+
+    Ref: International Tables for Crystallography (2004). Vol. C, Table 6.1.1.4.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_bs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[4]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t  as  atom_type_scat
+
+     _atom_type_scat.Cromer_Mann_bs  =  [ t.Cromer_Mann_b1,
+                                          t.Cromer_Mann_b2,
+                                          t.Cromer_Mann_b3,
+                                          t.Cromer_Mann_b4 ]
+;
+
+save_
+
 save_atom_type_scat.cromer_mann_c
 
     _definition.id                '_atom_type_scat.Cromer_Mann_c'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -7049,7 +7049,7 @@ save_
 save_refln.form_factor_table
 
     _definition.id                '_refln.form_factor_table'
-    _definition.update            2023-06-16
+    _definition.update            2026-07-14
     _description.text
 ;
     Atomic scattering factor table for the scattering angle
@@ -29739,6 +29739,12 @@ save_
        _atom_type_scat.gaussian_c
        _atom_type_scat.cromer_mann_as
        _atom_type_scat.cromer_mann_bs
+
+       Removed:
+       _atom_type_scat.inv_mott_bethe_coefs
+       _atom_type_scat.gaussian_coefs
+       _atom_type_scat.cromer_mann_coeffs
+
 
        Added _space_group.reference_setting, _space_group.transform_Pp_abc, and
        _space_group.transform_Qq_xyz from symCIF to SPACE_GROUP.

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -7097,7 +7097,7 @@ save_refln.form_factor_table
                           + cma[3] * Exp (-cmb[3] * s*s))
              } Else {
 
-               c  =   t.hi_ang_Fox_coeffs
+               c  =   t.hi_ang_Fox_coefs
 
                f  =   Exp ( c[0] + c[1]*s + c[2]*s*s + c[3]*s*s*s )
              }
@@ -26273,7 +26273,7 @@ save_atom_type_scat.exponential_polynomial_lower_limit
     The inclusive lower limit of s for which the corresponding exponential
     polynomial coefficients are valid.
 
-    See _atom_type_scat.exponential_polynomial_coeffs.
+    See _atom_type_scat.exponential_polynomial_coefs.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_lower_limit
@@ -26295,7 +26295,7 @@ save_atom_type_scat.exponential_polynomial_upper_limit
     The exclusive upper limit of s for which the corresponding exponential
     polynomial coefficients are valid.
 
-    See _atom_type_scat.exponential_polynomial_coeffs.
+    See _atom_type_scat.exponential_polynomial_coefs.
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_upper_limit

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25674,8 +25674,8 @@ save_atom_type_scat.cromer_mann_as
     factors:
     [ a1, a2, a3, a4 ].
 
-    See also: _atom_type_scat.cromer_mann_bs
-              _atom_type_scat.cromer_mann_c
+    See also: _atom_type_scat.Cromer_Mann_bs
+              _atom_type_scat.Cromer_Mann_c
 
     Ref: International Tables for Crystallography (2004). Vol. C, Table 6.1.1.4.
 ;
@@ -25790,8 +25790,8 @@ save_atom_type_scat.cromer_mann_bs
     factors:
     [ b1, b2, b3, b4 ].
 
-    See also: _atom_type_scat.cromer_mann_as
-              _atom_type_scat.cromer_mann_c
+    See also: _atom_type_scat.Cromer_Mann_as
+              _atom_type_scat.Cromer_Mann_c
 
     Ref: International Tables for Crystallography (2004). Vol. C, Table 6.1.1.4.
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-06-23
+    _dictionary.date              2026-07-14
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -26712,61 +26712,6 @@ save_atom_type_scat.inv_mott_bethe_coefs_su
 
 save_
 
-save_atom_type_scat.inv_mott_bethe_constant
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_constant'
-    _definition.update            2026-07-14
-    _description.text
-;
-    The constant for use in the inverse Mott-Bethe relationship for generating
-    X-ray scattering factors:
-    e
-
-    f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
-
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
-    electrons for the atom or ion. θ is the diffraction angle and λ is the
-    wavelength of the incident radiation in angstroms.
-
-    See also: _atom_type_scat.inv_mott_bethe_c_coefs
-              _atom_type_scat.inv_mott_bethe_d_coefs
-
-    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
-         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
-         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
-         127, 658-665.
-         Bethe, H. (1930). Ann. Phys. 397, 325-400.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_constant
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_constant_su
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_constant_su'
-    _definition.update            2026-07-14
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_constant.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_constant_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_constant'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
 save_atom_type_scat.inv_mott_bethe_lower_limit
 
     _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'
@@ -29715,7 +29660,7 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-06-23
+         3.4.0                    2026-07-14
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
@@ -29739,4 +29684,6 @@ save_
 
        Changed the _diffrn_source.device data item enumeration value
        from 'rot_anode' to 'rot-anode'.
+
+       Enhanced form factor parameterisations through reprovision of
 ;

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26217,10 +26217,10 @@ save_atom_type_scat.dispersion_source
 
 save_
 
-save_atom_type_scat.exponential_polynomial_coeffs
+save_atom_type_scat.exponential_polynomial_coefs
 
     _definition.id
-        '_atom_type_scat.exponential_polynomial_coeffs'
+        '_atom_type_scat.exponential_polynomial_coef'
     _definition.update            2023-06-16
     _description.text
 ;
@@ -26233,7 +26233,7 @@ save_atom_type_scat.exponential_polynomial_coeffs
     of the incident radiation in angstroms.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coeffs
+    _name.object_id               exponential_polynomial_coefs
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               List
@@ -26243,19 +26243,19 @@ save_atom_type_scat.exponential_polynomial_coeffs
 
 save_
 
-save_atom_type_scat.exponential_polynomial_coeffs_su
+save_atom_type_scat.exponential_polynomial_coefs_su
 
     _definition.id
-        '_atom_type_scat.exponential_polynomial_coeffs_su'
+        '_atom_type_scat.exponential_polynomial_coefs_su'
     _definition.update            2023-07-01
     _description.text
 ;
-    Standard uncertainty of _atom_type_scat.exponential_polynomial_coeffs.
+    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               exponential_polynomial_coeffs_su
+    _name.object_id               exponential_polynomial_coefs_su
     _name.linked_item_id
-        '_atom_type_scat.exponential_polynomial_coeffs'
+        '_atom_type_scat.exponential_polynomial_coefs'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List
@@ -26555,9 +26555,9 @@ save_atom_type_scat.hi_ang_fox_c3
 
 save_
 
-save_atom_type_scat.hi_ang_fox_coeffs
+save_atom_type_scat.hi_ang_fox_coefs
 
-    _definition.id                '_atom_type_scat.hi_ang_Fox_coeffs'
+    _definition.id                '_atom_type_scat.hi_ang_Fox_coefs'
     _definition.update            2023-06-16
     _description.text
 ;
@@ -26568,7 +26568,7 @@ save_atom_type_scat.hi_ang_fox_coeffs
          Table 6.1.1.5
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               hi_ang_Fox_coeffs
+    _name.object_id               hi_ang_Fox_coefs
     _type.purpose                 Number
     _type.source                  Derived
     _type.container               List
@@ -26580,7 +26580,7 @@ save_atom_type_scat.hi_ang_fox_coeffs
 ;
      With t  as  atom_type_scat
 
-    _atom_type_scat.hi_ang_Fox_coeffs  =
+    _atom_type_scat.hi_ang_Fox_coefs  =
     [t.hi_ang_Fox_c0,t.hi_ang_Fox_c1,t.hi_ang_Fox_c2,t.hi_ang_Fox_c3]
 ;
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26449,51 +26449,6 @@ save_atom_type_scat.gaussian_c_su
 
 save_
 
-save_atom_type_scat.gaussian_coefs
-
-    _definition.id                '_atom_type_scat.Gaussian_coefs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Gaussian coefficients for generating X-ray scattering factors:
-    [ c, a_1, b_1, a_2, b_2, ... , a_N, b_N ].
-
-    f(s; Z) = c + Sum[a~i~ * exp(-b~i~ * s^2^), i=1:N]
-
-    where s = sin(θ)/λ, θ is the diffraction angle and λ is the wavelength
-    of the incident radiation in angstroms.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.gaussian_coefs_su
-
-    _definition.id                '_atom_type_scat.Gaussian_coefs_su'
-    _definition.update            2023-07-01
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.Gaussian_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Gaussian_coefs_su
-    _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
 save_atom_type_scat.gaussian_lower_limit
 
     _definition.id                '_atom_type_scat.Gaussian_lower_limit'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26219,7 +26219,8 @@ save_
 
 save_atom_type_scat.exponential_polynomial_coeffs
 
-    _definition.id                '_atom_type_scat.exponential_polynomial_coeffs'
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_coeffs'
     _definition.update            2023-06-16
     _description.text
 ;
@@ -26253,7 +26254,8 @@ save_atom_type_scat.exponential_polynomial_coeffs_su
 ;
     _name.category_id             atom_type_scat
     _name.object_id               exponential_polynomial_coeffs_su
-    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coeffs'
+    _name.linked_item_id
+        '_atom_type_scat.exponential_polynomial_coeffs'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List
@@ -29744,7 +29746,6 @@ save_
        _atom_type_scat.inv_mott_bethe_coefs
        _atom_type_scat.gaussian_coefs
        _atom_type_scat.cromer_mann_coeffs
-
 
        Added _space_group.reference_setting, _space_group.transform_Pp_abc, and
        _space_group.transform_Qq_xyz from symCIF to SPACE_GROUP.

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25664,6 +25664,42 @@ save_atom_type_scat.cromer_mann_a4
 
 save_
 
+save_atom_type_scat.cromer_mann_as
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_as'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Cromer-Mann 'a' coefficients for generating X-ray scattering
+    factors:
+    [ a1, a2, a3, a4 ].
+
+    See also: _atom_type_scat.cromer_mann_bs
+              _atom_type_scat.cromer_mann_c
+
+    Ref: International Tables for Crystallography (2004). Vol. C, Table 6.1.1.4.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_as
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[4]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t  as  atom_type_scat
+
+     _atom_type_scat.Cromer_Mann_as  =  [ t.Cromer_Mann_a1,
+                                          t.Cromer_Mann_a2,
+                                          t.Cromer_Mann_a3,
+                                          t.Cromer_Mann_a4 ]
+;
+
+save_
+
 save_atom_type_scat.cromer_mann_b1
 
     _definition.id                '_atom_type_scat.Cromer_Mann_b1'

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26274,6 +26274,63 @@ save_atom_type_scat.hi_ang_fox_coeffs
 
 save_
 
+save_atom_type_scat.inv_mott_bethe_c_coefs
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c_coefs'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian scalar coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ c_1, c_2, ... , c_N ].
+
+    f(s; Z~0~) =
+    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    electrons for the atom or ion. θ is the diffraction angle and λ is the
+    wavelength of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.inv_mott_bethe_constant
+              _atom_type_scat.inv_mott_bethe_d_coefs
+
+    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
+         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
+         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
+         127, 658-665.
+         Bethe, H. (1930). Ann. Phys. 397, 325-400.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_c_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_c_coefs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c_coefs_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_c_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_c_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_c_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
 save_atom_type_scat.inv_mott_bethe_coefs
 
     _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
@@ -26318,6 +26375,118 @@ save_atom_type_scat.inv_mott_bethe_coefs_su
     _name.category_id             atom_type_scat
     _name.object_id               inv_Mott_Bethe_coefs_su
     _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_constant
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_constant'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The constant for use in the inverse Mott-Bethe relationship for generating
+    X-ray scattering factors:
+    e
+
+    f(s; Z~0~) =
+    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    electrons for the atom or ion. θ is the diffraction angle and λ is the
+    wavelength of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.inv_mott_bethe_c_coefs
+              _atom_type_scat.inv_mott_bethe_d_coefs
+
+    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
+         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
+         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
+         127, 658-665.
+         Bethe, H. (1930). Ann. Phys. 397, 325-400.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_constant
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_constant_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_constant_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_constant.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_constant_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_constant'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_d_coefs
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_d_coefs'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian exponent coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ d_1, d_2, ... , d_N ].
+
+    f(s; Z~0~) =
+    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    electrons for the atom or ion. θ is the diffraction angle and λ is the
+    wavelength of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.inv_mott_bethe_constant
+              _atom_type_scat.inv_mott_bethe_c_coefs
+
+    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
+         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
+         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
+         127, 658-665.
+         Bethe, H. (1930). Ann. Phys. 397, 325-400.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_d_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_d_coefs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_d_coefs_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_d_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_d_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_d_coefs'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26490,25 +26490,25 @@ save_atom_type_scat.hi_ang_fox_coeffs
 
 save_
 
-save_atom_type_scat.inv_mott_bethe_c_coefs
+save_atom_type_scat.inv_mott_bethe_as
 
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c_coefs'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_as'
     _definition.update            2026-07-14
     _description.text
 ;
     The set of Gaussian scalar coefficients for use in the inverse Mott-Bethe
     relationship for generating X-ray scattering factors:
-    [ c_1, c_2, ... , c_N ].
+    [ a_1, a_2, ... , a_N ].
 
     f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
+    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
 
     where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
     electrons for the atom or ion. θ is the diffraction angle and λ is the
     wavelength of the incident radiation in angstroms.
 
-    See also: _atom_type_scat.inv_mott_bethe_constant
-              _atom_type_scat.inv_mott_bethe_d_coefs
+    See also: _atom_type_scat.inv_mott_bethe_bs
+              _atom_type_scat.inv_mott_bethe_c
 
     Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
          Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
@@ -26517,33 +26517,145 @@ save_atom_type_scat.inv_mott_bethe_c_coefs
          Bethe, H. (1930). Ann. Phys. 397, 325-400.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_c_coefs
+    _name.object_id               inv_Mott_Bethe_as
     _type.purpose                 Measurand
     _type.source                  Derived
     _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
-    _units.code                   unspecified
+    _units.code                   angstroms
 
 save_
 
-save_atom_type_scat.inv_mott_bethe_c_coefs_su
+save_atom_type_scat.inv_mott_bethe_as_su
 
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c_coefs_su'
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_as_su'
     _definition.update            2026-07-14
     _description.text
 ;
-    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_c_coefs.
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_as.
 ;
     _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_c_coefs_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_c_coefs'
+    _name.object_id               inv_Mott_Bethe_as_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_as'
     _type.purpose                 SU
     _type.source                  Related
     _type.container               List
     _type.dimension               '[]'
     _type.contents                Real
-    _units.code                   unspecified
+    _units.code                   angstroms
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_bs
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_bs'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian exponent coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ b_1, b_2, ... , b_N ].
+
+    f(s; Z~0~) =
+    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    electrons for the atom or ion. θ is the diffraction angle and λ is the
+    wavelength of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.inv_mott_bethe_as
+              _atom_type_scat.inv_mott_bethe_c
+
+    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
+         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
+         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
+         127, 658-665.
+         Bethe, H. (1930). Ann. Phys. 397, 325-400.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_bs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_bs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_bs_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_bs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_bs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_bs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_c
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c'
+    _definition.update            2026-07-14
+    _description.text
+;
+    The set of Gaussian constant coefficient for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    c.
+
+    f(s; Z~0~) =
+    Z~0~ - 8π * a~0~ * s^2^ * {c + Sum[ a~i~ * exp(-b~i~ * s^2^), i=1:N]}
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
+    electrons for the atom or ion. θ is the diffraction angle and λ is the
+    wavelength of the incident radiation in angstroms.
+
+    See also: _atom_type_scat.inv_mott_bethe_as
+              _atom_type_scat.inv_mott_bethe_bs
+
+    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
+         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
+         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
+         127, 658-665.
+         Bethe, H. (1930). Ann. Phys. 397, 325-400.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_c_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_c_su'
+    _definition.update            2026-07-14
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_c.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_c_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_c'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
 
 save_
 
@@ -26650,63 +26762,6 @@ save_atom_type_scat.inv_mott_bethe_constant_su
     _type.purpose                 SU
     _type.source                  Related
     _type.container               Single
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_d_coefs
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_d_coefs'
-    _definition.update            2026-07-14
-    _description.text
-;
-    The set of Gaussian exponent coefficients for use in the inverse Mott-Bethe
-    relationship for generating X-ray scattering factors:
-    [ d_1, d_2, ... , d_N ].
-
-    f(s; Z~0~) =
-    Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}
-
-    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z~0~ is the number of
-    electrons for the atom or ion. θ is the diffraction angle and λ is the
-    wavelength of the incident radiation in angstroms.
-
-    See also: _atom_type_scat.inv_mott_bethe_constant
-              _atom_type_scat.inv_mott_bethe_c_coefs
-
-    Ref: Thorkildsen, G. (2023). Acta Cryst. A79, 318-330.
-         Thorkildsen, G. (2024). Acta Cryst. A80, 129-136.
-         Mott, N. F. & Bragg, W. L. (1930). Proc. R. Soc. Lond. Ser. A,
-         127, 658-665.
-         Bethe, H. (1930). Ann. Phys. 397, 325-400.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_d_coefs
-    _type.purpose                 Measurand
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[]'
-    _type.contents                Real
-    _units.code                   unspecified
-
-save_
-
-save_atom_type_scat.inv_mott_bethe_d_coefs_su
-
-    _definition.id                '_atom_type_scat.inv_Mott_Bethe_d_coefs_su'
-    _definition.update            2026-07-14
-    _description.text
-;
-    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_d_coefs.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               inv_Mott_Bethe_d_coefs_su
-    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_d_coefs'
-    _type.purpose                 SU
-    _type.source                  Related
-    _type.container               List
-    _type.dimension               '[]'
     _type.contents                Real
     _units.code                   unspecified
 

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -26002,39 +26002,6 @@ save_atom_type_scat.cromer_mann_c
 
 save_
 
-save_atom_type_scat.cromer_mann_coeffs
-
-    _definition.id                '_atom_type_scat.Cromer_Mann_coeffs'
-    _definition.update            2023-06-16
-    _description.text
-;
-    The set of Cromer-Mann coefficients for generating X-ray scattering
-    factors:
-    [ c, a1, b1, a2, b2, a3, b3, a4, b4 ].
-    Ref: International Tables for Crystallography (2004). Vol. C, Table 6.1.1.4.
-;
-    _name.category_id             atom_type_scat
-    _name.object_id               Cromer_Mann_coeffs
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               List
-    _type.dimension               '[9]'
-    _type.contents                Real
-    _units.code                   unspecified
-    _method.purpose               Evaluation
-    _method.expression
-;
-    With t  as  atom_type_scat
-
-     _atom_type_scat.Cromer_Mann_coeffs  =          [ t.Cromer_Mann_c,
-                                    t.Cromer_Mann_a1, t.Cromer_Mann_b1,
-                                    t.Cromer_Mann_a2, t.Cromer_Mann_b2,
-                                    t.Cromer_Mann_a3, t.Cromer_Mann_b3,
-                                    t.Cromer_Mann_a4, t.Cromer_Mann_b4 ]
-;
-
-save_
-
 save_atom_type_scat.dispersion
 
     _definition.id                '_atom_type_scat.dispersion'


### PR DESCRIPTION
The definition of `_atom_type_scat.inv_mott_bethe_coefs` holds the gaussian constant, scale and exponent in a single list. 

This PR gives three new data names (and their SU counterparts) to split up the three types of values into three data names:
 - `_atom_type_scat.inv_mott_bethe_c_coefs`
 - `_atom_type_scat.inv_mott_bethe_d_coefs`
 - `_atom_type_scat.inv_mott_bethe_constant`

the coeffs from the equation `f(s; Z~0~) = Z~0~ - 8π * a~0~ * s^2^ * {e + Sum[ c~i~ * exp(-d~i~ * s^2^), i=1:N]}` are stored separately: e (the constant), `c~i~` in `c_coefs`, and `d~i~` in `d_coefs`.

~Ideally `_atom_type_scat.inv_mott_bethe_coefs` would just be straight up removed, as I don't think it's been released yet, but the RC has been set up, so probably not.~

Argh. v3.3.0 has come out in the meantime.


.


edit:

Added 
- `_atom_type_scat.inv_mott_bethe_as`
- `_atom_type_scat.inv_mott_bethe_bs`
- ` _atom_type_scat.inv_mott_bethe_c`
- ` _atom_type_scat.gaussian_as`
- ` _atom_type_scat.gaussian_bs`
- ` _atom_type_scat.gaussian_c`
- ` _atom_type_scat.cromer_mann_as`
- ` _atom_type_scat.cromer_mann_bs`