### PR TITLE
Update CIF syntax check action to use 'main' branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Check syntax of all CIF files
       - name: Check CIF syntax
-        uses: COMCIFS/cif_syntax_check_action@master
+        uses: COMCIFS/cif_syntax_check_action@main
         id: cif_syntax_check
 
   semantics:


### PR DESCRIPTION
I've changed the name of the check action main branch from 'master' to 'main'. Now all our workflows need updating.