### PR TITLE
added enumeration to _atom_type_scat.length_neutron

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-07-10
+    _dictionary.date              2026-07-19
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -26544,7 +26544,7 @@ save_atom_type_scat.length_neutron
          '_atom_type_scat_length_neutron'
          '_atom_type.scat_length_neutron'
 
-    _definition.update            2012-11-20
+    _definition.update            2026-07-19
     _description.text
 ;
     The bound coherent scattering length for the atom type at the
@@ -26555,8 +26555,12 @@ save_atom_type_scat.length_neutron
     _type.purpose                 Number
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Real
-    _units.code                   femtometres
+    _type.contents                Complex
+    _enumeration.def_index_ids
+        ['_atom_type.element_symbol'  '_atom_type.mass_number']
+
+    _import.get
+        [{'file':templ_enum.cif  'save':length_neutron}]
 
 save_
 
@@ -29441,7 +29445,7 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-07-10
+         3.4.0                    2026-07-19
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
@@ -29468,4 +29472,7 @@ save_
 
        Added _space_group.reference_setting, _space_group.transform_Pp_abc, and
        _space_group.transform_Qq_xyz from symCIF to SPACE_GROUP.
+
+       Added enumeration and changed _type.contents to Complex for
+       _atom_type_scat.length_neutron.
 ;


### PR DESCRIPTION
requires https://github.com/COMCIFS/Enumeration_Templates/pull/16
see also https://github.com/COMCIFS/Enumeration_Templates/pull/1

Simple lookup and maintenance, dealing only with element symbol and mass number, not the myriad `_atom_type.symbol` values.