### PR TITLE
`_exptl_crystal.id` is defined in the multiblock dictionary

### DIFF
--- a/cif_core.dic
+++ b/cif_core.dic
@@ -11,7 +11,7 @@ data_CIF_CORE
     _dictionary.title             CIF_CORE
     _dictionary.class             Instance
     _dictionary.version           3.4.0
-    _dictionary.date              2026-07-19
+    _dictionary.date              2026-07-20
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/cif_core/main/cif_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -314,25 +314,6 @@ save_diffrn.ambient_temperature_lt
     _type.contents                Real
     _enumeration.range            0.0:
     _units.code                   kelvins
-
-save_
-
-save_diffrn.crystal_id
-
-    _definition.id                '_diffrn.crystal_id'
-    _definition.update            2022-05-09
-    _description.text
-;
-    Identifier for the crystal from which diffraction data were
-    collected. This is a pointer to _exptl_crystal.id.
-;
-    _name.category_id             diffrn
-    _name.object_id               crystal_id
-    _name.linked_item_id          '_exptl_crystal.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -10759,7 +10740,6 @@ save_EXPTL_CRYSTAL
 ;
     _name.category_id             EXPTL
     _name.object_id               EXPTL_CRYSTAL
-    _category_key.name            '_exptl_crystal.id'
 
 save_
 
@@ -11110,24 +11090,6 @@ save_exptl_crystal.f_000
     Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
     Else                                            _units.code =  "electrons"
 ;
-
-save_
-
-save_exptl_crystal.id
-
-    _definition.id                '_exptl_crystal.id'
-    _alias.definition_id          '_exptl_crystal_id'
-    _definition.update            2022-05-09
-    _description.text
-;
-    Code identifying a crystal.
-;
-    _name.category_id             exptl_crystal
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -29707,7 +29669,7 @@ save_
        _atom_site.U_iso_or_equiv. [bm, after Nespolo, M. (2024).
        J. Appl. Cryst. 57, 1733-1746]
 ;
-         3.4.0                    2026-07-19
+         3.4.0                    2026-07-20
 ;
        # Append change information below and update the above date
        # until dictionary is ready for release.
@@ -29752,4 +29714,6 @@ save_
 
        Update description od _atom_type.symbol to state that the charge given
        is the charge, and not the oxidation state.
+
+       Remove _exptl_crystal.id as it is present in multiblock dictionary.
 ;


### PR DESCRIPTION
`_exptl_crystal.id` as a key data name of a Set category is defined in the multiblock dictionary and so can be removed from the core dictionary.