### PR TITLE
update _atom_type.radius_bond enumeration

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -25664,7 +25664,7 @@ save_atom_type.radius_bond
     _definition.update            2026-07-19
     _description.text
 ;
-    The single-bond covalent radius of this atom type.
+    The effective intra-molecular bonding radius of this atom type.
 ;
     _name.category_id             atom_type
     _name.object_id               radius_bond

--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-07-10
+    _dictionary.date              2026-07-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -25661,10 +25661,10 @@ save_atom_type.radius_bond
 
     _definition.id                '_atom_type.radius_bond'
     _alias.definition_id          '_atom_type_radius_bond'
-    _definition.update            2026-04-20
+    _definition.update            2026-07-19
     _description.text
 ;
-    The effective intra-molecular bonding radius of this atom type.
+    The single-bond covalent radius of this atom type.
 ;
     _name.category_id             atom_type
     _name.object_id               radius_bond
@@ -25673,9 +25673,10 @@ save_atom_type.radius_bond
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:5.0
-    _enumeration.def_index_ids    ['_atom_type.symbol']
+    _enumeration.def_index_ids    ['_atom_type.element_symbol']
 
-    _import.get                   [{'file':templ_enum.cif  'save':radius_bond}]
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol_to_covalent_radius}]
 
 save_
 
@@ -29441,7 +29442,7 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-07-10
+         3.4.0                    2026-07-19
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
@@ -29468,4 +29469,6 @@ save_
 
        Added _space_group.reference_setting, _space_group.transform_Pp_abc, and
        _space_group.transform_Qq_xyz from symCIF to SPACE_GROUP.
+
+       Update enumeration for _atom_type.radius_bond.
 ;


### PR DESCRIPTION
Requires https://github.com/COMCIFS/Enumeration_Templates/pull/19

Simpler lookup and maintenance, dealing only with element symbol, not the myriad `_atom_type.symbol` values.