### PR TITLE
update _atom_type.atomic_mass enumeration

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-07-10
+    _dictionary.date              2026-07-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -25442,7 +25442,7 @@ save_
 save_atom_type.atomic_mass
 
     _definition.id                '_atom_type.atomic_mass'
-    _definition.update            2026-04-20
+    _definition.update            2026-07-19
     _description.text
 ;
     Mass of this atom type.
@@ -25453,9 +25453,10 @@ save_atom_type.atomic_mass
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
-    _enumeration.def_index_ids    ['_atom_type.symbol']
+    _enumeration.def_index_ids    ['_atom_type.element_symbol']
 
-    _import.get                   [{'file':templ_enum.cif  'save':atomic_mass}]
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol_to_atomic_mass}]
 
 save_
 
@@ -29441,7 +29442,7 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-07-10
+         3.4.0                    2026-07-19
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
@@ -29468,4 +29469,6 @@ save_
 
        Added _space_group.reference_setting, _space_group.transform_Pp_abc, and
        _space_group.transform_Qq_xyz from symCIF to SPACE_GROUP.
+
+       Update enumeration for _atom_type.atomic_mass
 ;


### PR DESCRIPTION
Requires https://github.com/COMCIFS/Enumeration_Templates/pull/20

Simpler lookup and maintenance, dealing only with element symbol, not the myriad `_atom_type.symbol` values.